### PR TITLE
chore: Fix import for GCP in mongodbatlas_privatelink_endpoint_service

### DIFF
--- a/docs/data-sources/privatelink_endpoint_service.md
+++ b/docs/data-sources/privatelink_endpoint_service.md
@@ -29,7 +29,7 @@ See [`mongodbatlas_privatelink_endpoint_service` resource](../resources/privatel
 
 * `project_id` - (Required) Unique identifier for the project.
 * `private_link_id` - (Required) Unique identifier of the private endpoint service for which you want to retrieve a private endpoint.
-* `endpoint_service_id` - (Required) Unique identifier of the interface endpoint you created in your VPC.
+* `endpoint_service_id` - (Required) Identifier of the endpoint resource in your cloud provider: for `AWS` and `AZURE`, the interface endpoint ID; for `GCP` port-mapped architecture, the forwarding rule name; for `GCP` legacy architecture, the network endpoint group name.
 * `provider_name` - (Required) Cloud provider for which you want to retrieve a private endpoint. Atlas accepts `AWS`, `AZURE` or `GCP`.
 
 ## Attributes Reference

--- a/docs/data-sources/privatelink_endpoint_service.md
+++ b/docs/data-sources/privatelink_endpoint_service.md
@@ -27,10 +27,10 @@ See [`mongodbatlas_privatelink_endpoint_service` resource](../resources/privatel
 
 ## Argument Reference
 
-* `project_id` - (Required) Unique identifier for the project.
-* `private_link_id` - (Required) Unique identifier of the private endpoint service for which you want to retrieve a private endpoint.
-* `endpoint_service_id` - (Required) Identifier of the endpoint resource in your cloud provider: for `AWS` and `AZURE`, the interface endpoint ID; for `GCP` port-mapped architecture, the forwarding rule name; for `GCP` legacy architecture, the network endpoint group name.
-* `provider_name` - (Required) Cloud provider for which you want to retrieve a private endpoint. Atlas accepts `AWS`, `AZURE` or `GCP`.
+* `project_id` - (Required) Unique identifier for the project, also known as `group_id` in the official documentation.
+* `private_link_id` - (Required) Unique identifier of the `AWS`, `AZURE` or `GCP` PrivateLink connection which is created by `mongodbatlas_privatelink_endpoint` resource.
+* `endpoint_service_id` - (Required) Unique identifier of the interface endpoint you created in your VPC. For `AWS` and `AZURE`, this is the interface endpoint identifier. For `GCP` port-mapped architecture, this is the forwarding rule name. For `GCP` legacy private endpoint architecture, this is the endpoint group name.
+* `provider_name` - (Required) Cloud provider for which you want to create a private endpoint. Atlas accepts `AWS`, `AZURE` or `GCP`.
 
 ## Attributes Reference
 

--- a/docs/data-sources/privatelink_endpoint_service.md
+++ b/docs/data-sources/privatelink_endpoint_service.md
@@ -8,102 +8,18 @@ subcategory: "Private Endpoint Services"
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
-## Example with AWS
-
-```terraform
-resource "mongodbatlas_privatelink_endpoint" "this" {
-  project_id    = "<PROJECT_ID>"
-  provider_name = "AWS"
-  region        = "US_EAST_1"
-}
-
-resource "aws_vpc_endpoint" "ptfe_service" {
-  vpc_id             = "vpc-7fc0a543"
-  service_name       = mongodbatlas_privatelink_endpoint.this.endpoint_service_name
-  vpc_endpoint_type  = "Interface"
-  subnet_ids         = ["subnet-de0406d2"]
-  security_group_ids = ["sg-3f238186"]
-}
-
-resource "mongodbatlas_privatelink_endpoint_service" "this" {
-  project_id          = mongodbatlas_privatelink_endpoint.this.project_id
-  private_link_id     = mongodbatlas_privatelink_endpoint.this.private_link_id
-  endpoint_service_id = aws_vpc_endpoint.ptfe_service.id
-  provider_name       = "AWS"
-}
-
-data "mongodbatlas_privatelink_endpoint_service" "this" {
-  project_id          = mongodbatlas_privatelink_endpoint_service.this.project_id
-  private_link_id     = mongodbatlas_privatelink_endpoint_service.this.private_link_id
-  endpoint_service_id = mongodbatlas_privatelink_endpoint_service.this.endpoint_service_id
-  provider_name       = "AWS"
-}
-```
-
-## Example with Azure
-
-```terraform
-resource "mongodbatlas_privatelink_endpoint" "this" {
-  project_id    = var.project_id
-  provider_name = "AZURE"
-  region        = "eastus2"
-}
-
-resource "azurerm_private_endpoint" "this" {
-  name                = "endpoint-this"
-  location            = data.azurerm_resource_group.this.location
-  resource_group_name = var.resource_group_name
-  subnet_id           = azurerm_subnet.this.id
-  private_service_connection {
-    name                           = mongodbatlas_privatelink_endpoint.this.private_link_service_name
-    private_connection_resource_id = mongodbatlas_privatelink_endpoint.this.private_link_service_resource_id
-    is_manual_connection           = true
-    request_message                = "Azure Private Link this"
-  }
-
-}
-
-resource "mongodbatlas_privatelink_endpoint_service" "this" {
-  project_id                  = mongodbatlas_privatelink_endpoint.this.project_id
-  private_link_id             = mongodbatlas_privatelink_endpoint.this.private_link_id
-  endpoint_service_id         = azurerm_private_endpoint.this.id
-  private_endpoint_ip_address = azurerm_private_endpoint.this.private_service_connection.0.private_ip_address
-  provider_name               = "AZURE"
-}
-
-data "mongodbatlas_privatelink_endpoint_service" "this" {
-  project_id          = mongodbatlas_privatelink_endpoint_service.this.project_id
-  private_link_id     = mongodbatlas_privatelink_endpoint_service.this.private_link_id
-  endpoint_service_id = mongodbatlas_privatelink_endpoint_service.this.endpoint_service_id
-  provider_name       = "AZURE"
-}
-```
-
-## Example with GCP (Legacy Architecture)
+## Example Usage
 
 ```terraform
 data "mongodbatlas_privatelink_endpoint_service" "this" {
   project_id          = mongodbatlas_privatelink_endpoint_service.this.project_id
   private_link_id     = mongodbatlas_privatelink_endpoint_service.this.private_link_id
   endpoint_service_id = mongodbatlas_privatelink_endpoint_service.this.endpoint_service_id
-  provider_name       = "GCP"
+  provider_name       = "AWS" # or "AZURE" or "GCP"
 }
 ```
 
-## Example with GCP (Port-Mapped Architecture)
-
-The port-mapped architecture uses port mapping to reduce resource provisioning. In the GCP legacy private endpoint architecture, service attachments were mapped 1:1 with Atlas nodes (one service attachment per node). In the port-mapped architecture, regardless of cloud provider, one service attachment can be mapped to up to 150 nodes via ports designated per node, enabling direct targeting of specific nodes using only one customer IP address. Enable it by setting `port_mapping_enabled = true` on the `mongodbatlas_privatelink_endpoint` resource.
-
-**Important:** For the port-mapped architecture, use `endpoint_service_id` (the forwarding rule name) and `private_endpoint_ip_address` (the IP address). The `endpoints` list is no longer used for the port-mapped architecture.
-
-```terraform
-data "mongodbatlas_privatelink_endpoint_service" "this" {
-  project_id          = mongodbatlas_privatelink_endpoint_service.this.project_id
-  private_link_id     = mongodbatlas_privatelink_endpoint_service.this.private_link_id
-  endpoint_service_id = mongodbatlas_privatelink_endpoint_service.this.endpoint_service_id
-  provider_name       = "GCP"
-}
-```
+See [`mongodbatlas_privatelink_endpoint_service` resource](../resources/privatelink_endpoint_service.md) for complete examples with each cloud provider.
 
 ### Available complete examples
 - [Setup private connection to a MongoDB Atlas Cluster with AWS VPC](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.6.0/examples/mongodbatlas_privatelink_endpoint/aws/cluster)
@@ -113,7 +29,7 @@ data "mongodbatlas_privatelink_endpoint_service" "this" {
 
 * `project_id` - (Required) Unique identifier for the project.
 * `private_link_id` - (Required) Unique identifier of the private endpoint service for which you want to retrieve a private endpoint.
-* `endpoint_service_id` - (Required) Unique identifier of the interface endpoint you created in your VPC. For `AWS` and `AZURE`, this is the interface endpoint identifier. For `GCP` port-mapped architecture, this is the forwarding rule name. For `GCP` legacy private endpoint architecture, this is the endpoint group name.
+* `endpoint_service_id` - (Required) Unique identifier of the interface endpoint you created in your VPC.
 * `provider_name` - (Required) Cloud provider for which you want to retrieve a private endpoint. Atlas accepts `AWS`, `AZURE` or `GCP`.
 
 ## Attributes Reference
@@ -129,7 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 * `error_message` - Error message pertaining to the interface endpoint. Returns null if there are no errors.
 * `aws_connection_status` - Status of the interface endpoint for AWS.
   Returns one of the following values:
-  * `NONE` - Atlas created the network load balancer and VPC endpoint service, but AWS hasn’t yet created the VPC endpoint.
+  * `NONE` - Atlas created the network load balancer and VPC endpoint service, but AWS hasn't yet created the VPC endpoint.
   * `PENDING_ACCEPTANCE` - AWS has received the connection request from your VPC endpoint to the Atlas VPC endpoint service.
   * `PENDING` - AWS is establishing the connection between your VPC endpoint and the Atlas VPC endpoint service.
   * `AVAILABLE` - Atlas VPC resources are connected to the VPC endpoint in your VPC. You can connect to Atlas clusters in this region using AWS PrivateLink.
@@ -148,6 +64,7 @@ In addition to all arguments above, the following attributes are exported:
   * `FAILED` - Atlas failed to accept the connection your private endpoint.
   * `DELETING` - Atlas is removing the connection to your private endpoint from the Private Link service.
 * `gcp_endpoint_status` - Status of the individual endpoint. Only populated for port-mapped architecture. Returns one of the following values: `INITIATING`, `AVAILABLE`, `FAILED`, `DELETING`.
+* `gcp_project_id` - Unique identifier of the GCP project in which the endpoints were created. Only applicable for GCP provider.
 * `endpoints` - Collection of individual private endpoints that comprise your network endpoint group. Only populated for GCP legacy private endpoint architecture.
   * `endpoint_name` - Forwarding rule that corresponds to the endpoint you created.
   * `ip_address` - Private IP address of the network endpoint group you created.

--- a/docs/resources/privatelink_endpoint.md
+++ b/docs/resources/privatelink_endpoint.md
@@ -19,7 +19,7 @@ The [private link Terraform module](https://registry.terraform.io/modules/terraf
 ```terraform
 resource "mongodbatlas_privatelink_endpoint" "this" {
   project_id    = "<PROJECT-ID>"
-  provider_name = "AWS/AZURE/GCP"
+  provider_name = "AWS" # or "AZURE" or "GCP"
   region        = "US_EAST_1"
 }
 ```

--- a/docs/resources/privatelink_endpoint.md
+++ b/docs/resources/privatelink_endpoint.md
@@ -20,7 +20,7 @@ The [private link Terraform module](https://registry.terraform.io/modules/terraf
 resource "mongodbatlas_privatelink_endpoint" "this" {
   project_id    = "<PROJECT-ID>"
   provider_name = "AWS" # or "AZURE" or "GCP"
-  region        = "US_EAST_1"
+  region        = "US_EAST_1" # Any valid AWS, Azure, or GCP region
 }
 ```
 

--- a/internal/service/privatelinkendpointservice/data_source.go
+++ b/internal/service/privatelinkendpointservice/data_source.go
@@ -97,6 +97,11 @@ func DataSource() *schema.Resource {
 				Computed:    true,
 				Description: "Status of the GCP endpoint. Only populated for port-mapped architecture.",
 			},
+			"gcp_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Unique identifier of the GCP project in which you created your endpoints. Only applicable for GCP provider.",
+			},
 			"port_mapping_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -150,6 +155,9 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		if err := d.Set("gcp_status", serviceEndpoint.GetStatus()); err != nil {
 			return diag.FromErr(fmt.Errorf(errorEndpointSetting, "gcp_status", endpointServiceID, err))
+		}
+		if err := d.Set("gcp_project_id", serviceEndpoint.GetGcpProjectId()); err != nil {
+			return diag.FromErr(fmt.Errorf(errorEndpointSetting, "gcp_project_id", endpointServiceID, err))
 		}
 		if serviceEndpoint.GetPortMappingEnabled() {
 			if len(serviceEndpoint.GetEndpoints()) != 1 {

--- a/internal/service/privatelinkendpointservice/resource.go
+++ b/internal/service/privatelinkendpointservice/resource.go
@@ -404,7 +404,7 @@ func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) 
 	endpointServiceID := parts[2]
 	providerName := parts[3]
 
-	_, _, err := connV2.PrivateEndpointServicesApi.GetPrivateEndpoint(ctx, projectID, providerName, endpointServiceID, privateLinkID).Execute()
+	privateEndpoint, _, err := connV2.PrivateEndpointServicesApi.GetPrivateEndpoint(ctx, projectID, providerName, endpointServiceID, privateLinkID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf(errorServiceEndpointRead, endpointServiceID, err)
 	}
@@ -423,6 +423,12 @@ func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	if err := d.Set("provider_name", providerName); err != nil {
 		return nil, fmt.Errorf(errorEndpointSetting, "provider_name", privateLinkID, err)
+	}
+
+	if providerName == constant.GCP {
+		if err := d.Set("gcp_project_id", privateEndpoint.GetGcpProjectId()); err != nil {
+			return nil, fmt.Errorf(errorEndpointSetting, "gcp_project_id", privateLinkID, err)
+		}
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{


### PR DESCRIPTION
## Description

Fix import for GCP in `mongodbatlas_privatelink_endpoint_service`. Import was failing before (legacy GCP) and similarly faile for new port-mapped. The issue is that `gcp_project_id` is Optional + ForceNew (not Computed) and is not returned by GET operation. Therefore Import is not able to populate it and a state drift happens when trying to apply the imported resource, e.g.:
 
<img width="756" height="325" alt="replaced" src="https://github.com/user-attachments/assets/35304ee8-dc4b-41ae-8414-f16a2514dd2b" />

The private endpoint would be deleted and created again, instead of an empty plan. 

Atlas is now returning the attribute and it's set in Import so no plan changes happen.

Also:
- Expose `gcp_project_id` in the datasource
- Improve and simplify datasource doc



Link to any related issue(s): CLOUDP-378355

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
