### PR TITLE
feat: Supports autogeneration of Service Account on `mongodbatlas_organization` resource creation

### DIFF
--- a/.changelog/4150.txt
+++ b/.changelog/4150.txt
@@ -1,3 +1,11 @@
 ```release-note:enhancement
 resource/mongodbatlas_organization: Adds optional `service_account` block to create a Service Account instead of a Programmatic API Key on organization creation
 ```
+
+```release-note:enhancement
+resource/mongodbatlas_organization: Adds `service_account.client_id` computed attribute with the Service Account Client ID
+```
+
+```release-note:enhancement
+resource/mongodbatlas_organization: Adds `service_account.secrets` computed attribute with the Service Account secrets list
+```

--- a/.changelog/4150.txt
+++ b/.changelog/4150.txt
@@ -1,3 +1,11 @@
 ```release-note:enhancement
-resource/mongodbatlas_organization: Adds automatic Service Account creation alongside the organization, exporting `client_id` and `client_secret` as computed sensitive attributes. Adds `service_account_secret_expires_after_hours` attribute to configure the secret expiration time
+resource/mongodbatlas_organization: Adds `client_id` computed attribute with the Service Account Client ID created alongside the organization
+```
+
+```release-note:enhancement
+resource/mongodbatlas_organization: Adds `client_secret` computed attribute with the Service Account secret created alongside the organization
+```
+
+```release-note:enhancement
+resource/mongodbatlas_organization: Adds `service_account_secret_expires_after_hours` attribute to configure the Service Account secret expiration time
 ```

--- a/.changelog/4150.txt
+++ b/.changelog/4150.txt
@@ -1,11 +1,3 @@
 ```release-note:enhancement
-resource/mongodbatlas_organization: Adds `client_id` computed attribute with the Service Account Client ID created alongside the organization
-```
-
-```release-note:enhancement
-resource/mongodbatlas_organization: Adds `client_secret` computed attribute with the Service Account secret created alongside the organization
-```
-
-```release-note:enhancement
-resource/mongodbatlas_organization: Adds `service_account_secret_expires_after_hours` attribute to configure the Service Account secret expiration time
+resource/mongodbatlas_organization: Adds optional `service_account` block to create a Service Account instead of a Programmatic API Key on organization creation
 ```

--- a/.changelog/4150.txt
+++ b/.changelog/4150.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_organization: Adds automatic Service Account creation alongside the organization, exporting `client_id` and `client_secret` as computed sensitive attributes. Adds `service_account_secret_expires_after_hours` attribute to configure the secret expiration time
+```

--- a/docs/guides/provider-configuration.md
+++ b/docs/guides/provider-configuration.md
@@ -27,7 +27,7 @@ SAs simplify authentication by eliminating the need to create new Atlas-specific
 
 To use SA authentication, create an SA in your [MongoDB Atlas organization](https://www.mongodb.com/docs/atlas/configure-api-access/#grant-programmatic-access-to-an-organization) and set the credentials, for example:
 
-~> **NOTE:** When creating a new organization with the [`mongodbatlas_organization`](../resources/organization) resource, a Service Account is automatically created alongside the organization. The resulting `client_id` and `client_secret` attributes can be used directly to configure the provider for the new organization.
+~> **NOTE:** When creating a new organization with the [`mongodbatlas_organization`](../resources/organization) resource, you can define a `service_account` block to create a Service Account instead of a Programmatic API Key. The resulting `client_id` and `client_secret` attributes can be used directly to configure the provider for the new organization.
 
 ```terraform
 provider "mongodbatlas" {

--- a/docs/guides/provider-configuration.md
+++ b/docs/guides/provider-configuration.md
@@ -27,7 +27,7 @@ SAs simplify authentication by eliminating the need to create new Atlas-specific
 
 To use SA authentication, create an SA in your [MongoDB Atlas organization](https://www.mongodb.com/docs/atlas/configure-api-access/#grant-programmatic-access-to-an-organization) and set the credentials, for example:
 
-~> **TIP:** When creating a new organization with the [`mongodbatlas_organization`](../resources/organization) resource, a Service Account is automatically created alongside the organization. The resulting `client_id` and `client_secret` attributes can be used directly to configure the provider for the new organization.
+~> **NOTE:** When creating a new organization with the [`mongodbatlas_organization`](../resources/organization) resource, a Service Account is automatically created alongside the organization. The resulting `client_id` and `client_secret` attributes can be used directly to configure the provider for the new organization.
 
 ```terraform
 provider "mongodbatlas" {

--- a/docs/guides/provider-configuration.md
+++ b/docs/guides/provider-configuration.md
@@ -27,6 +27,8 @@ SAs simplify authentication by eliminating the need to create new Atlas-specific
 
 To use SA authentication, create an SA in your [MongoDB Atlas organization](https://www.mongodb.com/docs/atlas/configure-api-access/#grant-programmatic-access-to-an-organization) and set the credentials, for example:
 
+~> **TIP:** When creating a new organization with the [`mongodbatlas_organization`](../resources/organization) resource, a Service Account is automatically created alongside the organization. The resulting `client_id` and `client_secret` attributes can be used directly to configure the provider for the new organization.
+
 ```terraform
 provider "mongodbatlas" {
   client_id     = var.mongodbatlas_client_id

--- a/docs/guides/service-account-secret-rotation.md
+++ b/docs/guides/service-account-secret-rotation.md
@@ -18,6 +18,8 @@ This guide applies to both organization-level and project-level service accounts
 
 **Note**: The steps below use organization-level resources, but the same approach applies to project-level resources.
 
+~> **WARNING:** Service Account secrets expire after the configured `secret_expires_after_hours` period. To avoid losing access to the Atlas Administration API, update your application with the new client secret as soon as possible after rotation. If all secrets expire before being replaced, you will lose access to the organization. For more information, see [Rotate Service Account Secrets](https://www.mongodb.com/docs/atlas/tutorial/rotate-service-account-secrets/).
+
 ## Best Practices Before Starting
 
 - **Backup your Terraform state file** before making any changes.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -67,9 +67,9 @@ resource "mongodbatlas_organization" "this" {
 
 ~> **NOTE:** - If you create an organization with our Terraform provider version >=1.30.0, this field is set to `true` by default.<br> - If you have an existing organization created with our Terraform provider version <1.30.0, this field might be `false`, which is the [API default value](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createorganization). To prevent the creation of future default alerts, set this explicitly to `true`.
 
-### service_account
+* `service_account` - (Optional) Block to create a Service Account instead of a Programmatic API Key when creating the organization. The API does not allow creating both in the same request. If omitted, a Programmatic API Key is created (default behavior). This block can't be updated after creation. See [Service Account](#service-account).
 
-Optional block to create a Service Account instead of a Programmatic API Key when creating the organization. The API does not allow creating both in the same request. If omitted, a Programmatic API Key is created (default behavior). This block can't be updated after creation.
+### Service Account
 
 * `name` - (Required) Human-readable name for the Service Account.
 * `description` - (Required) Human-readable description for the Service Account.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -13,7 +13,7 @@ subcategory: "Organizations"
 ## Example Usage
 
 ```terraform
-resource "mongodbatlas_organization" "test" {
+resource "mongodbatlas_organization" "this" {
   org_owner_id = "<ORG_OWNER_ID>"
   name = "testCreateORG"
   description = "test API key and Service Account from Org Creation"
@@ -62,7 +62,7 @@ In addition to all arguments above, the following attributes are exported:
 You can import an existing organization using the organization ID, e.g.:
 
 ```
-$ terraform import mongodbatlas_organization.example 5d09d6a59ccf6445652a444a
+$ terraform import mongodbatlas_organization.this 5d09d6a59ccf6445652a444a
 ```
 
 ~> **IMPORTANT:** When importing an existing organization, you should **NOT** specify the creation-only attributes (`org_owner_id`, `description`, `role_names`, `federation_settings_id`, `service_account_secret_expires_after_hours`) in your Terraform configuration.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -78,6 +78,8 @@ output "service_account_secret" {
 * `description` - (Required) Human readable description for the Service Account.
 * `roles` - (Required) A list of organization-level roles for the Service Account.
 * `secret_expires_after_hours` - (Required) The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.
+
+~> **WARNING:** Service Account secrets expire after the configured `secret_expires_after_hours` period. To avoid losing access to the Atlas Administration API, update your application with the new client secret before the current one expires. If all secrets expire without being replaced, you will lose access to the organization. For more information, see [Rotate Service Account Secrets](https://www.mongodb.com/docs/atlas/tutorial/rotate-service-account-secrets/).
 * `client_id` - The Client ID of the Service Account.
 * `created_at` - The date that the Service Account was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 * `secrets` - A list of secrets associated with the specified Service Account. See [Secrets](#secrets).

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -23,7 +23,7 @@ resource "mongodbatlas_organization" "this" {
 }
 ```
 
-### With Service Account
+### With Service Account (Recommended)
 
 ```terraform
 resource "mongodbatlas_organization" "this" {

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -6,13 +6,13 @@ subcategory: "Organizations"
 
 `mongodbatlas_organization` provides programmatic management (including creation) of a MongoDB Atlas Organization resource.
 
-~> **IMPORTANT NOTE:**  When you establish an Atlas organization using this resource, it automatically generates a set of initial credentials. By default, a Programmatic API Key (public and private key) is created — in this case, `role_names` must have the ORG_OWNER role specified. Alternatively, you can define a `service_account` block to create a [Service Account](../guides/provider-configuration#service-account-recommended) (client ID and client secret) instead. The API does not allow creating both in the same request. These credential values are stored in the Terraform state and used by the resource for subsequent operations on the organization.
+~> **IMPORTANT NOTE:**  When you establish an Atlas organization using this resource, it automatically generates a set of initial credentials. Defining `description` and `role_names` creates a Programmatic API Key (public and private key) — in this case, `role_names` must have the ORG_OWNER role specified. Defining a `service_account` block creates a [Service Account](../guides/provider-configuration#service-account-recommended) (client ID and client secret) instead. The API does not allow creating both in the same request. These credential values are stored in the Terraform state and used by the resource for subsequent operations on the organization.
 
 ~> **IMPORTANT NOTE:** To use this resource, the requesting API Key must have the Organization Owner role. The requesting API Key's organization must be a paying organization. To learn more, see Configure a Paying Organization in the MongoDB Atlas documentation.
 
 ## Example Usage
 
-### With Programmatic API Key (default)
+### With Programmatic API Key
 
 ```terraform
 resource "mongodbatlas_organization" "this" {
@@ -58,7 +58,7 @@ output "service_account_secret" {
 * `description` - (Optional) Programmatic API Key description. This attribute is required in creation and can't be updated later.
 
 ~> **NOTE:** Creating an organization will return a set of credentials that are stored in the Terraform state and used by the `mongodbatlas_organization` resource for subsequent operations (read, update, delete) on the new organization. The credentials stored depend on the authentication method used during creation:
-- **Programmatic API Key (default):** `public_key` and `private_key` are stored. These credentials do not expire.
+- **Programmatic API Key:** `public_key` and `private_key` are stored. These credentials do not expire.
 - **Service Account:** `service_account.client_id` and `service_account.secrets.0.secret` are stored. Service Account secrets expire after the configured `secret_expires_after_hours` period. When the secret expires, the resource automatically falls back to provider-level credentials for subsequent operations.
 - In case of importing the resource, no organization-specific credentials are stored and provider credentials are used instead.
 - Terraform state contains sensitive credential data. Follow [Terraform's best practices for sensitive data in state](https://developer.hashicorp.com/terraform/language/state/sensitive-data).
@@ -74,7 +74,7 @@ output "service_account_secret" {
 
 ~> **NOTE:** - If you create an organization with our Terraform provider version >=1.30.0, this field is set to `true` by default.<br> - If you have an existing organization created with our Terraform provider version <1.30.0, this field might be `false`, which is the [API default value](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createorganization). To prevent the creation of future default alerts, set this explicitly to `true`.
 
-* `service_account` - (Optional) Block to create a Service Account instead of a Programmatic API Key when creating the organization. The API does not allow creating both in the same request. If omitted, a Programmatic API Key is created (default behavior). This block can't be updated after creation. See [Service Account](#service-account).
+* `service_account` - (Optional) Block to create a Service Account instead of a Programmatic API Key when creating the organization. The API does not allow creating both in the same request. Mutually exclusive with `description` and `role_names`. This block can't be updated after creation. See [Service Account](#service-account).
 
 ### Service Account
 
@@ -93,8 +93,6 @@ output "service_account_secret" {
 * `created_at` - The date that the secret was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 * `expires_at` - The date for the expiration of the secret. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 * `secret_id` - Unique 24-hexadecimal digit string that identifies the secret.
-* `last_used_at` - The last time the secret was used. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-* `masked_secret_value` - The masked Service Account secret.
 * `secret` - (Sensitive) The secret for the Service Account. It will be returned only the first time after creation.
 
 ## Attributes Reference

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -6,7 +6,7 @@ subcategory: "Organizations"
 
 `mongodbatlas_organization` provides programmatic management (including creation) of a MongoDB Atlas Organization resource.
 
-~> **IMPORTANT NOTE:**  When you establish an Atlas organization using this resource, it automatically generates a set of initial public and private Programmatic API Keys. These key values are vital to store because you'll need to use them to grant access to the newly created Atlas organization. To use this resource, `role_names` for new API Key must have the ORG_OWNER role specified.
+~> **IMPORTANT NOTE:**  When you establish an Atlas organization using this resource, it automatically generates a set of initial Programmatic API Keys (public and private key) and a Service Account (client ID and client secret). These credential values are vital to store because you'll need to use them to grant access to the newly created Atlas organization. To use this resource, `role_names` must have the ORG_OWNER role specified.
 
 ~> **IMPORTANT NOTE:** To use this resource, the requesting API Key must have the Organization Owner role. The requesting API Key's organization must be a paying organization. To learn more, see Configure a Paying Organization in the MongoDB Atlas documentation.
 
@@ -16,8 +16,9 @@ subcategory: "Organizations"
 resource "mongodbatlas_organization" "test" {
   org_owner_id = "<ORG_OWNER_ID>"
   name = "testCreateORG"
-  description = "test API key from Org Creation Test"
+  description = "test API key and Service Account from Org Creation"
   role_names = ["ORG_OWNER"]
+  service_account_secret_expires_after_hours = 8760
 }
 ```
 
@@ -30,11 +31,12 @@ resource "mongodbatlas_organization" "test" {
 
 * `name` - (Required) The name of the organization.
 * `org_owner_id` - (Optional) Unique 24-hexadecimal digit string that identifies the Atlas user that you want to assign the Organization Owner role. This user must be a member of the same organization as the calling API key.  This is only required when authenticating with Programmatic API Keys. [MongoDB Atlas Admin API - Get User By Username](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/MongoDB-Cloud-Users/operation/getUserByUsername). This attribute is required in creation and can't be updated later.
-* `description` - (Optional) Programmatic API Key description. This attribute is required in creation and can't be updated later.
+* `description` - (Optional) Description for the Programmatic API Key and the Service Account created alongside the organization. This attribute is required in creation and can't be updated later.
 
-~> **NOTE:** Creating an organization will return a new API Key pair that can be used to authenticate and manage the new organization  with MongoDB Atlas Terraform modules/blueprints.  These credentials will be used by the `mongodbatlas_organization` resource. In case of importing the resource, these credentials will be empty so the provider credentials will be used instead.
+~> **NOTE:** Creating an organization will return a new API Key pair and a Service Account that can be used to authenticate and manage the new organization with MongoDB Atlas Terraform modules/blueprints. These credentials will be used by the `mongodbatlas_organization` resource. In case of importing the resource, these credentials will be empty so the provider credentials will be used instead.
 
-* `role_names` - (Optional) List of Organization roles that the Programmatic API key needs to have. Ensure that you provide at least one role and ensure all roles are valid for the Organization.  You must specify an array even if you are only associating a single role with the Programmatic API key. The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#organization-roles) describes the roles that you can assign to a Programmatic API key. This attribute is required in creation and can't be updated later.
+* `role_names` - (Optional) List of Organization roles assigned to both the Programmatic API Key and the Service Account. Ensure that you provide at least one role and ensure all roles are valid for the Organization. You must specify an array even if you are only associating a single role. The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#organization-roles) describes the available roles. This attribute is required in creation and can't be updated later.
+* `service_account_secret_expires_after_hours` - (Optional) The expiration time of the Service Account secret, provided in hours. This attribute is required in creation and can't be updated later.
 * `federation_settings_id` - (Optional) Unique 24-hexadecimal digit string that identifies the federation to link the newly created organization to. If specified, the proposed Organization Owner of the new organization must have the Organization Owner role in an organization associated with the federation. This attribute can't be updated after creation.
 * `api_access_list_required` - (Optional) Flag that indicates whether to require API operations to originate from an IP Address added to the API access list for the specified organization.
 * `multi_factor_auth_required` - (Optional) Flag that indicates whether to require users to set up Multi-Factor Authentication (MFA) before accessing the specified organization. To learn more, see: https://www.mongodb.com/docs/atlas/security-multi-factor-authentication/.
@@ -52,6 +54,8 @@ In addition to all arguments above, the following attributes are exported:
 * `org_id` - The organization id.
 * `public_key` - Public API key value set for the specified organization API key.
 * `private_key` - Redacted private key returned for this organization API key. This key displays unredacted when first created and is saved within the Terraform state file.
+* `client_id` - The Client ID of the Service Account created alongside the organization.
+* `client_secret` - The secret for the Service Account. This value is only returned when the organization is first created and is saved within the Terraform state file.
 
 ## Import
 
@@ -61,7 +65,7 @@ You can import an existing organization using the organization ID, e.g.:
 $ terraform import mongodbatlas_organization.example 5d09d6a59ccf6445652a444a
 ```
 
-~> **IMPORTANT:** When importing an existing organization, you should **NOT** specify the creation-only attributes (`org_owner_id`, `description`, `role_names`, `federation_settings_id`) in your Terraform configuration.
+~> **IMPORTANT:** When importing an existing organization, you should **NOT** specify the creation-only attributes (`org_owner_id`, `description`, `role_names`, `federation_settings_id`, `service_account_secret_expires_after_hours`) in your Terraform configuration.
 
 See the [Guide: Importing MongoDB Atlas Organizations](../guides/importing-organization) for more information.
 

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -151,14 +151,6 @@ func Resource() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
-									"last_used_at": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"masked_secret_value": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
 									"secret": {
 										Type:      schema.TypeString,
 										Computed:  true,
@@ -200,7 +192,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		return diag.FromErr(fmt.Errorf("error creating Organization: %s", err))
 	}
-	if _, ok := d.GetOk("service_account"); ok {
+	if usingSA {
 		sa, saOk := organization.GetServiceAccountOk()
 		if !saOk {
 			return diag.FromErr(fmt.Errorf("service account was not returned by the API"))
@@ -407,12 +399,10 @@ func setServiceAccountState(d *schema.ResourceData, sa *admin.OrgServiceAccount)
 	var secretsList []map[string]any
 	for _, s := range sa.GetSecrets() {
 		secretsList = append(secretsList, map[string]any{
-			"created_at":          s.GetCreatedAt().String(),
-			"expires_at":          s.GetExpiresAt().String(),
-			"secret_id":           s.GetId(),
-			"last_used_at":        s.GetLastUsedAt().String(),
-			"masked_secret_value": s.GetMaskedSecretValue(),
-			"secret":              s.GetSecret(),
+			"created_at": s.GetCreatedAt().String(),
+			"expires_at": s.GetExpiresAt().String(),
+			"secret_id":  s.GetId(),
+			"secret":     s.GetSecret(),
 		})
 	}
 	saMap["secrets"] = secretsList

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -147,10 +147,11 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(fmt.Errorf("error setting `client_id`: %s", err))
 		}
 		secrets := sa.GetSecrets()
-		if len(secrets) > 0 {
-			if err := d.Set("client_secret", secrets[0].GetSecret()); err != nil {
-				return diag.FromErr(fmt.Errorf("error setting `client_secret`: %s", err))
-			}
+		if len(secrets) == 0 {
+			return diag.FromErr(fmt.Errorf("service account was created but no client secret was returned by the API"))
+		}
+		if err := d.Set("client_secret", secrets[0].GetSecret()); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting `client_secret`: %s", err))
 		}
 	}
 	conn = getAtlasV2Connection(d, meta) // Using new credentials from the created organization.

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -378,6 +378,7 @@ func configBasic(orgOwnerID, name, description, roleNames string, useSkipDefault
 		name = %q
 		description = %q
 		role_names = [%q]
+		service_account_secret_expires_after_hours = 8760
 		
 		%s
 	  }
@@ -393,6 +394,7 @@ func configWithSettings(orgOwnerID, name, description, roleNames string, setting
 		name = %q
 		description = %q
 		role_names = [%q]
+		service_account_secret_expires_after_hours = 8760
 		%s
 	  }
 	`, orgOwnerID, name, description, roleNames, settingsStr)
@@ -487,7 +489,7 @@ func checkAggr(orgOwnerID, name, description string, settings *admin.Organizatio
 		checkExists(resourceName),
 	}
 	checks = acc.AddAttrChecks(resourceName, checks, attributes)
-	checks = acc.AddAttrSetChecks(resourceName, checks, "role_names.#")
+	checks = acc.AddAttrSetChecks(resourceName, checks, "role_names.#", "client_id", "client_secret")
 	checks = append(checks, extra...)
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -484,7 +484,7 @@ func getTestClientWithNewOrgCreds(rs *terraform.ResourceState) (*admin.APIClient
 	}
 
 	clientID := rs.Primary.Attributes["service_account.0.client_id"]
-	clientSecret := rs.Primary.Attributes["service_account.0.client_secret"]
+	clientSecret := rs.Primary.Attributes["service_account.0.secrets.0.secret"]
 	if clientID != "" && clientSecret != "" {
 		c := &config.Credentials{
 			ClientID:     clientID,
@@ -569,7 +569,9 @@ func checkAggrSA(orgOwnerID, name string, settings *admin.OrganizationSettings, 
 	}
 	checks = acc.AddAttrChecks(resourceName, checks, attributes)
 	checks = acc.AddAttrSetChecks(resourceName, checks,
-		"service_account.0.client_id", "service_account.0.client_secret")
+		"service_account.0.client_id", "service_account.0.created_at",
+		"service_account.0.secrets.0.secret", "service_account.0.secrets.0.created_at",
+		"service_account.0.secrets.0.expires_at", "service_account.0.secrets.0.secret_id")
 	checks = append(checks, extra...)
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -145,6 +145,34 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 	})
 }
 
+func TestAccConfigRSOrganization_ServiceAccount(t *testing.T) {
+	acc.SkipTestForCI(t) // affects the org
+
+	var (
+		orgOwnerID = os.Getenv("MONGODB_ATLAS_ORG_OWNER_ID")
+		name       = acc.RandomName()
+		saName     = "test-sa"
+		saDesc     = "test SA for Acceptance tests"
+		saRole     = "ORG_OWNER"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configServiceAccount(orgOwnerID, name, saName, saDesc, saRole),
+				Check: checkAggrSA(orgOwnerID, name, defaultSettings,
+					resource.TestCheckResourceAttr(resourceName, "service_account.0.name", saName),
+					resource.TestCheckResourceAttr(resourceName, "service_account.0.description", saDesc),
+					resource.TestCheckResourceAttr(resourceName, "service_account.0.secret_expires_after_hours", "8760"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccConfigRSOrganizationCreate_Errors(t *testing.T) {
 	var (
 		roleName    = "ORG_OWNER"
@@ -378,11 +406,25 @@ func configBasic(orgOwnerID, name, description, roleNames string, useSkipDefault
 		name = %q
 		description = %q
 		role_names = [%q]
-		service_account_secret_expires_after_hours = 8760
 		
 		%s
 	  }
 	`, orgOwnerID, name, description, roleNames, skipDefaultAlertSettingsStr)
+}
+
+func configServiceAccount(orgOwnerID, name, saName, saDesc, saRole string) string {
+	return fmt.Sprintf(`
+	  resource "mongodbatlas_organization" "test" {
+		org_owner_id = %q
+		name = %q
+		service_account {
+			name = %q
+			description = %q
+			roles = [%q]
+			secret_expires_after_hours = 8760
+		}
+	  }
+	`, orgOwnerID, name, saName, saDesc, saRole)
 }
 
 func configWithSettings(orgOwnerID, name, description, roleNames string, settingsConfig *admin.OrganizationSettings) string {
@@ -394,7 +436,6 @@ func configWithSettings(orgOwnerID, name, description, roleNames string, setting
 		name = %q
 		description = %q
 		role_names = [%q]
-		service_account_secret_expires_after_hours = 8760
 		%s
 	  }
 	`, orgOwnerID, name, description, roleNames, settingsStr)
@@ -425,20 +466,39 @@ func getSettingsConfig(settings *admin.OrganizationSettings) string {
 // getTestClientWithNewOrgCreds creates a new Atlas client with credentials for the newly created organization which
 // is required to call relevant API methods for the new organization, for example ListOrganizations requires that the requesting API
 // key must have the Organization Member role. So we cannot invoke API methods on the new organization with credentials configured in the provider.
+// It tries PAK credentials first, then SA credentials.
 func getTestClientWithNewOrgCreds(rs *terraform.ResourceState) (*admin.APIClient, error) {
-	if rs.Primary.Attributes["public_key"] == "" {
-		return nil, fmt.Errorf("no public_key is set")
+	publicKey := rs.Primary.Attributes["public_key"]
+	privateKey := rs.Primary.Attributes["private_key"]
+	if publicKey != "" && privateKey != "" {
+		c := &config.Credentials{
+			PublicKey:  publicKey,
+			PrivateKey: privateKey,
+			BaseURL:    acc.MongoDBClient.BaseURL,
+		}
+		client, err := config.NewClient(c, acc.MongoDBClient.TerraformVersion)
+		if err != nil {
+			return nil, fmt.Errorf("error creating client with PAK credentials: %s", err)
+		}
+		return client.AtlasV2, nil
 	}
-	if rs.Primary.Attributes["private_key"] == "" {
-		return nil, fmt.Errorf("no private_key is set")
+
+	clientID := rs.Primary.Attributes["service_account.0.client_id"]
+	clientSecret := rs.Primary.Attributes["service_account.0.client_secret"]
+	if clientID != "" && clientSecret != "" {
+		c := &config.Credentials{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			BaseURL:      acc.MongoDBClient.BaseURL,
+		}
+		client, err := config.NewClient(c, acc.MongoDBClient.TerraformVersion)
+		if err != nil {
+			return nil, fmt.Errorf("error creating client with SA credentials: %s", err)
+		}
+		return client.AtlasV2, nil
 	}
-	c := &config.Credentials{
-		PublicKey:  rs.Primary.Attributes["public_key"],
-		PrivateKey: rs.Primary.Attributes["private_key"],
-		BaseURL:    acc.MongoDBClient.BaseURL,
-	}
-	client, _ := config.NewClient(c, acc.MongoDBClient.TerraformVersion)
-	return client.AtlasV2, nil
+
+	return nil, fmt.Errorf("no credentials available (neither PAK nor SA)")
 }
 
 func TestValidateAPIKeyIsOrgOwner(t *testing.T) {
@@ -489,7 +549,27 @@ func checkAggr(orgOwnerID, name, description string, settings *admin.Organizatio
 		checkExists(resourceName),
 	}
 	checks = acc.AddAttrChecks(resourceName, checks, attributes)
-	checks = acc.AddAttrSetChecks(resourceName, checks, "role_names.#", "client_id", "client_secret")
+	checks = acc.AddAttrSetChecks(resourceName, checks, "role_names.#", "public_key", "private_key")
+	checks = append(checks, extra...)
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func checkAggrSA(orgOwnerID, name string, settings *admin.OrganizationSettings, extra ...resource.TestCheckFunc) resource.TestCheckFunc {
+	attributes := map[string]string{
+		"name":                       name,
+		"org_owner_id":               orgOwnerID,
+		"api_access_list_required":   strconv.FormatBool(settings.GetApiAccessListRequired()),
+		"multi_factor_auth_required": strconv.FormatBool(settings.GetMultiFactorAuthRequired()),
+		"restrict_employee_access":   strconv.FormatBool(settings.GetRestrictEmployeeAccess()),
+		"gen_ai_features_enabled":    strconv.FormatBool(settings.GetGenAIFeaturesEnabled()),
+		"security_contact":           settings.GetSecurityContact(),
+	}
+	checks := []resource.TestCheckFunc{
+		checkExists(resourceName),
+	}
+	checks = acc.AddAttrChecks(resourceName, checks, attributes)
+	checks = acc.AddAttrSetChecks(resourceName, checks,
+		"service_account.0.client_id", "service_account.0.client_secret")
 	checks = append(checks, extra...)
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }


### PR DESCRIPTION
## Description


Adds automatic Service Account creation alongside the organization, exporting `client_id` and `client_secret` as computed sensitive attributes. Adds `service_account_secret_expires_after_hours` attribute to configure the secret expiration time.

Testing fallback mechanism:
- Create an org with SA
```
resource "mongodbatlas_organization" "sa_expiry_test" {
  org_owner_id = var.org_owner_id
  name         = "sa-expiry-test-org"

  service_account {
    name                       = "test-sa-fallback"
    description                = "SA"
    roles                      = ["ORG_OWNER"]
    secret_expires_after_hours = 8 # short-lived — secret expires in 8 hours
  }
}
```
- update provider block with generated SA
- Apply with no changes (org resource still uses credentials stored in state)
```
mongodbatlas_organization.sa_expiry_test: Refreshing state... [id=b3JnX2lk:Njk5NDNiOWI4NTZlNmU1OTA4YjYyMjQ4]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
- delete autogenerated SA(this will force the fallback mechanism) and create a new SA. Update provider block to use the newly created SA
- apply with no changes
```
mongodbatlas_organization.sa_expiry_test: Refreshing state... [id=b3JnX2lk:Njk5NDNiOWI4NTZlNmU1OTA4YjYyMjQ4]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Link to any related issue(s): CLOUDP-379374

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
