### PR TITLE
chore: Improve autogen handling of null collections during marshaling

### DIFF
--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -23,7 +23,7 @@ import (
 //   - `omitjson`: Attribute is never marshaled.
 //   - `omitjsonupdate`: Attribute is not marshaled if isUpdate is true.
 //   - `sendnullasnullonupdate`: Attribute is marshaled as null if isUpdate is true.
-//   - `sendnullasemptyonupdate`: Attribute is marshaled as empty if isUpdate is true (collections only).
+//   - `sendnullasemptyonupdate`: Attribute is marshaled as empty value (`[]` or `{}`) if isUpdate is true (collections only).
 func Marshal(model any, isUpdate bool) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -18,11 +18,12 @@ import (
 //   - Terraform types: String, Bool, Int64, Float64.
 //   - Custom types: Object, Map, List, Set & jsontypes.Normalized.
 //
-// Attributes that are null or unknown are not marshaled.
-// Attributes with autogen tag `omitjson` are never marshaled, this only applies to the root model.
-// Attributes with autogen tag `omitjsonupdate` are not marshaled if isUpdate is true, this only applies to the root model.
-// Attributes with autogen tag `includenullonupdate` are marshaled if isUpdate is true (even if null), this only applies to the root model.
-// Null list or set root elements are sent as empty arrays if isUpdate is true.
+// Attributes that are null or unknown are not marshaled by default.
+// This behavior can be controlled via autogen tags (tags are exclusive):
+//   - `omitjson`: Attribute is never marshaled.
+//   - `omitjsonupdate`: Attribute is not marshaled if isUpdate is true.
+//   - `sendnullasnullonupdate`: Attribute is marshaled as null if isUpdate is true.
+//   - `sendnullasemptyonupdate`: Attribute is marshaled as empty if isUpdate is true (collections only).
 func Marshal(model any, isUpdate bool) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {
@@ -78,8 +79,8 @@ func marshalAttr(attrNameJSON string, attrValModel reflect.Value, objJSON map[st
 		return err
 	}
 
-	// Emit empty array for null list/set attributes unless explicit configuration with includeNullOnUpdate
-	if val == nil && isUpdate && !tags.IncludeNullOnUpdate {
+	// Emit empty collection on update for null list/set/map attributes when configured via sendNullAsEmptyOnUpdate
+	if val == nil && isUpdate && tags.SendNullAsEmptyOnUpdate {
 		switch obj.(type) {
 		case customtypes.ListValueInterface, customtypes.NestedListValueInterface, customtypes.SetValueInterface, customtypes.NestedSetValueInterface:
 			val = []any{}
@@ -88,8 +89,8 @@ func marshalAttr(attrNameJSON string, attrValModel reflect.Value, objJSON map[st
 		}
 	}
 
-	// Emit value if non-nil, or emit null on update when configured by includeNullOnUpdate
-	if val != nil || (isUpdate && tags.IncludeNullOnUpdate) {
+	// Emit value if non-nil, or emit null on update when configured via sendNullAsNullOnUpdate
+	if val != nil || (isUpdate && tags.SendNullAsNullOnUpdate) {
 		if tags.ListAsMap {
 			val = ModifyJSONFromMapToList(val)
 		}

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -184,75 +184,96 @@ func TestMarshalUpdateAbsentAttrs(t *testing.T) {
 	type modelEmptyTest struct{}
 
 	model := struct {
-		AttrList                    customtypes.ListValue[types.String]         `tfsdk:"attr_list"`
-		AttrListIncludeNull         customtypes.ListValue[types.String]         `tfsdk:"attr_list_include_null" autogen:"includenullonupdate"`
-		AttrSet                     customtypes.SetValue[types.String]          `tfsdk:"attr_set"`
-		AttrSetIncludeNull          customtypes.SetValue[types.String]          `tfsdk:"attr_set_include_null" autogen:"includenullonupdate"`
-		AttrNestedList              customtypes.NestedListValue[modelEmptyTest] `tfsdk:"attr_nested_list"`
-		AttrNestedListIncludeNull   customtypes.NestedListValue[modelEmptyTest] `tfsdk:"attr_nested_list_include_null" autogen:"includenullonupdate"`
-		AttrNestedSet               customtypes.NestedSetValue[modelEmptyTest]  `tfsdk:"attr_nested_set"`
-		AttrNestedSetIncludeNull    customtypes.NestedSetValue[modelEmptyTest]  `tfsdk:"attr_nested_set_include_null" autogen:"includenullonupdate"`
-		AttrMap                     customtypes.MapValue[types.String]          `tfsdk:"attr_map"`
-		AttrMapIncludeNull          customtypes.MapValue[types.String]          `tfsdk:"attr_map_include_null" autogen:"includenullonupdate"`
-		AttrNestedMap               customtypes.NestedMapValue[modelEmptyTest]  `tfsdk:"attr_nested_map"`
-		AttrNestedMapIncludeNull    customtypes.NestedMapValue[modelEmptyTest]  `tfsdk:"attr_nested_map_include_null" autogen:"includenullonupdate"`
-		AttrNestedObject            customtypes.ObjectValue[modelEmptyTest]     `tfsdk:"attr_nested_object"`
-		AttrNestedObjectIncludeNull customtypes.ObjectValue[modelEmptyTest]     `tfsdk:"attr_nested_object_include_null" autogen:"includenullonupdate"`
-		AttrString                  types.String                                `tfsdk:"attr_string"`
-		AttrStringIncludeNull       types.String                                `tfsdk:"attr_include_update" autogen:"includenullonupdate"`
-		AttrInt                     types.Int64                                 `tfsdk:"attr_int"`
-		AttrIntIncludeNull          types.Int64                                 `tfsdk:"attr_int_include_null" autogen:"includenullonupdate"`
-		AttrBool                    types.Bool                                  `tfsdk:"attr_bool"`
-		AttrBoolIncludeNull         types.Bool                                  `tfsdk:"attr_bool_include_null" autogen:"includenullonupdate"`
+		AttrList                  customtypes.ListValue[types.String]         `tfsdk:"attr_list"`
+		AttrListSendNull          customtypes.ListValue[types.String]         `tfsdk:"attr_list_send_null" autogen:"sendnullasnullonupdate"`
+		AttrListSendEmpty         customtypes.ListValue[types.String]         `tfsdk:"attr_list_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrSet                   customtypes.SetValue[types.String]          `tfsdk:"attr_set"`
+		AttrSetSendNull           customtypes.SetValue[types.String]          `tfsdk:"attr_set_send_null" autogen:"sendnullasnullonupdate"`
+		AttrSetSendEmpty          customtypes.SetValue[types.String]          `tfsdk:"attr_set_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrNestedList            customtypes.NestedListValue[modelEmptyTest] `tfsdk:"attr_nested_list"`
+		AttrNestedListSendNull    customtypes.NestedListValue[modelEmptyTest] `tfsdk:"attr_nested_list_send_null" autogen:"sendnullasnullonupdate"`
+		AttrNestedListSendEmpty   customtypes.NestedListValue[modelEmptyTest] `tfsdk:"attr_nested_list_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrNestedSet             customtypes.NestedSetValue[modelEmptyTest]  `tfsdk:"attr_nested_set"`
+		AttrNestedSetSendNull     customtypes.NestedSetValue[modelEmptyTest]  `tfsdk:"attr_nested_set_send_null" autogen:"sendnullasnullonupdate"`
+		AttrNestedSetSendEmpty    customtypes.NestedSetValue[modelEmptyTest]  `tfsdk:"attr_nested_set_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrMap                   customtypes.MapValue[types.String]          `tfsdk:"attr_map"`
+		AttrMapSendNull           customtypes.MapValue[types.String]          `tfsdk:"attr_map_send_null" autogen:"sendnullasnullonupdate"`
+		AttrMapSendEmpty          customtypes.MapValue[types.String]          `tfsdk:"attr_map_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrNestedMap             customtypes.NestedMapValue[modelEmptyTest]  `tfsdk:"attr_nested_map"`
+		AttrNestedMapSendNull     customtypes.NestedMapValue[modelEmptyTest]  `tfsdk:"attr_nested_map_send_null" autogen:"sendnullasnullonupdate"`
+		AttrNestedMapSendEmpty    customtypes.NestedMapValue[modelEmptyTest]  `tfsdk:"attr_nested_map_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrNestedObject          customtypes.ObjectValue[modelEmptyTest]     `tfsdk:"attr_nested_object"`
+		AttrNestedObjectSendNull  customtypes.ObjectValue[modelEmptyTest]     `tfsdk:"attr_nested_object_send_null" autogen:"sendnullasnullonupdate"`
+		AttrNestedObjectSendEmpty customtypes.ObjectValue[modelEmptyTest]     `tfsdk:"attr_nested_object_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrString                types.String                                `tfsdk:"attr_string"`
+		AttrStringSendNull        types.String                                `tfsdk:"attr_send_update" autogen:"sendnullasnullonupdate"`
+		AttrStringSendEmpty       types.String                                `tfsdk:"attr_string_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrInt                   types.Int64                                 `tfsdk:"attr_int"`
+		AttrIntSendNull           types.Int64                                 `tfsdk:"attr_int_send_null" autogen:"sendnullasnullonupdate"`
+		AttrIntSendEmpty          types.Int64                                 `tfsdk:"attr_int_send_empty" autogen:"sendnullasemptyonupdate"`
+		AttrBool                  types.Bool                                  `tfsdk:"attr_bool"`
+		AttrBoolSendNull          types.Bool                                  `tfsdk:"attr_bool_send_null" autogen:"sendnullasnullonupdate"`
+		AttrBoolSendEmpty         types.Bool                                  `tfsdk:"attr_bool_send_empty" autogen:"sendnullasemptyonupdate"`
 	}{
-		AttrList:                    customtypes.NewListValueNull[types.String](t.Context()),
-		AttrListIncludeNull:         customtypes.NewListValueNull[types.String](t.Context()),
-		AttrSet:                     customtypes.NewSetValueNull[types.String](t.Context()),
-		AttrSetIncludeNull:          customtypes.NewSetValueNull[types.String](t.Context()),
-		AttrMap:                     customtypes.NewMapValueNull[types.String](t.Context()),
-		AttrMapIncludeNull:          customtypes.NewMapValueNull[types.String](t.Context()),
-		AttrNestedObject:            customtypes.NewObjectValueNull[modelEmptyTest](t.Context()),
-		AttrNestedList:              customtypes.NewNestedListValueNull[modelEmptyTest](t.Context()),
-		AttrNestedListIncludeNull:   customtypes.NewNestedListValueNull[modelEmptyTest](t.Context()),
-		AttrNestedSet:               customtypes.NewNestedSetValueNull[modelEmptyTest](t.Context()),
-		AttrNestedSetIncludeNull:    customtypes.NewNestedSetValueNull[modelEmptyTest](t.Context()),
-		AttrNestedMap:               customtypes.NewNestedMapValueNull[modelEmptyTest](t.Context()),
-		AttrNestedMapIncludeNull:    customtypes.NewNestedMapValueNull[modelEmptyTest](t.Context()),
-		AttrNestedObjectIncludeNull: customtypes.NewObjectValueNull[modelEmptyTest](t.Context()),
-		AttrString:                  types.StringNull(),
-		AttrBool:                    types.BoolNull(),
-		AttrInt:                     types.Int64Null(),
-		AttrStringIncludeNull:       types.StringNull(),
-		AttrIntIncludeNull:          types.Int64Null(),
-		AttrBoolIncludeNull:         types.BoolNull(),
+		AttrList:                  customtypes.NewListValueNull[types.String](t.Context()),
+		AttrListSendNull:          customtypes.NewListValueNull[types.String](t.Context()),
+		AttrListSendEmpty:         customtypes.NewListValueNull[types.String](t.Context()),
+		AttrSet:                   customtypes.NewSetValueNull[types.String](t.Context()),
+		AttrSetSendNull:           customtypes.NewSetValueNull[types.String](t.Context()),
+		AttrSetSendEmpty:          customtypes.NewSetValueNull[types.String](t.Context()),
+		AttrMap:                   customtypes.NewMapValueNull[types.String](t.Context()),
+		AttrMapSendNull:           customtypes.NewMapValueNull[types.String](t.Context()),
+		AttrMapSendEmpty:          customtypes.NewMapValueNull[types.String](t.Context()),
+		AttrNestedObject:          customtypes.NewObjectValueNull[modelEmptyTest](t.Context()),
+		AttrNestedList:            customtypes.NewNestedListValueNull[modelEmptyTest](t.Context()),
+		AttrNestedListSendNull:    customtypes.NewNestedListValueNull[modelEmptyTest](t.Context()),
+		AttrNestedListSendEmpty:   customtypes.NewNestedListValueNull[modelEmptyTest](t.Context()),
+		AttrNestedSet:             customtypes.NewNestedSetValueNull[modelEmptyTest](t.Context()),
+		AttrNestedSetSendNull:     customtypes.NewNestedSetValueNull[modelEmptyTest](t.Context()),
+		AttrNestedSetSendEmpty:    customtypes.NewNestedSetValueNull[modelEmptyTest](t.Context()),
+		AttrNestedMap:             customtypes.NewNestedMapValueNull[modelEmptyTest](t.Context()),
+		AttrNestedMapSendNull:     customtypes.NewNestedMapValueNull[modelEmptyTest](t.Context()),
+		AttrNestedMapSendEmpty:    customtypes.NewNestedMapValueNull[modelEmptyTest](t.Context()),
+		AttrNestedObjectSendNull:  customtypes.NewObjectValueNull[modelEmptyTest](t.Context()),
+		AttrNestedObjectSendEmpty: customtypes.NewObjectValueNull[modelEmptyTest](t.Context()),
+		AttrString:                types.StringNull(),
+		AttrBool:                  types.BoolNull(),
+		AttrInt:                   types.Int64Null(),
+		AttrStringSendNull:        types.StringNull(),
+		AttrStringSendEmpty:       types.StringNull(),
+		AttrIntSendNull:           types.Int64Null(),
+		AttrIntSendEmpty:          types.Int64Null(),
+		AttrBoolSendNull:          types.BoolNull(),
+		AttrBoolSendEmpty:         types.BoolNull(),
 	}
-	// null list, set and map elements are sent with empty values in update.
-	// fields with includenullonupdate tag are included even when null during updates.
+	// Default behavior: null values are not included in the update payload.
+	// Fields with sendnullasnullonupdate tag are included as null during updates.
+	// Fields with sendnullasemptyonupdate tag send empty values ([] for list/set, {} for map) during updates.
 	const expectedJSON = `
 		{
-			"attrList": [],
-			"attrListIncludeNull": null,
-			"attrSet": [],
-			"attrSetIncludeNull": null,
-			"attrMap": {},
-			"attrMapIncludeNull": null,
-			"attrNestedMap": {},
-			"attrNestedMapIncludeNull": null,
-			"attrNestedList": [],
-			"attrNestedListIncludeNull": null,
-			"attrNestedSet": [],
-			"attrNestedSetIncludeNull": null,
-			"attrNestedObjectIncludeNull": null,
-			"attrStringIncludeNull": null,
-			"attrIntIncludeNull": null,
-			"attrBoolIncludeNull": null
+			"attrListSendNull": null,
+			"attrListSendEmpty": [],
+			"attrSetSendNull": null,
+			"attrSetSendEmpty": [],
+			"attrMapSendNull": null,
+			"attrMapSendEmpty": {},
+			"attrNestedMapSendNull": null,
+			"attrNestedMapSendEmpty": {},
+			"attrNestedListSendNull": null,
+			"attrNestedListSendEmpty": [],
+			"attrNestedSetSendNull": null,
+			"attrNestedSetSendEmpty": [],
+			"attrNestedObjectSendNull": null,
+			"attrStringSendNull": null,
+			"attrIntSendNull": null,
+			"attrBoolSendNull": null
 		}
 	`
 	raw, err := autogen.Marshal(&model, true)
 	require.NoError(t, err)
 	assert.JSONEq(t, expectedJSON, string(raw))
 
-	// Test that includenullonupdate fields are NOT included when isUpdate is false
+	// Test that sendnullasnullonupdate and sendnullasemptyonupdate fields are NOT included when isUpdate is false
 	rawCreate, errCreate := autogen.Marshal(&model, false)
 	require.NoError(t, errCreate)
 	const expectedJSONCreate = `
@@ -271,7 +292,7 @@ func TestMarshalCustomTypeObject(t *testing.T) {
 		AttrPrimitiveOmit    types.String                            `tfsdk:"attr_primitive_omit" autogen:"omitjson"`
 		AttrObjectOmit       customtypes.ObjectValue[modelEmptyTest] `tfsdk:"attr_object_omit" autogen:"omitjson"`
 		AttrObjectOmitUpdate customtypes.ObjectValue[modelEmptyTest] `tfsdk:"attr_object_omit_update" autogen:"omitjsonupdate"`
-		AttrNull             customtypes.ObjectValue[modelEmptyTest] `tfsdk:"attr_null" autogen:"includenullonupdate"`
+		AttrNull             customtypes.ObjectValue[modelEmptyTest] `tfsdk:"attr_null" autogen:"sendnullasnullonupdate"`
 		AttrInt              types.Int64                             `tfsdk:"attr_int"`
 		AttrMANYUpper        types.Int64                             `tfsdk:"attr_many_upper"`
 	}
@@ -445,7 +466,6 @@ func TestMarshalCustomTypeNestedList(t *testing.T) {
 					}
 				}
 			],
-			"attrNestedListNull": [],
 			"attrNestedListEmpty": []
 		}
 	`
@@ -545,7 +565,6 @@ func TestMarshalCustomTypeNestedSet(t *testing.T) {
 					}
 				}
 			],
-			"attrNestedSetNull": [],
 			"attrNestedSetEmpty": []
 		}
 	`
@@ -645,7 +664,6 @@ func TestMarshalCustomTypeNestedMap(t *testing.T) {
 					}
 				}
 			},
-			"attrNestedMapNull": {},
 			"attrNestedMapEmpty": {}
 		}
 	`
@@ -694,8 +712,7 @@ func TestMarshalListAsMap(t *testing.T) {
 					"value": "val2"
 				}
 			],
-			"attrListAsMapEmpty": [],
-			"attrListAsMapNull": []
+			"attrListAsMapEmpty": []
 		}
 	`
 	rawCreate, err := autogen.Marshal(&model, false)

--- a/internal/common/autogen/property_tags.go
+++ b/internal/common/autogen/property_tags.go
@@ -7,35 +7,38 @@ import (
 )
 
 const (
-	tagKey                    = "autogen"
-	tagSensitive              = "sensitive"
-	tagValOmitJSON            = "omitjson"
-	tagValOmitJSONUpdate      = "omitjsonupdate"
-	tagValIncludeNullOnUpdate = "includenullonupdate"
-	tagValListAsMap           = "listasmap"
-	tagValSkipStateListMerge  = "skipstatelistmerge"
-	tagAPIName                = "apiname" // e.g., apiname:"groupId" means JSON field is "groupId", used if the API name is different from the uncapitalized model name
+	tagKey                        = "autogen"
+	tagSensitive                  = "sensitive"
+	tagValOmitJSON                = "omitjson"
+	tagValOmitJSONUpdate          = "omitjsonupdate"
+	tagValSendNullAsNullOnUpdate  = "sendnullasnullonupdate"
+	tagValSendNullAsEmptyOnUpdate = "sendnullasemptyonupdate"
+	tagValListAsMap               = "listasmap"
+	tagValSkipStateListMerge      = "skipstatelistmerge"
+	tagAPIName                    = "apiname" // e.g., apiname:"groupId" means JSON field is "groupId", used if the API name is different from the uncapitalized model name
 )
 
 type PropertyTags struct {
-	APIName             *string
-	Sensitive           bool
-	OmitJSON            bool
-	OmitJSONUpdate      bool
-	IncludeNullOnUpdate bool
-	ListAsMap           bool
-	SkipStateListMerge  bool
+	APIName                 *string
+	Sensitive               bool
+	OmitJSON                bool
+	OmitJSONUpdate          bool
+	SendNullAsNullOnUpdate  bool
+	SendNullAsEmptyOnUpdate bool
+	ListAsMap               bool
+	SkipStateListMerge      bool
 }
 
 func GetPropertyTags(field *reflect.StructField) PropertyTags {
 	tags := strings.Split(field.Tag.Get(tagKey), ",")
 	result := PropertyTags{
-		Sensitive:           slices.Contains(tags, tagSensitive),
-		OmitJSON:            slices.Contains(tags, tagValOmitJSON),
-		OmitJSONUpdate:      slices.Contains(tags, tagValOmitJSONUpdate),
-		IncludeNullOnUpdate: slices.Contains(tags, tagValIncludeNullOnUpdate),
-		ListAsMap:           slices.Contains(tags, tagValListAsMap),
-		SkipStateListMerge:  slices.Contains(tags, tagValSkipStateListMerge),
+		Sensitive:               slices.Contains(tags, tagSensitive),
+		OmitJSON:                slices.Contains(tags, tagValOmitJSON),
+		OmitJSONUpdate:          slices.Contains(tags, tagValOmitJSONUpdate),
+		SendNullAsNullOnUpdate:  slices.Contains(tags, tagValSendNullAsNullOnUpdate),
+		SendNullAsEmptyOnUpdate: slices.Contains(tags, tagValSendNullAsEmptyOnUpdate),
+		ListAsMap:               slices.Contains(tags, tagValListAsMap),
+		SkipStateListMerge:      slices.Contains(tags, tagValSkipStateListMerge),
 	}
 	if apiName := field.Tag.Get(tagAPIName); apiName != "" {
 		result.APIName = &apiName

--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -631,8 +631,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 
 type TFModel struct {
 	ReplicationSpecs                              customtypes.NestedListValue[TFReplicationSpecsModel]       `tfsdk:"replication_specs"`
-	Labels                                        customtypes.MapValue[types.String]                         `tfsdk:"labels" autogen:"listasmap"`
-	Tags                                          customtypes.MapValue[types.String]                         `tfsdk:"tags" autogen:"listasmap"`
+	Labels                                        customtypes.MapValue[types.String]                         `tfsdk:"labels" autogen:"listasmap,sendnullasemptyonupdate"`
+	Tags                                          customtypes.MapValue[types.String]                         `tfsdk:"tags" autogen:"listasmap,sendnullasemptyonupdate"`
 	MongoDBEmployeeAccessGrant                    customtypes.ObjectValue[TFMongoDBEmployeeAccessGrantModel] `tfsdk:"mongo_db_employee_access_grant"`
 	MongoDBVersion                                types.String                                               `tfsdk:"mongo_db_version" autogen:"omitjson"`
 	ConfigServerManagementMode                    types.String                                               `tfsdk:"config_server_management_mode"`

--- a/internal/serviceapi/clusteroldapi/resource_schema.go
+++ b/internal/serviceapi/clusteroldapi/resource_schema.go
@@ -530,8 +530,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 type TFModel struct {
 	DiskSizeGB                                types.Float64                                              `tfsdk:"disk_size_gb"`
 	ReplicationSpecs                          customtypes.NestedListValue[TFReplicationSpecsModel]       `tfsdk:"replication_specs"`
-	Tags                                      customtypes.MapValue[types.String]                         `tfsdk:"tags" autogen:"listasmap"`
-	Labels                                    customtypes.MapValue[types.String]                         `tfsdk:"labels" autogen:"listasmap"`
+	Tags                                      customtypes.MapValue[types.String]                         `tfsdk:"tags" autogen:"listasmap,sendnullasemptyonupdate"`
+	Labels                                    customtypes.MapValue[types.String]                         `tfsdk:"labels" autogen:"listasmap,sendnullasemptyonupdate"`
 	Id                                        types.String                                               `tfsdk:"id" autogen:"omitjson"`
 	MongoDBMajorVersion                       types.String                                               `tfsdk:"mongo_db_major_version"`
 	ConfigServerType                          types.String                                               `tfsdk:"config_server_type" autogen:"omitjson"`

--- a/internal/serviceapi/databaseuserapi/resource_schema.go
+++ b/internal/serviceapi/databaseuserapi/resource_schema.go
@@ -111,9 +111,9 @@ type TFModel struct {
 	AwsIAMType      types.String                               `tfsdk:"aws_iam_type"`
 	DatabaseName    types.String                               `tfsdk:"database_name"`
 	DeleteAfterDate types.String                               `tfsdk:"delete_after_date"`
-	Description     types.String                               `tfsdk:"description" autogen:"includenullonupdate"`
+	Description     types.String                               `tfsdk:"description" autogen:"sendnullasnullonupdate"`
 	GroupId         types.String                               `tfsdk:"group_id"`
-	Labels          customtypes.MapValue[types.String]         `tfsdk:"labels" autogen:"listasmap"`
+	Labels          customtypes.MapValue[types.String]         `tfsdk:"labels" autogen:"listasmap,sendnullasemptyonupdate"`
 	LdapAuthType    types.String                               `tfsdk:"ldap_auth_type"`
 	OidcAuthType    types.String                               `tfsdk:"oidc_auth_type"`
 	Password        types.String                               `tfsdk:"password" autogen:"sensitive"`

--- a/internal/serviceapi/projectapi/resource_schema.go
+++ b/internal/serviceapi/projectapi/resource_schema.go
@@ -57,7 +57,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	Tags                      customtypes.MapValue[types.String] `tfsdk:"tags" autogen:"listasmap"`
+	Tags                      customtypes.MapValue[types.String] `tfsdk:"tags" autogen:"listasmap,sendnullasemptyonupdate"`
 	Created                   types.String                       `tfsdk:"created" autogen:"omitjson"`
 	Id                        types.String                       `tfsdk:"id" autogen:"omitjson"`
 	Name                      types.String                       `tfsdk:"name"`

--- a/internal/serviceapi/searchindexapi/resource_schema.go
+++ b/internal/serviceapi/searchindexapi/resource_schema.go
@@ -518,7 +518,7 @@ type TFDefinitionModel struct {
 	Analyzers      customtypes.NestedListValue[TFDefinitionAnalyzersModel] `tfsdk:"analyzers"`
 	Fields         customtypes.ListValue[jsontypes.Normalized]             `tfsdk:"fields"`
 	Synonyms       customtypes.NestedListValue[TFDefinitionSynonymsModel]  `tfsdk:"synonyms"`
-	TypeSets       customtypes.NestedListValue[TFDefinitionTypeSetsModel]  `tfsdk:"type_sets" autogen:"includenullonupdate"`
+	TypeSets       customtypes.NestedListValue[TFDefinitionTypeSetsModel]  `tfsdk:"type_sets" autogen:"sendnullasnullonupdate"`
 	Analyzer       types.String                                            `tfsdk:"analyzer"`
 	Mappings       customtypes.ObjectValue[TFDefinitionMappingsModel]      `tfsdk:"mappings"`
 	SearchAnalyzer types.String                                            `tfsdk:"search_analyzer"`

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -336,6 +336,26 @@ func TestConvertToProviderSpec_nested(t *testing.T) {
 							PresentInAnyResponse:     true,
 						},
 						{
+							TFSchemaName:             "attr_send_empty_in_updates",
+							TFModelName:              "AttrSendEmptyInUpdates",
+							APIName:                  "attrSendEmptyInUpdates",
+							ComputedOptionalRequired: codespec.Optional,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr("Send empty in updates"),
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+						{
+							TFSchemaName:             "attr_send_null_in_updates",
+							TFModelName:              "AttrSendNullInUpdates",
+							APIName:                  "attrSendNullInUpdates",
+							ComputedOptionalRequired: codespec.Optional,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr("Send null in updates"),
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+						{
 							TFSchemaName:             "cluster_name",
 							TFModelName:              "ClusterName",
 							APIName:                  "clusterName",
@@ -627,13 +647,23 @@ func TestConvertToProviderSpec_nested_schemaOverrides(t *testing.T) {
 					Description: conversion.StringPtr(testResourceDesc),
 					Attributes: codespec.Attributes{
 						{
-							TFSchemaName:             "attr_always_in_updates",
-							TFModelName:              "AttrAlwaysInUpdates",
-							APIName:                  "attrAlwaysInUpdates",
+							TFSchemaName:             "attr_send_empty_in_updates",
+							TFModelName:              "AttrSendEmptyInUpdates",
+							APIName:                  "attrSendEmptyInUpdates",
 							ComputedOptionalRequired: codespec.Optional,
 							String:                   &codespec.StringAttribute{},
-							Description:              conversion.StringPtr("Always in updates"),
-							ReqBodyUsage:             codespec.IncludeNullOnUpdate,
+							Description:              conversion.StringPtr("Send empty in updates"),
+							ReqBodyUsage:             codespec.SendNullAsEmptyOnUpdate,
+							PresentInAnyResponse:     true,
+						},
+						{
+							TFSchemaName:             "attr_send_null_in_updates",
+							TFModelName:              "AttrSendNullInUpdates",
+							APIName:                  "attrSendNullInUpdates",
+							ComputedOptionalRequired: codespec.Optional,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr("Send null in updates"),
+							ReqBodyUsage:             codespec.SendNullAsNullOnUpdate,
 							PresentInAnyResponse:     true,
 						},
 						{
@@ -2089,5 +2119,6 @@ func TestConvertToProviderSpec_withTagsAndLabelsAsMapType(t *testing.T) {
 		assert.Nil(t, attr.ListNested, "Attribute %s should be a map type", attr.TFSchemaName)
 		assert.True(t, attr.ListTypeAsMap, "Attribute %s should have correct flag", attr.TFSchemaName)
 		assert.Contains(t, []string{"labels", "tags"}, attr.TFSchemaName, "Resource attribute should be either 'labels' or 'tags'")
+		assert.Equal(t, codespec.SendNullAsEmptyOnUpdate, attr.ReqBodyUsage, "Attribute %s should have correct ReqBodyUsage", attr.TFSchemaName)
 	}
 }

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -242,8 +242,10 @@ func commonRSAndDSOverridesTransformation(attr *Attribute, paths *attrPaths, sch
 	if override.Sensitive != nil {
 		attr.Sensitive = *override.Sensitive
 	}
-	if override.IncludeNullOnUpdate != nil && *override.IncludeNullOnUpdate {
-		attr.ReqBodyUsage = IncludeNullOnUpdate
+	if override.RequestBodyUsage != nil {
+		if err := applyReqBodyUsageOverride(*override.RequestBodyUsage, attr); err != nil {
+			return err
+		}
 	}
 	if override.Type != nil {
 		if err := applyTypeOverride(&override, attr); err != nil {
@@ -333,6 +335,18 @@ func getComputabilityFromConfig(computability config.Computability) ComputedOpti
 		return Optional
 	}
 	return Required
+}
+
+func applyReqBodyUsageOverride(reqBodyUsage config.ReqBodyUsage, attr *Attribute) error {
+	switch reqBodyUsage {
+	case config.SendNullAsNullOnUpdate:
+		attr.ReqBodyUsage = SendNullAsNullOnUpdate
+		return nil
+	case config.SendNullAsEmptyOnUpdate:
+		attr.ReqBodyUsage = SendNullAsEmptyOnUpdate
+		return nil
+	}
+	return fmt.Errorf("unsupported request body usage defined in configuration: %s for attribute %s", reqBodyUsage, attr.TFSchemaName)
 }
 
 // ApplyTimeoutTransformation adds a timeout attribute to the resource schema if any operation has wait blocks.
@@ -430,5 +444,7 @@ func tagsAndLabelsAsMapTypeTransformation(attr *Attribute, _ *attrPaths, _ confi
 		ElementType: String,
 	}
 	attr.ListTypeAsMap = true
+	// Send an empty map on updates if the tags/labels attribute is null
+	attr.ReqBodyUsage = SendNullAsEmptyOnUpdate
 	return nil
 }

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -144,10 +144,11 @@ const (
 type AttributeReqBodyUsage string
 
 const (
-	AllRequestBodies    AttributeReqBodyUsage = "all_request_bodies" // by default attribute is sent in request bodies
-	OmitInUpdateBody    AttributeReqBodyUsage = "omit_in_update_body"
-	IncludeNullOnUpdate AttributeReqBodyUsage = "include_null_on_update" // attributes that always must be sent in update request body even if null
-	OmitAlways          AttributeReqBodyUsage = "omit_always"            // this covers computed-only attributes and attributes which are only used for path/query params
+	AllRequestBodies        AttributeReqBodyUsage = "all_request_bodies" // by default attribute is sent in request bodies
+	OmitInUpdateBody        AttributeReqBodyUsage = "omit_in_update_body"
+	SendNullAsNullOnUpdate  AttributeReqBodyUsage = "send_null_as_null_on_update"  // attributes with null value are sent as null in update request body
+	SendNullAsEmptyOnUpdate AttributeReqBodyUsage = "send_null_as_empty_on_update" // attributes with null value are sent as empty in update request body (collections only)
+	OmitAlways              AttributeReqBodyUsage = "omit_always"                  // this covers computed-only attributes and attributes which are only used for path/query params
 )
 
 type BoolAttribute struct {

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -1074,6 +1074,12 @@ components:
         attrAlwaysInUpdates:
           type: string
           description: Always in updates
+        attrSendNullInUpdates:
+          type: string
+          description: Send null in updates
+        attrSendEmptyInUpdates:
+          type: string
+          description: Send empty in updates
     SingleNestedAttrWithNestedMaps:
       type: object
       description: Test field description
@@ -1137,6 +1143,12 @@ components:
         attrAlwaysInUpdates:
           type: string
           description: Always in updates
+        attrSendNullInUpdates:
+          type: string
+          description: Send null in updates
+        attrSendEmptyInUpdates:
+          type: string
+          description: Send empty in updates
       required:
         - nestedListArrayAttr
     SimpleStringRefObject:

--- a/tools/codegen/codespec/testdata/config-nested-schema-overrides.yml
+++ b/tools/codegen/codespec/testdata/config-nested-schema-overrides.yml
@@ -30,6 +30,7 @@ resources:
           "set_primitive_string_attr",
           "single_nested_attr",
           "single_nested_attr_with_nested_maps",
+          "attr_always_in_updates",
         ]
 
       overrides:
@@ -42,5 +43,7 @@ resources:
             optional: true
             computed: true
           description: "Optional string that has config override to optional/computed"
-        attr_always_in_updates:
-          include_null_on_update: true
+        attr_send_null_in_updates:
+          request_body_usage: "send_null_as_null_on_update"
+        attr_send_empty_in_updates:
+          request_body_usage: "send_null_as_empty_on_update"

--- a/tools/codegen/codespec/testdata/config-path-based-alias.yml
+++ b/tools/codegen/codespec/testdata/config-path-based-alias.yml
@@ -31,6 +31,8 @@ resources:
           "outer_object",
           "optional_string_attr",
           "attr_always_in_updates",
+          "attr_send_null_in_updates",
+          "attr_send_empty_in_updates",
           "nested_list_array_attr.list_primitive_string_attr",
           "nested_list_array_attr.list_primitive_string_computed_attr",
           "nested_set_array_attr.list_primitive_string_attr",

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -472,7 +472,7 @@ resources:
         password:
           sensitive: true
         description:
-          include_null_on_update: true
+          request_body_usage: "send_null_as_null_on_update"
 
   # Singleton resource in project.
   # Create uses PATCH.
@@ -672,7 +672,7 @@ resources:
         indexId: indexID # path param name does not match the API response property
       overrides:
         definition.type_sets:
-          include_null_on_update: true # on update if an empty array is sent the index definition is rejected with error Invalid definition: "typeSets" cannot be empty.
+          request_body_usage: "send_null_as_null_on_update" # on update if an empty array is sent the index definition is rejected with error Invalid definition: "typeSets" cannot be empty.
 
   # Update doesn't work because API defines incorrectly region and cloud_provider at root level in PATCH instead of inside data_process_region as in the other endpoints.
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.

--- a/tools/codegen/config/config_model.go
+++ b/tools/codegen/config/config_model.go
@@ -52,15 +52,15 @@ type SchemaOptions struct {
 }
 
 type Override struct {
-	Computability       *Computability `yaml:"computability,omitempty"`
-	Sensitive           *bool          `yaml:"sensitive"`
-	IncludeNullOnUpdate *bool          `yaml:"include_null_on_update"`
-	SkipStateListMerge  *bool          `yaml:"skip_state_list_merge"`
-	ImmutableComputed   *bool          `yaml:"immutable_computed"` // Currently supported for string attributes, support for additional types can be added as needed.
-	Type                *Type          `yaml:"type"`
-	Description         string         `yaml:"description"`
-	PlanModifiers       []PlanModifier `yaml:"plan_modifiers"`
-	Validators          []Validator    `yaml:"validators"`
+	Computability      *Computability `yaml:"computability,omitempty"`
+	Sensitive          *bool          `yaml:"sensitive"`
+	RequestBodyUsage   *ReqBodyUsage  `yaml:"request_body_usage,omitempty"`
+	SkipStateListMerge *bool          `yaml:"skip_state_list_merge"`
+	ImmutableComputed  *bool          `yaml:"immutable_computed"` // Currently supported for string attributes, support for additional types can be added as needed.
+	Type               *Type          `yaml:"type"`
+	Description        string         `yaml:"description"`
+	PlanModifiers      []PlanModifier `yaml:"plan_modifiers"`
+	Validators         []Validator    `yaml:"validators"`
 }
 
 type PlanModifier struct {
@@ -78,6 +78,13 @@ type Computability struct {
 	Computed bool `yaml:"computed"`
 	Required bool `yaml:"required"`
 }
+
+type ReqBodyUsage string
+
+const (
+	SendNullAsNullOnUpdate  ReqBodyUsage = "send_null_as_null_on_update"  // attributes with null value are sent as null in update request body
+	SendNullAsEmptyOnUpdate ReqBodyUsage = "send_null_as_empty_on_update" // attributes with null value are sent as empty in update request body (collections only)
+)
 
 type Type string
 

--- a/tools/codegen/gofilegen/schema/typed_model.go
+++ b/tools/codegen/gofilegen/schema/typed_model.go
@@ -112,8 +112,10 @@ func typedModelProperty(attr *codespec.Attribute, isDataSource bool, dsPrefix st
 		autogenTags = append(autogenTags, "omitjson")
 	case codespec.OmitInUpdateBody:
 		autogenTags = append(autogenTags, "omitjsonupdate")
-	case codespec.IncludeNullOnUpdate:
-		autogenTags = append(autogenTags, "includenullonupdate")
+	case codespec.SendNullAsNullOnUpdate:
+		autogenTags = append(autogenTags, "sendnullasnullonupdate")
+	case codespec.SendNullAsEmptyOnUpdate:
+		autogenTags = append(autogenTags, "sendnullasemptyonupdate")
 	}
 
 	if len(autogenTags) > 0 {

--- a/tools/codegen/models/cluster_api.yaml
+++ b/tools/codegen/models/cluster_api.yaml
@@ -510,7 +510,7 @@ schema:
           tf_schema_name: labels
           tf_model_name: Labels
           api_name: labels
-          req_body_usage: all_request_bodies
+          req_body_usage: send_null_as_empty_on_update
           sensitive: false
           create_only: false
           present_in_any_response: true
@@ -1551,7 +1551,7 @@ schema:
           tf_schema_name: tags
           tf_model_name: Tags
           api_name: tags
-          req_body_usage: all_request_bodies
+          req_body_usage: send_null_as_empty_on_update
           sensitive: false
           create_only: false
           present_in_any_response: true

--- a/tools/codegen/models/cluster_old_api.yaml
+++ b/tools/codegen/models/cluster_old_api.yaml
@@ -511,7 +511,7 @@ schema:
           tf_schema_name: labels
           tf_model_name: Labels
           api_name: labels
-          req_body_usage: all_request_bodies
+          req_body_usage: send_null_as_empty_on_update
           sensitive: false
           create_only: false
           present_in_any_response: true
@@ -1262,7 +1262,7 @@ schema:
           tf_schema_name: tags
           tf_model_name: Tags
           api_name: tags
-          req_body_usage: all_request_bodies
+          req_body_usage: send_null_as_empty_on_update
           sensitive: false
           create_only: false
           present_in_any_response: true

--- a/tools/codegen/models/database_user_api.yaml
+++ b/tools/codegen/models/database_user_api.yaml
@@ -42,7 +42,7 @@ schema:
           tf_schema_name: description
           tf_model_name: Description
           api_name: description
-          req_body_usage: include_null_on_update
+          req_body_usage: send_null_as_null_on_update
           sensitive: false
           create_only: false
           present_in_any_response: true
@@ -72,7 +72,7 @@ schema:
           tf_schema_name: labels
           tf_model_name: Labels
           api_name: labels
-          req_body_usage: all_request_bodies
+          req_body_usage: send_null_as_empty_on_update
           sensitive: false
           create_only: false
           present_in_any_response: true

--- a/tools/codegen/models/project_api.yaml
+++ b/tools/codegen/models/project_api.yaml
@@ -88,7 +88,7 @@ schema:
           tf_schema_name: tags
           tf_model_name: Tags
           api_name: tags
-          req_body_usage: all_request_bodies
+          req_body_usage: send_null_as_empty_on_update
           sensitive: false
           create_only: false
           present_in_any_response: true

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -373,7 +373,7 @@ schema:
                       tf_schema_name: type_sets
                       tf_model_name: TypeSets
                       api_name: typeSets
-                      req_body_usage: include_null_on_update
+                      req_body_usage: send_null_as_null_on_update
                       sensitive: false
                       create_only: false
                       present_in_any_response: false


### PR DESCRIPTION
## Description

Improve autogen handling of null collections during marshaling. 
- The previous default behavior of sending null collections as empty collections causes issues on APIs that validate type-specific fields to be the only ones present in request bodies.

Changed the default collection marshaling behavior on updates to be the same as other attributes (not sent if unknown/null).
- Added a new tag `sendnullasemptyonupdate` for marshaling to send empty collections when the attribute value is null. This was the previous default behavior, now opt-in.
- Renamed existing tag `includenullonupdate` to `sendnullasnullonupdate` for consistency. Behavior stays the same.

Config overrides now accept request body usage tags instead of a boolean flag, e.g.:
```yml
overrides:
  attribute_name:
    #include_null_on_update: true # before
    request_body_usage: "send_null_as_null_on_update" # after
```

Link to any related issue(s): CLOUDP-380279

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
