### PR TITLE
chore: Add api_spec_url param to autogen-update-api-spec command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,29 +142,33 @@ update-atlas-sdk: ## Update the Atlas SDK dependency
 	./scripts/update-sdk.sh
 
 # e.g. run: make scaffold resource_name=streamInstance type=resource
-# - type argument can have the values: `resource`, `data-source`, `plural-data-source`.
+# type - valid values: `resource`, `data-source`, `plural-data-source`.
 # details on usage can be found in contributing/development-best-practices.md under "Scaffolding initial Code and File Structure"
 .PHONY: scaffold
 scaffold: ## Create scaffolding for a new resource
 	@go run ./tools/scaffold/*.go $(resource_name) $(type)
 	@echo "Reminder: configure the new $(type) in provider.go"
 
+# Generate flattened API spec used by codegen
+# api_spec_url (optional) - URL to the OpenAPI spec (default: https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml).
 .PHONY: autogen-update-api-spec
-autogen-update-api-spec: ## Generate flattened API spec used by codegen
-	@scripts/generate-autogen-api-spec.sh
+autogen-update-api-spec:
+	@scripts/generate-autogen-api-spec.sh $(api_spec_url)
 
 # Generate resources using API spec present in tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
-# resource_name is optional, if not provided all configured resource models will be generated
-# resource_tier is optional; valid values: prod, internal (default: all)
-# step is optional; valid values: model-gen, code-gen (default: both)
+# resource_name (optional) - If not provided all configured resource models will be generated.
+# resource_tier (optional) - Valid values: `prod`, `internal` (default: all).
+# step (optional) - Valid values: `model-gen`, `code-gen` (default: both).
 # e.g. make autogen-generate-resources resource_name=search_deployment_api
 .PHONY: autogen-generate-resources
 autogen-generate-resources:
 	@go run ./tools/codegen/main.go $(if $(resource_name),--resource-name $(resource_name),) $(if $(resource_tier),--resource-tier $(resource_tier),) $(if $(step),--step $(step),)
 
-## Complete generation pipeline: Fetch latest API Spec -> update resource models -> generate resource code
-# resource_name is optional, if not provided all configured resources code will be generated
-# resource_tier is optional; valid values: prod, internal (default: all)
+# Complete generation pipeline: Fetch latest API Spec -> update resource models -> generate resource code
+# api_spec_url (optional) - URL to the OpenAPI spec (default: https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml).
+# resource_name (optional) - If not provided all configured resources code will be generated
+# resource_tier (optional) - Valid values: `prod`, `internal` (default: all)
+# step (optional) - Valid values: `model-gen`, `code-gen` (default: both).
 # e.g. make autogen-pipeline resource_tier=prod
 .PHONY: autogen-pipeline
 autogen-pipeline: autogen-update-api-spec autogen-generate-resources

--- a/scripts/generate-autogen-api-spec.sh
+++ b/scripts/generate-autogen-api-spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_SPEC_URL="${SOURCE_SPEC_URL:-https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml}"
+SOURCE_SPEC_URL="${1:-https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml}"
 SPEC_PATH="tools/codegen/atlasapispec/raw-multi-version-api-spec.yml"
 FLATTENED_SPEC_PATH="tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml"
 


### PR DESCRIPTION
## Description

Adding a api_spec_url param to autogen-update-api-spec so its easier to download the cloud-dev spec via make commands moving forward.
- Could use SOURCE_SPEC_URL env variable before, moving to a positional param to be consistent with other commands.
- Updating comments to clarify usage.

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
