### PR TITLE
chore: Fix checkDestroy in log_integration tests

### DIFF
--- a/internal/serviceapi/logintegration/resource_test.go
+++ b/internal/serviceapi/logintegration/resource_test.go
@@ -271,16 +271,15 @@ resource "aws_iam_role_policy" "s3_bucket_policy" {
 }
 
 func checkDestroy(state *terraform.State) error {
-	if projectDestroyedErr := acc.CheckDestroyProject(state); projectDestroyedErr != nil {
-		return projectDestroyedErr
-	}
-	for _, rs := range state.RootModule().Resources {
-		if rs.Type == "mongodbatlas_push_based_log_export_api" {
-			_, _, err := acc.ConnV2().PushBasedLogExportApi.GetGroupLogIntegration(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["id"]).Execute()
-			if err == nil {
-				return fmt.Errorf("push-based log export for project_id %s with id %s still exists", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["id"])
-			}
+	for name, rs := range state.RootModule().Resources {
+		if name != resourceName {
+			continue
 		}
+		_, _, err := acc.ConnV2().PushBasedLogExportApi.GetGroupLogIntegration(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["id"]).Execute()
+		if err == nil {
+			return fmt.Errorf("log integration for project_id %s with id %s still exists", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["id"])
+		}
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

checkDestroy was checking the wrong resource.

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
