### PR TITLE
chore: Refactor common TestMain logic and fail on cleanup failure

### DIFF
--- a/internal/common/validate/http_status_checks.go
+++ b/internal/common/validate/http_status_checks.go
@@ -17,3 +17,7 @@ func StatusBadRequest(resp *http.Response) bool {
 func StatusInternalServerError(resp *http.Response) bool {
 	return resp != nil && resp.StatusCode == http.StatusInternalServerError
 }
+
+func StatusConflict(resp *http.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusConflict
+}

--- a/internal/service/accesslistapikey/main_test.go
+++ b/internal/service/accesslistapikey/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/advancedcluster/main_test.go
+++ b/internal/service/advancedcluster/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/alertconfiguration/main_test.go
+++ b/internal/service/alertconfiguration/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/apikey/main_test.go
+++ b/internal/service/apikey/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/apikeyprojectassignment/main_test.go
+++ b/internal/service/apikeyprojectassignment/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/atlasuser/main_test.go
+++ b/internal/service/atlasuser/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/auditing/main_test.go
+++ b/internal/service/auditing/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/backupcompliancepolicy/main_test.go
+++ b/internal/service/backupcompliancepolicy/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/cloudbackupschedule/main_test.go
+++ b/internal/service/cloudbackupschedule/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/cloudbackupsnapshot/main_test.go
+++ b/internal/service/cloudbackupsnapshot/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/cloudbackupsnapshotexportbucket/main_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/cloudbackupsnapshotexportjob/main_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/cloudbackupsnapshotrestorejob/main_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/cloudprovideraccess/main_test.go
+++ b/internal/service/cloudprovideraccess/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/clouduserorgassignment/main_test.go
+++ b/internal/service/clouduserorgassignment/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/clouduserprojectassignment/main_test.go
+++ b/internal/service/clouduserprojectassignment/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/clouduserteamassignment/main_test.go
+++ b/internal/service/clouduserteamassignment/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/cluster/main_test.go
+++ b/internal/service/cluster/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/clusteroutagesimulation/main_test.go
+++ b/internal/service/clusteroutagesimulation/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/customdbrole/main_test.go
+++ b/internal/service/customdbrole/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/customdnsconfigurationclusteraws/main_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/databaseuser/main_test.go
+++ b/internal/service/databaseuser/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/encryptionatrest/main_test.go
+++ b/internal/service/encryptionatrest/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/encryptionatrestprivateendpoint/main_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/eventtrigger/main_test.go
+++ b/internal/service/eventtrigger/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/federateddatabaseinstance/main_test.go
+++ b/internal/service/federateddatabaseinstance/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/federatedquerylimit/main_test.go
+++ b/internal/service/federatedquerylimit/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/federatedsettingsidentityprovider/main_test.go
+++ b/internal/service/federatedsettingsidentityprovider/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/federatedsettingsorgconfig/main_test.go
+++ b/internal/service/federatedsettingsorgconfig/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/federatedsettingsorgrolemapping/main_test.go
+++ b/internal/service/federatedsettingsorgrolemapping/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/flexcluster/main_test.go
+++ b/internal/service/flexcluster/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/flexrestorejob/main_test.go
+++ b/internal/service/flexrestorejob/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/flexsnapshot/main_test.go
+++ b/internal/service/flexsnapshot/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/globalclusterconfig/main_test.go
+++ b/internal/service/globalclusterconfig/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/ldapconfiguration/main_test.go
+++ b/internal/service/ldapconfiguration/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/ldapverify/main_test.go
+++ b/internal/service/ldapverify/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/maintenancewindow/main_test.go
+++ b/internal/service/maintenancewindow/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/mongodbemployeeaccessgrant/main_test.go
+++ b/internal/service/mongodbemployeeaccessgrant/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/networkcontainer/main_test.go
+++ b/internal/service/networkcontainer/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/networkpeering/main_test.go
+++ b/internal/service/networkpeering/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/onlinearchive/main_test.go
+++ b/internal/service/onlinearchive/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/organization/main_test.go
+++ b/internal/service/organization/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/orginvitation/main_test.go
+++ b/internal/service/orginvitation/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/privateendpointregionalmode/main_test.go
+++ b/internal/service/privateendpointregionalmode/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/privatelinkendpoint/main_test.go
+++ b/internal/service/privatelinkendpoint/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/privatelinkendpointservice/main_test.go
+++ b/internal/service/privatelinkendpointservice/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/main_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/project/main_test.go
+++ b/internal/service/project/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/projectapikey/main_test.go
+++ b/internal/service/projectapikey/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/projectinvitation/main_test.go
+++ b/internal/service/projectinvitation/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/projectipaccesslist/main_test.go
+++ b/internal/service/projectipaccesslist/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/projectipaddresses/main_test.go
+++ b/internal/service/projectipaddresses/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/projectserviceaccountaccesslistentry/main_test.go
+++ b/internal/service/projectserviceaccountaccesslistentry/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/pushbasedlogexport/main_test.go
+++ b/internal/service/pushbasedlogexport/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/resourcepolicy/main_test.go
+++ b/internal/service/resourcepolicy/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/rolesorgid/main_test.go
+++ b/internal/service/rolesorgid/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/searchdeployment/main_test.go
+++ b/internal/service/searchdeployment/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/searchindex/main_test.go
+++ b/internal/service/searchindex/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/serverlessinstance/main_test.go
+++ b/internal/service/serverlessinstance/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/serviceaccountaccesslistentry/main_test.go
+++ b/internal/service/serviceaccountaccesslistentry/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/sharedtier/main_test.go
+++ b/internal/service/sharedtier/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/streamaccountdetails/main_test.go
+++ b/internal/service/streamaccountdetails/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/streamconnection/main_test.go
+++ b/internal/service/streamconnection/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/streaminstance/main_test.go
+++ b/internal/service/streaminstance/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/streamprivatelinkendpoint/main_test.go
+++ b/internal/service/streamprivatelinkendpoint/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/streamprocessor/main_test.go
+++ b/internal/service/streamprocessor/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/streamworkspace/main_test.go
+++ b/internal/service/streamworkspace/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/team/main_test.go
+++ b/internal/service/team/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/teamprojectassignment/main_test.go
+++ b/internal/service/teamprojectassignment/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/thirdpartyintegration/main_test.go
+++ b/internal/service/thirdpartyintegration/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/service/x509authenticationdatabaseuser/main_test.go
+++ b/internal/service/x509authenticationdatabaseuser/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/alertconfigurationapi/main_test.go
+++ b/internal/serviceapi/alertconfigurationapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/auditingapi/main_test.go
+++ b/internal/serviceapi/auditingapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/clusterapi/main_test.go
+++ b/internal/serviceapi/clusterapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/clusteroldapi/main_test.go
+++ b/internal/serviceapi/clusteroldapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/customdbroleapi/main_test.go
+++ b/internal/serviceapi/customdbroleapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/databaseuserapi/main_test.go
+++ b/internal/serviceapi/databaseuserapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/maintenancewindowapi/main_test.go
+++ b/internal/serviceapi/maintenancewindowapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/projectapi/main_test.go
+++ b/internal/serviceapi/projectapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/projectserviceaccount/main_test.go
+++ b/internal/serviceapi/projectserviceaccount/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/projectserviceaccountsecret/main_test.go
+++ b/internal/serviceapi/projectserviceaccountsecret/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/projectsettingsapi/main_test.go
+++ b/internal/serviceapi/projectsettingsapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/pushbasedlogexportapi/main_test.go
+++ b/internal/serviceapi/pushbasedlogexportapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/resourcepolicyapi/main_test.go
+++ b/internal/serviceapi/resourcepolicyapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/searchdeploymentapi/main_test.go
+++ b/internal/serviceapi/searchdeploymentapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/searchindexapi/main_test.go
+++ b/internal/serviceapi/searchindexapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/serviceaccount/main_test.go
+++ b/internal/serviceapi/serviceaccount/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/serviceaccountprojectassignment/main_test.go
+++ b/internal/serviceapi/serviceaccountprojectassignment/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/serviceaccountsecret/main_test.go
+++ b/internal/serviceapi/serviceaccountsecret/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/streaminstanceapi/main_test.go
+++ b/internal/serviceapi/streaminstanceapi/main_test.go
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/serviceapi/streamprocessorapi/main_test.go
+++ b/internal/serviceapi/streamprocessorapi/main_test.go
@@ -8,7 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	acc.SetupSharedResources()
-	exitCode := m.Run()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -26,7 +26,7 @@ func createProject(tb testing.TB, name string) string {
 	return id
 }
 
-func deleteProject(id string) {
+func deleteProject(id string) error {
 	_, err := ConnV2().ProjectsApi.DeleteGroup(context.Background(), id).Execute()
 	if admin.IsErrorCode(err, "CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS") {
 		fmt.Printf("Project deletion failed will retry in 30s: %s, error: %s", id, err)
@@ -34,8 +34,9 @@ func deleteProject(id string) {
 		_, err = ConnV2().ProjectsApi.DeleteGroup(context.Background(), id).Execute()
 	}
 	if err != nil {
-		fmt.Printf("Project deletion failed: %s, error: %s", id, err)
+		return fmt.Errorf("project deletion failed: %s, error: %w", id, err)
 	}
+	return nil
 }
 
 func createCluster(tb testing.TB, projectID, name string) string {
@@ -50,16 +51,17 @@ func createCluster(tb testing.TB, projectID, name string) string {
 	return name
 }
 
-func deleteCluster(projectID, name string) {
+func deleteCluster(projectID, name string) error {
 	_, err := ConnV2().ClustersApi.DeleteCluster(context.Background(), projectID, name).Execute()
 	if err != nil {
-		fmt.Printf("Cluster deletion failed: %s %s, error: %s", projectID, name, err)
+		return fmt.Errorf("cluster deletion failed: %s %s, error: %w", projectID, name, err)
 	}
 	stateConf := cluster.DeleteStateChangeConfig(context.Background(), ConnV2(), projectID, name, 1*time.Hour)
 	_, err = stateConf.WaitForStateContext(context.Background())
 	if err != nil {
-		fmt.Printf("Cluster deletion failed: %s %s, error: %s", projectID, name, err)
+		return fmt.Errorf("cluster deletion failed: %s %s, error: %w", projectID, name, err)
 	}
+	return nil
 }
 
 func clusterReq(name, projectID string) admin.ClusterDescription20240805 {

--- a/internal/testutil/acc/privatelink_endpoint.go
+++ b/internal/testutil/acc/privatelink_endpoint.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/privatelinkendpoint"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20250312013/admin"
@@ -30,12 +31,23 @@ func createPrivateLinkEndpoint(tb testing.TB, projectID, providerName, region st
 }
 
 func deletePrivateLinkEndpoint(projectID, providerName, privateLinkEndpointID string) error {
-	_, err := ConnV2().PrivateEndpointServicesApi.DeletePrivateEndpointService(context.Background(), projectID, providerName, privateLinkEndpointID).Execute()
-	if err != nil {
-		return fmt.Errorf("failed to delete private link endpoint %s: %w", privateLinkEndpointID, err)
+	const maxConflictRetries = 3
+	for i := range maxConflictRetries {
+		resp, err := ConnV2().PrivateEndpointServicesApi.DeletePrivateEndpointService(context.Background(), projectID, providerName, privateLinkEndpointID).Execute()
+		if err != nil {
+			// 409 Conflict occurs when an attached endpoint is still being removed.
+			// Always happens for deleteOnCreateTimeout tests since the resource does not wait for deletion in that case.
+			if validate.StatusConflict(resp) && i < maxConflictRetries-1 {
+				fmt.Printf("Private link endpoint deletion failed, will retry in 10s: %s, error: %s\n", privateLinkEndpointID, err)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+			return fmt.Errorf("failed to delete private link endpoint %s: %w", privateLinkEndpointID, err)
+		}
+		break
 	}
 	stateConf := privatelinkendpoint.DeleteStateChangeConfig(context.Background(), ConnV2(), projectID, providerName, privateLinkEndpointID, 1*time.Hour)
-	_, err = stateConf.WaitForStateContext(context.Background())
+	_, err := stateConf.WaitForStateContext(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to delete private link endpoint %s: %w", privateLinkEndpointID, err)
 	}

--- a/internal/testutil/acc/privatelink_endpoint.go
+++ b/internal/testutil/acc/privatelink_endpoint.go
@@ -29,15 +29,15 @@ func createPrivateLinkEndpoint(tb testing.TB, projectID, providerName, region st
 	return privateEndpoint.GetId()
 }
 
-func deletePrivateLinkEndpoint(projectID, providerName, privateLinkEndpointID string) {
+func deletePrivateLinkEndpoint(projectID, providerName, privateLinkEndpointID string) error {
 	_, err := ConnV2().PrivateEndpointServicesApi.DeletePrivateEndpointService(context.Background(), projectID, providerName, privateLinkEndpointID).Execute()
 	if err != nil {
-		fmt.Printf("Failed to delete private link endpoint %s: %s\n", privateLinkEndpointID, err)
-		return
+		return fmt.Errorf("failed to delete private link endpoint %s: %w", privateLinkEndpointID, err)
 	}
 	stateConf := privatelinkendpoint.DeleteStateChangeConfig(context.Background(), ConnV2(), projectID, providerName, privateLinkEndpointID, 1*time.Hour)
 	_, err = stateConf.WaitForStateContext(context.Background())
 	if err != nil {
-		fmt.Printf("Failed to delete private link endpoint %s: %s\n", privateLinkEndpointID, err)
+		return fmt.Errorf("failed to delete private link endpoint %s: %w", privateLinkEndpointID, err)
 	}
+	return nil
 }

--- a/tools/scaffold/template/main_test.tmpl
+++ b/tools/scaffold/template/main_test.tmpl
@@ -8,8 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cleanup := acc.SetupSharedResources()
-	exitCode := m.Run()
-	cleanup()
-	os.Exit(exitCode)
+	os.Exit(acc.Run(m))
 }


### PR DESCRIPTION
## Description

- Moving common logic to run acc/mig tests to a Run() function.
- Now exiting with a non-zero exit code when shared resources cleanup fails

Cleanup fix:
- Retry Private Endpoint Service deletions on 409 Conflicts. This is due to Private Endpoints still being deleted from the Service which always happens for deleteOnCreateTimeout tests.

Link to any related issue(s): CLOUDP-321119

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
