### PR TITLE
feat: Add role_id azure key vault encryption at rest

### DIFF
--- a/docs/data-sources/encryption_at_rest.md
+++ b/docs/data-sources/encryption_at_rest.md
@@ -174,6 +174,7 @@ Read-Only:
 - `key_vault_name` (String) Unique string that identifies the Azure Key Vault that contains your key.
 - `require_private_networking` (Boolean) Enable connection to your Azure Key Vault over private networking.
 - `resource_group_name` (String) Name of the Azure resource group that contains your Azure Key Vault.
+- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.
 - `secret` (String, Sensitive) Private data that you need secured and that belongs to the specified Azure Key Vault (AKV) tenant (**azureKeyVault.tenantID**). This data can include any type of sensitive data such as passwords, database connection strings, API keys, and the like. AKV stores this information as encrypted binary data.
 - `subscription_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies your Azure subscription.
 - `tenant_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies the Azure Active Directory tenant within your Azure subscription.

--- a/docs/data-sources/encryption_at_rest.md
+++ b/docs/data-sources/encryption_at_rest.md
@@ -174,7 +174,7 @@ Read-Only:
 - `key_vault_name` (String) Unique string that identifies the Azure Key Vault that contains your key.
 - `require_private_networking` (Boolean) Enable connection to your Azure Key Vault over private networking.
 - `resource_group_name` (String) Name of the Azure resource group that contains your Azure Key Vault.
-- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.
+- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Azure Service Principal that Atlas uses to access the Azure Key Vault.
 - `secret` (String, Sensitive) Private data that you need secured and that belongs to the specified Azure Key Vault (AKV) tenant (**azureKeyVault.tenantID**). This data can include any type of sensitive data such as passwords, database connection strings, API keys, and the like. AKV stores this information as encrypted binary data.
 - `subscription_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies your Azure subscription.
 - `tenant_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies the Azure Active Directory tenant within your Azure subscription.

--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -223,6 +223,7 @@ Optional:
 - `key_vault_name` (String) Unique string that identifies the Azure Key Vault that contains your key.
 - `require_private_networking` (Boolean) Enable connection to your Azure Key Vault over private networking.
 - `resource_group_name` (String) Name of the Azure resource group that contains your Azure Key Vault.
+- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.
 - `secret` (String, Sensitive) Private data that you need secured and that belongs to the specified Azure Key Vault (AKV) tenant (**azureKeyVault.tenantID**). This data can include any type of sensitive data such as passwords, database connection strings, API keys, and the like. AKV stores this information as encrypted binary data.
 - `subscription_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies your Azure subscription.
 - `tenant_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies the Azure Active Directory tenant within your Azure subscription.

--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -223,7 +223,7 @@ Optional:
 - `key_vault_name` (String) Unique string that identifies the Azure Key Vault that contains your key.
 - `require_private_networking` (Boolean) Enable connection to your Azure Key Vault over private networking.
 - `resource_group_name` (String) Name of the Azure resource group that contains your Azure Key Vault.
-- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.
+- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Azure Service Principal that Atlas uses to access the Azure Key Vault.
 - `secret` (String, Sensitive) Private data that you need secured and that belongs to the specified Azure Key Vault (AKV) tenant (**azureKeyVault.tenantID**). This data can include any type of sensitive data such as passwords, database connection strings, API keys, and the like. AKV stores this information as encrypted binary data.
 - `subscription_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies your Azure subscription.
 - `tenant_id` (String, Sensitive) Unique 36-hexadecimal character string that identifies the Azure Active Directory tenant within your Azure subscription.

--- a/internal/service/encryptionatrest/data_source_schema.go
+++ b/internal/service/encryptionatrest/data_source_schema.go
@@ -75,7 +75,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 					},
 					"role_id": schema.StringAttribute{
 						Computed:            true,
-						MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.",
+						MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Azure Service Principal that Atlas uses to access the Azure Key Vault.",
 					},
 					"key_vault_name": schema.StringAttribute{
 						Computed:            true,

--- a/internal/service/encryptionatrest/data_source_schema.go
+++ b/internal/service/encryptionatrest/data_source_schema.go
@@ -73,6 +73,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						Sensitive:           true,
 						MarkdownDescription: "Web address with a unique key that identifies for your Azure Key Vault.",
 					},
+					"role_id": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.",
+					},
 					"key_vault_name": schema.StringAttribute{
 						Computed:            true,
 						MarkdownDescription: "Unique string that identifies the Azure Key Vault that contains your key.",

--- a/internal/service/encryptionatrest/model.go
+++ b/internal/service/encryptionatrest/model.go
@@ -79,14 +79,14 @@ func NewTFAzureKeyVaultConfigItem(az *admin.AzureKeyVault) *TFAzureKeyVaultConfi
 
 	return &TFAzureKeyVaultConfigModel{
 		Enabled:                  types.BoolPointerValue(az.Enabled),
-		ClientID:                 types.StringValue(az.GetClientID()),
+		ClientID:                 conversion.StringNullIfEmpty(az.GetClientID()),
 		AzureEnvironment:         types.StringValue(az.GetAzureEnvironment()),
 		SubscriptionID:           types.StringValue(az.GetSubscriptionID()),
 		ResourceGroupName:        types.StringValue(az.GetResourceGroupName()),
 		KeyVaultName:             types.StringValue(az.GetKeyVaultName()),
 		KeyIdentifier:            types.StringValue(az.GetKeyIdentifier()),
 		RoleID:                   conversion.StringNullIfEmpty(az.GetRoleId()),
-		TenantID:                 types.StringValue(az.GetTenantID()),
+		TenantID:                 conversion.StringNullIfEmpty(az.GetTenantID()),
 		Secret:                   conversion.StringNullIfEmpty(az.GetSecret()),
 		RequirePrivateNetworking: types.BoolValue(az.GetRequirePrivateNetworking()),
 		Valid:                    types.BoolPointerValue(az.Valid),

--- a/internal/service/encryptionatrest/model.go
+++ b/internal/service/encryptionatrest/model.go
@@ -79,14 +79,14 @@ func NewTFAzureKeyVaultConfigItem(az *admin.AzureKeyVault) *TFAzureKeyVaultConfi
 
 	return &TFAzureKeyVaultConfigModel{
 		Enabled:                  types.BoolPointerValue(az.Enabled),
-		ClientID:                 conversion.StringNullIfEmpty(az.GetClientID()),
+		ClientID:                 types.StringPointerValue(az.ClientID),
 		AzureEnvironment:         types.StringValue(az.GetAzureEnvironment()),
 		SubscriptionID:           types.StringValue(az.GetSubscriptionID()),
 		ResourceGroupName:        types.StringValue(az.GetResourceGroupName()),
 		KeyVaultName:             types.StringValue(az.GetKeyVaultName()),
 		KeyIdentifier:            types.StringValue(az.GetKeyIdentifier()),
-		RoleID:                   conversion.StringNullIfEmpty(az.GetRoleId()),
-		TenantID:                 conversion.StringNullIfEmpty(az.GetTenantID()),
+		RoleID:                   types.StringPointerValue(az.RoleId),
+		TenantID:                 types.StringPointerValue(az.TenantID),
 		Secret:                   conversion.StringNullIfEmpty(az.GetSecret()),
 		RequirePrivateNetworking: types.BoolValue(az.GetRequirePrivateNetworking()),
 		Valid:                    types.BoolPointerValue(az.Valid),

--- a/internal/service/encryptionatrest/model.go
+++ b/internal/service/encryptionatrest/model.go
@@ -148,14 +148,14 @@ func NewAtlasAzureKeyVault(tfAzKeyVaultConfigSlice []TFAzureKeyVaultConfigModel)
 
 	return &admin.AzureKeyVault{
 		Enabled:                  v.Enabled.ValueBoolPointer(),
-		ClientID:                 v.ClientID.ValueStringPointer(),
+		ClientID:                 conversion.NilForUnknownOrEmptyString(v.ClientID),
 		AzureEnvironment:         v.AzureEnvironment.ValueStringPointer(),
 		SubscriptionID:           v.SubscriptionID.ValueStringPointer(),
 		ResourceGroupName:        v.ResourceGroupName.ValueStringPointer(),
 		KeyVaultName:             v.KeyVaultName.ValueStringPointer(),
 		KeyIdentifier:            v.KeyIdentifier.ValueStringPointer(),
 		Secret:                   v.Secret.ValueStringPointer(),
-		TenantID:                 v.TenantID.ValueStringPointer(),
+		TenantID:                 conversion.NilForUnknownOrEmptyString(v.TenantID),
 		RequirePrivateNetworking: v.RequirePrivateNetworking.ValueBoolPointer(),
 		RoleId:                   v.RoleID.ValueStringPointer(),
 	}

--- a/internal/service/encryptionatrest/model.go
+++ b/internal/service/encryptionatrest/model.go
@@ -85,6 +85,7 @@ func NewTFAzureKeyVaultConfigItem(az *admin.AzureKeyVault) *TFAzureKeyVaultConfi
 		ResourceGroupName:        types.StringValue(az.GetResourceGroupName()),
 		KeyVaultName:             types.StringValue(az.GetKeyVaultName()),
 		KeyIdentifier:            types.StringValue(az.GetKeyIdentifier()),
+		RoleID:                   conversion.StringNullIfEmpty(az.GetRoleId()),
 		TenantID:                 types.StringValue(az.GetTenantID()),
 		Secret:                   conversion.StringNullIfEmpty(az.GetSecret()),
 		RequirePrivateNetworking: types.BoolValue(az.GetRequirePrivateNetworking()),
@@ -156,6 +157,7 @@ func NewAtlasAzureKeyVault(tfAzKeyVaultConfigSlice []TFAzureKeyVaultConfigModel)
 		Secret:                   v.Secret.ValueStringPointer(),
 		TenantID:                 v.TenantID.ValueStringPointer(),
 		RequirePrivateNetworking: v.RequirePrivateNetworking.ValueBoolPointer(),
+		RoleId:                   v.RoleID.ValueStringPointer(),
 	}
 }
 

--- a/internal/service/encryptionatrest/model.go
+++ b/internal/service/encryptionatrest/model.go
@@ -79,14 +79,14 @@ func NewTFAzureKeyVaultConfigItem(az *admin.AzureKeyVault) *TFAzureKeyVaultConfi
 
 	return &TFAzureKeyVaultConfigModel{
 		Enabled:                  types.BoolPointerValue(az.Enabled),
-		ClientID:                 types.StringPointerValue(az.ClientID),
+		ClientID:                 types.StringValue(az.GetClientID()),
 		AzureEnvironment:         types.StringValue(az.GetAzureEnvironment()),
 		SubscriptionID:           types.StringValue(az.GetSubscriptionID()),
 		ResourceGroupName:        types.StringValue(az.GetResourceGroupName()),
 		KeyVaultName:             types.StringValue(az.GetKeyVaultName()),
 		KeyIdentifier:            types.StringValue(az.GetKeyIdentifier()),
 		RoleID:                   types.StringPointerValue(az.RoleId),
-		TenantID:                 types.StringPointerValue(az.TenantID),
+		TenantID:                 types.StringValue(az.GetTenantID()),
 		Secret:                   conversion.StringNullIfEmpty(az.GetSecret()),
 		RequirePrivateNetworking: types.BoolValue(az.GetRequirePrivateNetworking()),
 		Valid:                    types.BoolPointerValue(az.Valid),

--- a/internal/service/encryptionatrest/model_test.go
+++ b/internal/service/encryptionatrest/model_test.go
@@ -56,6 +56,7 @@ var (
 		ResourceGroupName:        &resourceGroupName,
 		KeyVaultName:             &keyVaultName,
 		KeyIdentifier:            &keyIdentifier,
+		RoleId:                   &roleID,
 		TenantID:                 &tenantID,
 		Secret:                   &secret,
 		RequirePrivateNetworking: &requirePrivateNetworking,
@@ -71,6 +72,7 @@ var (
 		TenantID:                 types.StringValue(tenantID),
 		Secret:                   types.StringValue(secret),
 		RequirePrivateNetworking: types.BoolValue(requirePrivateNetworking),
+		RoleID:                   types.StringValue(roleID),
 	}
 	GoogleCloudKMS = &admin.GoogleCloudKMS{
 		Enabled:              &enabled,

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -83,6 +83,7 @@ type TFAzureKeyVaultConfigModel struct {
 	Enabled                  types.Bool   `tfsdk:"enabled"`
 	RequirePrivateNetworking types.Bool   `tfsdk:"require_private_networking"`
 	Valid                    types.Bool   `tfsdk:"valid"`
+	RoleID                   types.String `tfsdk:"role_id"`
 }
 type TFGcpKmsConfigModel struct {
 	ServiceAccountKey    types.String `tfsdk:"service_account_key"`
@@ -229,6 +230,10 @@ func (r *encryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequ
 						"valid": schema.BoolAttribute{
 							Computed:            true,
 							MarkdownDescription: "Flag that indicates whether the Azure encryption key can encrypt and decrypt data.",
+						},
+						"role_id": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.",
 						},
 					},
 				},

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -537,15 +537,11 @@ func HandleAzureKeyVaultConfigDefaults(ctx context.Context, earRSCurrent, earRSN
 		return
 	}
 
-	// Some fields may be omitted in the response (especially sensitive fields like client_id, tenant_id, secret).
-	// To keep state stable after Create/Update, we need topreserve those values from config (or prior state).
+	// handling sensitive values that are not returned in the API response, so we sync them from the config
+	// that user provided. encryptionAtRestRSConfig is nil during Read(), so we use the current plan
 	if earRSConfig != nil && len(earRSConfig.AzureKeyVaultConfig) > 0 {
-		earRSNew.AzureKeyVaultConfig[0].ClientID = earRSConfig.AzureKeyVaultConfig[0].ClientID
-		earRSNew.AzureKeyVaultConfig[0].TenantID = earRSConfig.AzureKeyVaultConfig[0].TenantID
 		earRSNew.AzureKeyVaultConfig[0].Secret = earRSConfig.AzureKeyVaultConfig[0].Secret
 	} else {
-		earRSNew.AzureKeyVaultConfig[0].ClientID = earRSCurrent.AzureKeyVaultConfig[0].ClientID
-		earRSNew.AzureKeyVaultConfig[0].TenantID = earRSCurrent.AzureKeyVaultConfig[0].TenantID
 		earRSNew.AzureKeyVaultConfig[0].Secret = earRSCurrent.AzureKeyVaultConfig[0].Secret
 	}
 }

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -184,6 +184,7 @@ func (r *encryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequ
 						},
 						"client_id": schema.StringAttribute{
 							Optional:            true,
+							Computed:            true,
 							Sensitive:           true,
 							MarkdownDescription: "Unique 36-hexadecimal character string that identifies an Azure application associated with your Azure Active Directory tenant.",
 						},
@@ -216,6 +217,7 @@ func (r *encryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequ
 						},
 						"tenant_id": schema.StringAttribute{
 							Optional:            true,
+							Computed:            true,
 							Sensitive:           true,
 							MarkdownDescription: "Unique 36-hexadecimal character string that identifies the Azure Active Directory tenant within your Azure subscription.",
 						},

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -537,11 +537,15 @@ func HandleAzureKeyVaultConfigDefaults(ctx context.Context, earRSCurrent, earRSN
 		return
 	}
 
-	// handling sensitive values that are not returned in the API response, so we sync them from the config
-	// that user provided. encryptionAtRestRSConfig is nil during Read(), so we use the current plan
+	// Some fields may be omitted in the response (especially sensitive fields like client_id, tenant_id, secret).
+	// To keep state stable after Create/Update, we need topreserve those values from config (or prior state).
 	if earRSConfig != nil && len(earRSConfig.AzureKeyVaultConfig) > 0 {
+		earRSNew.AzureKeyVaultConfig[0].ClientID = earRSConfig.AzureKeyVaultConfig[0].ClientID
+		earRSNew.AzureKeyVaultConfig[0].TenantID = earRSConfig.AzureKeyVaultConfig[0].TenantID
 		earRSNew.AzureKeyVaultConfig[0].Secret = earRSConfig.AzureKeyVaultConfig[0].Secret
 	} else {
+		earRSNew.AzureKeyVaultConfig[0].ClientID = earRSCurrent.AzureKeyVaultConfig[0].ClientID
+		earRSNew.AzureKeyVaultConfig[0].TenantID = earRSCurrent.AzureKeyVaultConfig[0].TenantID
 		earRSNew.AzureKeyVaultConfig[0].Secret = earRSCurrent.AzureKeyVaultConfig[0].Secret
 	}
 }

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -80,10 +80,10 @@ type TFAzureKeyVaultConfigModel struct {
 	KeyIdentifier            types.String `tfsdk:"key_identifier"`
 	Secret                   types.String `tfsdk:"secret"`
 	TenantID                 types.String `tfsdk:"tenant_id"`
+	RoleID                   types.String `tfsdk:"role_id"`
 	Enabled                  types.Bool   `tfsdk:"enabled"`
 	RequirePrivateNetworking types.Bool   `tfsdk:"require_private_networking"`
 	Valid                    types.Bool   `tfsdk:"valid"`
-	RoleID                   types.String `tfsdk:"role_id"`
 }
 type TFGcpKmsConfigModel struct {
 	ServiceAccountKey    types.String `tfsdk:"service_account_key"`

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -233,7 +233,7 @@ func (r *encryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequ
 						},
 						"role_id": schema.StringAttribute{
 							Optional:            true,
-							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Azure Service Principal that MongoDB Cloud uses to access the Azure Key Vault.",
+							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Azure Service Principal that Atlas uses to access the Azure Key Vault.",
 						},
 					},
 				},

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -157,6 +157,8 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 }
 
 func TestAccEncryptionAtRest_basicAzureWithRole(t *testing.T) {
+	acc.SkipTestForCI(t) // needs Azure configuration
+
 	var (
 		projectID = acc.ProjectIDExecution(t)
 	)

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -156,6 +156,26 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 	})
 }
 
+func TestAccEncryptionAtRest_basicAzureWithRole(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acc.PreCheckEncryptionAtRestEnvAzureWithRole(t)
+		},
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.EARDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configAzureKeyVaultWithRole(projectID, true),
+				Check:  checkEARResourceAzureWithRole(projectID),
+			},
+		},
+	})
+}
+
 func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 	acc.SkipTestForCI(t) // needs GCP configuration
 
@@ -524,6 +544,56 @@ func configGoogleCloudKms(projectID string, google *admin.GoogleCloudKMS, useDat
 		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())
 	}
 	return config
+}
+
+func configAzureKeyVaultWithRole(projectID string, useDatasource bool) string {
+	config := fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = %[1]q
+
+			azure_key_vault_config {
+				enabled             = true
+				role_id             = %[2]q
+				azure_environment   = "AZURE"
+				subscription_id     = %[3]q
+				resource_group_name = %[4]q
+				key_vault_name      = %[5]q
+				key_identifier      = %[6]q
+			}
+		}
+	`, projectID,
+		os.Getenv("AZURE_CPA_ROLE_ID"),
+		os.Getenv("AZURE_SUBSCRIPTION_ID"),
+		os.Getenv("AZURE_RESOURCE_GROUP_NAME"),
+		os.Getenv("AZURE_KEY_VAULT_NAME"),
+		os.Getenv("AZURE_KEY_IDENTIFIER"),
+	)
+
+	if useDatasource {
+		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())
+	}
+	return config
+}
+
+func checkEARResourceAzureWithRole(projectID string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		acc.CheckEARExists(resourceName),
+		resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+		resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
+		resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", "AZURE"),
+		resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", os.Getenv("AZURE_RESOURCE_GROUP_NAME")),
+		resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", os.Getenv("AZURE_KEY_VAULT_NAME")),
+		resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.role_id", os.Getenv("AZURE_CPA_ROLE_ID")),
+		resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.valid", "true"),
+
+		resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
+		resource.TestCheckResourceAttr(datasourceName, "azure_key_vault_config.enabled", "true"),
+		resource.TestCheckResourceAttr(datasourceName, "azure_key_vault_config.azure_environment", "AZURE"),
+		resource.TestCheckResourceAttr(datasourceName, "azure_key_vault_config.resource_group_name", os.Getenv("AZURE_RESOURCE_GROUP_NAME")),
+		resource.TestCheckResourceAttr(datasourceName, "azure_key_vault_config.key_vault_name", os.Getenv("AZURE_KEY_VAULT_NAME")),
+		resource.TestCheckResourceAttr(datasourceName, "azure_key_vault_config.role_id", os.Getenv("AZURE_CPA_ROLE_ID")),
+		resource.TestCheckResourceAttr(datasourceName, "azure_key_vault_config.valid", "true"),
+	)
 }
 
 func configGoogleCloudKmsWithRole(projectID string, google *admin.GoogleCloudKMS, useDatasource bool) string {

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -162,6 +162,19 @@ func PreCheckGCPEnvWithRole(tb testing.TB) {
 	}
 }
 
+func PreCheckEncryptionAtRestEnvAzureWithRole(tb testing.TB) {
+	tb.Helper()
+	PreCheckBasic(tb)
+
+	if os.Getenv("AZURE_EAR_ROLE_ID") == "" ||
+		os.Getenv("AZURE_SUBSCRIPTION_ID") == "" ||
+		os.Getenv("AZURE_RESOURCE_GROUP_NAME") == "" ||
+		os.Getenv("AZURE_KEY_VAULT_NAME") == "" ||
+		os.Getenv("AZURE_KEY_IDENTIFIER") == "" {
+		tb.Fatal("`AZURE_EAR_ROLE_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP_NAME`, `AZURE_KEY_VAULT_NAME`, and `AZURE_KEY_IDENTIFIER` must be set acceptance testing")
+	}
+}
+
 func PreCheckPeeringEnvAWS(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("AWS_ACCOUNT_ID") == "" ||


### PR DESCRIPTION
## Description

This PR adds an improvement for Azure Key Vault, by providing serverless authentication adding `role_id` support to `mongodbatlas_encryption_at_rest`, meaning that static credentiasl (`client_id/tenant_id/secret`) are no longer required. 

The PR also adds test coverage for the  workflow, please note that acceptance test is skipped in CI, matching the existing GCP test about that same field addition. Test has been run in local, and is passing. 

Link to any related issue(s): [CLOUDP-377432](https://jira.mongodb.org/browse/CLOUDP-377432)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [X] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

With this new auth workflow using `role_id`, the API responses will omit fields `client_id` and `tenant_id`. These attributes are optional + sensitive, and the provider maps those omitted values to `""` instead of `null`, which will trigger post-apply “inconsistent result” errors like the following:

```
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to mongodbatlas_encryption_at_rest.test, provider "provider[\"registry.terraform.io/mongodb/mongodbatlas\"]" produced an
│ unexpected new value: .azure_key_vault_config[0].client_id: inconsistent values for sensitive attribute.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to mongodbatlas_encryption_at_rest.test, provider "provider[\"registry.terraform.io/mongodb/mongodbatlas\"]" produced an
│ unexpected new value: .azure_key_vault_config[0].tenant_id: inconsistent values for sensitive attribute.
```

In order to avoid this, it's been agreed to change `client_id` and `tenant_id` to `Computed + Optional`, to avoid any potential breaking changes. 

## Manual Tests for Migration - From Static Credentials to Serverless

1. Defined TF config with static credentials (usage of `client_id`, `tenant_id` and `secret`):

```
resource "mongodbatlas_encryption_at_rest" "test" {
  project_id = "<PROJECT_ID>"

  azure_key_vault_config {
    enabled           = true
    azure_environment = "AZURE"

     tenant_id       = "<YOUR_TENANT_ID>"
     subscription_id = "<SUBSCRIPTION_ID>"
     client_id       = "<CLIENT_ID>"
     secret          = "<SECRET>"

    resource_group_name = "RESOURCE_GROUP_NAME"
    key_vault_name      = "KEY_VAULT_NAME"
    key_identifier      = "<YOUR_KEY_IDENTIFIER>"
  }
}

```

2. `tf plan/tf apply`: Configuration gets created, and state file populates the correct fields

```
            "azure_key_vault_config": {
              "azure_environment": "AZURE",
              "client_id": <REDACTED>,
              "enabled": true,
              "key_identifier": "<REDACTED>",
              "key_vault_name": "<REDACTED>,
              "require_private_networking": false,
              "resource_group_name": "<REDACTED>",
              "role_id": null,
              "secret": <REDACTED>,
              "subscription_id": "<REDACTED>",
              "tenant_id": <REDACTED>,
              "valid": true
            },
```

3. Update config file with new secretless auth (usage of `role_id`):

```
resource "mongodbatlas_encryption_at_rest" "test" {
  project_id = "<PROJECT_ID>"

  azure_key_vault_config {
    enabled           = true
    azure_environment = "AZURE"

     subscription_id = "<SUBSCRIPTION_ID>"

    resource_group_name = "RESOURCE_GROUP_NAME"
    key_vault_name      = "KEY_VAULT_NAME"
    key_identifier      = "<YOUR_KEY_IDENTIFIER>"
    role_id             = "<ROLE_ID>"
  }
}

```

4. `tf plan/apply`: Plan command shows changes to azure config, apply is successful.

```
            "azure_key_vault_config": {
              "azure_environment": "AZURE",
              "client_id": "",
              "enabled": true,
              "key_identifier": "<REDACTED>",
              "key_vault_name": "<REDACTED>,
              "require_private_networking": false,
              "resource_group_name": "<REDACTED>",
              "role_id": "<REDACTED>",
              "secret": null,
              "subscription_id": "<REDACTED>",
              "tenant_id": "",
              "valid": true
            },
```
