### PR TITLE
chore: Rollback changes for in-place update of project_ip_access_list

### DIFF
--- a/.changelog/4139.txt
+++ b/.changelog/4139.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/mongodbatlas_project_ip_access_lists: In-place updates are not currently supported. Modifying any attribute requires a replacement
+```

--- a/docs/resources/project_ip_access_list.md
+++ b/docs/resources/project_ip_access_list.md
@@ -92,7 +92,6 @@ Optional:
 
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
-- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 ## Import
 

--- a/docs/resources/project_ip_access_list.md
+++ b/docs/resources/project_ip_access_list.md
@@ -8,7 +8,7 @@ subcategory: "Projects"
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
-~> **IMPORTANT:** When you remove an entry from the access list, existing connections from the removed address(es) may remain open for a variable amount of time. How much time passes before Atlas closes the connection depends on several factors, including how the connection was established, the particular behavior of the application or driver using the address, and the connection protocol (e.g., TCP or UDP). This is particularly important to consider when changing an existing IP address or CIDR block as they cannot be updated via the Provider (comments can however), hence a change will force the destruction and recreation of entries.
+~> **IMPORTANT:** When you remove an entry from the access list, existing connections from the removed address(es) may remain open for a variable amount of time. How much time passes before Atlas closes the connection depends on several factors, including how the connection was established, the particular behavior of the application or driver using the address, and the connection protocol (e.g., TCP or UDP). This is particularly important to consider when changing an existing IP address or CIDR block as they cannot be updated via the Provider, hence a change will force the destruction and recreation of entries.
 
 ~> **IMPORTANT:** During creation this resource does not validate whether the specified `ip_address`, `cidr_block`, or `aws_security_group` already exists in the project's access list (known limitation). Defining a duplicate entry will result in a successful resource creation associated to the existing entry.
 

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list.go
@@ -19,16 +19,14 @@ import (
 )
 
 const (
-	errorAccessListCreate  = "error creating Project IP Access List information: %s"
-	errorAccessListRead    = "error getting Project IP Access List information: %s"
-	errorAccessListUpdate  = "error updating Project IP Access List information: %s"
-	errorAccessListDelete  = "error deleting Project IP Access List information: %s"
-	timeoutCreateDelete    = 45 * time.Minute
-	timeoutRead            = 2 * time.Minute
-	timeoutUpdate          = 45 * time.Minute
-	timeoutRetryItem       = 2 * time.Minute
-	delayCreateUpdate      = 10 * time.Second
-	minTimeoutCreateUpdate = 10 * time.Second
+	errorAccessListCreate = "error creating Project IP Access List information: %s"
+	errorAccessListRead   = "error getting Project IP Access List information: %s"
+	errorAccessListDelete = "error deleting Project IP Access List information: %s"
+	timeoutCreateDelete   = 45 * time.Minute
+	timeoutRead           = 2 * time.Minute
+	timeoutRetryItem      = 2 * time.Minute
+	delayCreate           = 10 * time.Second
+	minTimeoutCreate      = 10 * time.Second
 )
 
 var createAccessListEntryMutex = concurrency.NewMutexKV()
@@ -74,7 +72,7 @@ func (r *projectIPAccessListRS) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	entry, err := createOrUpdate(ctx, connV2, projectIPAccessListModel, timeout, errorAccessListCreate)
+	entry, err := createEntry(ctx, connV2, projectIPAccessListModel, timeout, errorAccessListCreate)
 	if err != nil {
 		resp.Diagnostics.AddError("error creating resource", err.Error())
 		return
@@ -216,59 +214,7 @@ func (r *projectIPAccessListRS) ImportState(ctx context.Context, req resource.Im
 	}))...)
 }
 
-// Update is supported only for the comment field. The rest of the fields trigger a replace.
-func (r *projectIPAccessListRS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var projectIPAccessListState *TfProjectIPAccessListModel
-	var projectIPAccessListPlan *TfProjectIPAccessListModel
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &projectIPAccessListState)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &projectIPAccessListPlan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	updatedProjectIPAccessList := &TfProjectIPAccessListModel{
-		ID:               projectIPAccessListState.ID,
-		ProjectID:        projectIPAccessListState.ProjectID,
-		CIDRBlock:        projectIPAccessListState.CIDRBlock,
-		IPAddress:        projectIPAccessListState.IPAddress,
-		AWSSecurityGroup: projectIPAccessListState.AWSSecurityGroup,
-
-		// Only comment and timeouts can be updated without replace.
-		Comment:  projectIPAccessListPlan.Comment,
-		Timeouts: projectIPAccessListPlan.Timeouts,
-	}
-
-	connV2 := r.Client.AtlasV2
-	timeout, diags := updatedProjectIPAccessList.Timeouts.Update(ctx, timeoutUpdate)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	entry, err := createOrUpdate(ctx, connV2, updatedProjectIPAccessList, timeout, errorAccessListUpdate)
-	if err != nil {
-		resp.Diagnostics.AddError("error updating resource", err.Error())
-		return
-	}
-	if entry == nil {
-		resp.Diagnostics.AddError("error", fmt.Errorf(errorAccessListUpdate, "entry is nil").Error())
-		return
-	}
-
-	projectIPAccessListNewModel := NewTfProjectIPAccessListModel(updatedProjectIPAccessList, entry)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &projectIPAccessListNewModel)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-}
-
-// HELP-67341: The post operation behaves both as a POST and a PUT.
-func createOrUpdate(ctx context.Context, connV2 *admin.APIClient, projectIPAccessListModel *TfProjectIPAccessListModel, timeout time.Duration, errorMsg string) (*admin.NetworkPermissionEntry, error) {
+func createEntry(ctx context.Context, connV2 *admin.APIClient, projectIPAccessListModel *TfProjectIPAccessListModel, timeout time.Duration, errorMsg string) (*admin.NetworkPermissionEntry, error) {
 	projectID := projectIPAccessListModel.ProjectID.ValueString()
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
@@ -312,8 +258,8 @@ func createOrUpdate(ctx context.Context, connV2 *admin.APIClient, projectIPAcces
 			return entry, "created", nil
 		},
 		Timeout:    timeout,
-		Delay:      delayCreateUpdate,
-		MinTimeout: minTimeoutCreateUpdate,
+		Delay:      delayCreate,
+		MinTimeout: minTimeoutCreate,
 	}
 
 	// Wait, catching any errors

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -40,10 +40,6 @@ func TestAccProjectIPAccessList_settingIPAddress(t *testing.T) {
 				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(ipAddress, "", "", comment, withDS)...),
 			},
 			{
-				Config: configWithIPAddress(projectID, ipAddress, updatedComment, withDS),
-				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(ipAddress, "", "", updatedComment, withDS)...),
-			},
-			{
 				Config: configWithIPAddress(projectID, updatedIPAddress, updatedComment, withDS),
 				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(updatedIPAddress, "", "", updatedComment, withDS)...),
 			},
@@ -77,10 +73,6 @@ func TestAccProjectIPAccessList_settingCIDRBlock(t *testing.T) {
 				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", cidrBlock, "", comment, withDS)...),
 			},
 			{
-				Config: configWithCIDRBlock(projectID, cidrBlock, updatedComment, withDS),
-				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", cidrBlock, "", updatedComment, withDS)...),
-			},
-			{
 				Config: configWithCIDRBlock(projectID, updatedCIDRBlock, updatedComment, withDS),
 				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", updatedCIDRBlock, "", updatedComment, withDS)...),
 			},
@@ -111,10 +103,6 @@ func TestAccProjectIPAccessList_settingAWSSecurityGroup(t *testing.T) {
 			{
 				Config: configWithAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment, withDS),
 				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", "", awsSGroup, comment, withDS)...),
-			},
-			{
-				Config: configWithAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, updatedComment, withDS),
-				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", "", awsSGroup, updatedComment, withDS)...),
 			},
 			{
 				Config: configWithAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, updatedAWSSgroup, updatedComment, withDS),

--- a/internal/service/projectipaccesslist/resource_schema.go
+++ b/internal/service/projectipaccesslist/resource_schema.go
@@ -80,13 +80,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: awsSecurityGroupDesc,
 			},
 			"comment": schema.StringAttribute{
-				Optional:            true,
-				Computed:            true,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 				MarkdownDescription: "Remark that explains the purpose or scope of this IP access list entry.",
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Read:   true,
-				Update: true,
 				Delete: true,
 			}),
 		},

--- a/templates/resources/project_ip_access_list.md.tmpl
+++ b/templates/resources/project_ip_access_list.md.tmpl
@@ -8,7 +8,7 @@ subcategory: "Projects"
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
-~> **IMPORTANT:** When you remove an entry from the access list, existing connections from the removed address(es) may remain open for a variable amount of time. How much time passes before Atlas closes the connection depends on several factors, including how the connection was established, the particular behavior of the application or driver using the address, and the connection protocol (e.g., TCP or UDP). This is particularly important to consider when changing an existing IP address or CIDR block as they cannot be updated via the Provider (comments can however), hence a change will force the destruction and recreation of entries.
+~> **IMPORTANT:** When you remove an entry from the access list, existing connections from the removed address(es) may remain open for a variable amount of time. How much time passes before Atlas closes the connection depends on several factors, including how the connection was established, the particular behavior of the application or driver using the address, and the connection protocol (e.g., TCP or UDP). This is particularly important to consider when changing an existing IP address or CIDR block as they cannot be updated via the Provider, hence a change will force the destruction and recreation of entries.
 
 ~> **IMPORTANT:** During creation this resource does not validate whether the specified `ip_address`, `cidr_block`, or `aws_security_group` already exists in the project's access list (known limitation). Defining a duplicate entry will result in a successful resource creation associated to the existing entry.
 


### PR DESCRIPTION
## Description

Rolling back changes from https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4003 as they are not enough to enable in-place updates for the `comment` attribute of project_ip_access_list.

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
