### PR TITLE
chore: Handle Service Account credentials incorrectly used in PAK arguments

### DIFF
--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -96,7 +96,7 @@ func (c *Credentials) Errors() string {
 			return "Service Account will be used but Client Secret is required"
 		}
 	case Digest:
-		if strings.HasPrefix(c.PublicKey, serviceAccountPrefix) || strings.HasPrefix(c.PrivateKey, serviceAccountPrefix) {
+		if strings.HasPrefix(c.PublicKey, serviceAccountPrefix) {
 			return "Service Account credentials (starting with 'mdb_sa') were provided in public_key/private_key which are meant for Programmatic Access Keys. " +
 				"Please use client_id and client_secret arguments for Service Account authentication"
 		}

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 )
@@ -83,6 +84,8 @@ func (c *Credentials) Warnings() string {
 	return ""
 }
 
+const serviceAccountPrefix = "mdb_sa"
+
 func (c *Credentials) Errors() string {
 	switch c.AuthMethod() {
 	case ServiceAccount:
@@ -93,6 +96,10 @@ func (c *Credentials) Errors() string {
 			return "Service Account will be used but Client Secret is required"
 		}
 	case Digest:
+		if strings.HasPrefix(c.PublicKey, serviceAccountPrefix) || strings.HasPrefix(c.PrivateKey, serviceAccountPrefix) {
+			return "Service Account credentials (starting with 'mdb_sa') were provided in public_key/private_key which are meant for Programmatic Access Keys. " +
+				"Please use client_id and client_secret arguments for Service Account authentication"
+		}
 		if c.PublicKey == "" {
 			return "API Key will be used but Public Key is required"
 		}

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -386,23 +386,15 @@ func TestCredentials_Errors(t *testing.T) {
 			},
 			want: "",
 		},
-		"SA credentials in public_key and private_key": {
+		"SA client_id in public_key with private_key set": {
 			credentials: config.Credentials{
 				PublicKey:  "mdb_sa_id_12345",
-				PrivateKey: "mdb_sa_sk_12345",
+				PrivateKey: "some_secret_value",
 			},
 			want: "Service Account credentials (starting with 'mdb_sa') were provided in public_key/private_key which are meant for Programmatic Access Keys. " +
 				"Please use client_id and client_secret arguments for Service Account authentication",
 		},
-		"SA credentials in private_key only": {
-			credentials: config.Credentials{
-				PublicKey:  "public",
-				PrivateKey: "mdb_sa_sk_12345",
-			},
-			want: "Service Account credentials (starting with 'mdb_sa') were provided in public_key/private_key which are meant for Programmatic Access Keys. " +
-				"Please use client_id and client_secret arguments for Service Account authentication",
-		},
-		"SA credentials in public_key with no private_key": {
+		"SA client_id in public_key with missing private_key": {
 			credentials: config.Credentials{
 				PublicKey: "mdb_sa_id_12345",
 			},

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -386,6 +386,29 @@ func TestCredentials_Errors(t *testing.T) {
 			},
 			want: "",
 		},
+		"SA credentials in public_key and private_key": {
+			credentials: config.Credentials{
+				PublicKey:  "mdb_sa_id_12345",
+				PrivateKey: "mdb_sa_sk_12345",
+			},
+			want: "Service Account credentials (starting with 'mdb_sa') were provided in public_key/private_key which are meant for Programmatic Access Keys. " +
+				"Please use client_id and client_secret arguments for Service Account authentication",
+		},
+		"SA credentials in private_key only": {
+			credentials: config.Credentials{
+				PublicKey:  "public",
+				PrivateKey: "mdb_sa_sk_12345",
+			},
+			want: "Service Account credentials (starting with 'mdb_sa') were provided in public_key/private_key which are meant for Programmatic Access Keys. " +
+				"Please use client_id and client_secret arguments for Service Account authentication",
+		},
+		"SA credentials in public_key with no private_key": {
+			credentials: config.Credentials{
+				PublicKey: "mdb_sa_id_12345",
+			},
+			want: "Service Account credentials (starting with 'mdb_sa') were provided in public_key/private_key which are meant for Programmatic Access Keys. " +
+				"Please use client_id and client_secret arguments for Service Account authentication",
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
## Description

Adds early validation to detect when Service Account credentials (prefixed with mdb_sa) are mistakenly provided in `public_key` provider argument, which is meant for Programmatic Access Keys (PAK)
Returns a clear error at provider init guiding users to use client_id and client_secret instead, avoiding a cryptic auth denial error downstream

Link to any related issue(s): CLOUDP-377299

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
