### PR TITLE
chore: Delete TestAccAdvancedCluster_tls12to13CustomCipherUpdate

### DIFF
--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -2048,46 +2048,6 @@ func checkAdvancedDefaultWrite(name, writeConcern, tls string) resource.TestChec
 		pluralChecks...)
 }
 
-// Test to update advanced_configuration from TLS1_2 (CUSTOM) to TLS1_3 (CUSTOM).
-// Third step to update back to TLS1_3 → TLS1_2 is skipped due to environment flakiness for now. Enable once CLOUDP-362374 is solved.
-// See https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3912 for more details.
-func TestAccAdvancedCluster_tls12to13CustomCipherUpdate(t *testing.T) {
-	acc.SkipTestForCI(t) // Skipping due to almost-consistent failures on cluster update. Enable once CLOUDP-362374 is solved.
-	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 5)
-		processArgsTLS12       = &admin.ClusterDescriptionProcessArgs20240805{
-			TlsCipherConfigMode:            conversion.StringPtr("CUSTOM"),
-			CustomOpensslCipherConfigTls12: conversion.Pointer([]string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}),
-			MinimumEnabledTlsProtocol:      conversion.StringPtr("TLS1_2"),
-		}
-		processArgsTLS13 = &admin.ClusterDescriptionProcessArgs20240805{
-			TlsCipherConfigMode:            conversion.StringPtr("CUSTOM"),
-			CustomOpensslCipherConfigTls13: conversion.Pointer([]string{"TLS_AES_128_GCM_SHA256"}),
-			MinimumEnabledTlsProtocol:      conversion.StringPtr("TLS1_3"),
-		}
-	)
-
-	advancedConfigTLS13 := configAdvanced(t, projectID, clusterName, "", processArgsTLS13)
-	advancedConfigTLS12 := configAdvanced(t, projectID, clusterName, "", processArgsTLS12)
-
-	check := checkAdvancedTLS(clusterName, "TLS1_2", processArgsTLS12)
-	updateCheck := checkAdvancedTLS(clusterName, "TLS1_3", processArgsTLS13)
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		Steps: []resource.TestStep{
-			{
-				Config: advancedConfigTLS12,
-				Check:  check,
-			},
-			{
-				Config: advancedConfigTLS13,
-				Check:  updateCheck,
-			},
-		},
-	})
-}
-
 func TestAccAdvancedCluster_tls13CustomCiphers(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)


### PR DESCRIPTION
## Description

Delete TestAccAdvancedCluster_tls12to13CustomCipherUpdate as discussed offline.

Link to any related issue(s): CLOUDP-368381

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
