### PR TITLE
chore: Skipping flaky tenant upgrade test in CI

### DIFF
--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1019,6 +1019,7 @@ func TestAccCluster_withAutoScalingAWS(t *testing.T) {
 }
 
 func TestAccCluster_tenant(t *testing.T) {
+	acc.SkipTestForCI(t) // test encountered flakiness (~75% success rate), related ticket: CLOUDP-375027
 	var (
 		resourceName           = "mongodbatlas_cluster.tenant"
 		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 1)
@@ -1046,8 +1047,7 @@ func TestAccCluster_tenant(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
-					// We need to check for both 10 (expected) and 5 as API encounters flakiness (~75% success rate), related ticket: CLOUDP-375027
-					resource.TestCheckResourceAttrWith(resourceName, "disk_size_gb", acc.MatchesExpression(`^(5|10)$`)),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

Follow up of https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4096 after hitting a new failure last week ([reference](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/21419842339/job/61676863296)) that provided additional details.

Updated CLOUDP-375027 with latest info, as ticket has been moved to backlog we can skip this test for now.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
