### PR TITLE
doc: Updates maintentance_window docs to recommend use of auto_defer_once_enabled

### DIFF
--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -33,8 +33,24 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
     end_hour_of_day   = 17
     }
   }
-
 ```
+
+### Automatic Deferral
+
+Use `auto_defer_once_enabled` to enable automatic deferral.
+
+```terraform
+  resource "mongodbatlas_maintenance_window" "test" {
+    project_id  = "<your-project-id>"
+    day_of_week = 3
+    hour_of_day = 4
+    auto_defer_once_enabled = true
+  }
+```
+
+### One-Time Manual Deferral
+
+Use `defer` to defer the next scheduled maintenance event by one week. This only works when maintenance is already scheduled.
 
 ```terraform
   resource "mongodbatlas_maintenance_window" "test" {
@@ -51,9 +67,10 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 * `project_id` - The unique identifier of the project for the Maintenance Window.
 * `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - (Required) Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone.
-* `defer` - (Optional) Defer the next scheduled maintenance event for the given project by one week. Only works when maintenance is already scheduled.
-* `auto_defer` - (Optional) Boolean flag to toggle automatic deferral on/off. Each change flips the current state. Achieves the same outcome as `auto_defer_once_enabled` but through a toggle operation.
-* `auto_defer_once_enabled` - (Optional) When `true`, enables automatic deferral of all scheduled maintenance for the given project by one week. Achieves the same outcome as `auto_defer` but by directly setting the value to true or false. If `auto_defer` is modified triggering a toggle, it will impact the value of this attribute.
+* `defer` - (Optional) Defer the next scheduled maintenance event for the given project by 
+one week. Only works when maintenance is already scheduled.
+* `auto_defer_once_enabled` - (Optional) **Recommended** field to enable or disable automatic deferral of all scheduled maintenance for the given project by one week. Achieves the same outcome as `auto_defer`, but by directly setting the value to `true` or `false`, which is idempotent and keeps Terraform state aligned with Atlas. If `auto_defer` is used to toggle the underlying flag, it will also affect the value of this attribute.
+* `auto_defer` - (Optional) Boolean flag to **toggle** automatic deferral on/off. Each change flips the current state (ON → OFF or OFF → ON). Achieves the same outcome as `auto_defer_once_enabled` but through a toggle operation, which can make the current state opaque to Terraform and introduce state drift. **For most use cases, prefer `auto_defer_once_enabled` instead.** <!-- see CLOUDP-375465 for details -->
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).
 
 ### Protected Hours

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -37,7 +37,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 
 ### Automatic Deferral
 
-Use `auto_defer_once_enabled` to enable automatic deferral.
+Use `auto_defer_once_enabled` to enable or disable automatic deferral.
 
 ```terraform
   resource "mongodbatlas_maintenance_window" "test" {

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -54,8 +54,10 @@ Use `defer` to defer the next scheduled maintenance event by one week. This only
 
 ```terraform
   resource "mongodbatlas_maintenance_window" "test" {
-    project_id = "<your-project-id>"
-    defer      = true
+    project_id  = "<your-project-id>"
+    day_of_week = 3
+    hour_of_day = 4
+    defer       = true
   }
 ```
 

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -69,8 +69,7 @@ Use `defer` to defer the next scheduled maintenance event by one week. This only
 * `project_id` - The unique identifier of the project for the Maintenance Window.
 * `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - (Required) Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone.
-* `defer` - (Optional) Defer the next scheduled maintenance event for the given project by 
-one week. Only works when maintenance is already scheduled.
+* `defer` - (Optional) Defer the next scheduled maintenance event for the given project by one week. Only works when maintenance is already scheduled.
 * `auto_defer_once_enabled` - (Optional) **Recommended** field to enable or disable automatic deferral of all scheduled maintenance for the given project by one week. Achieves the same outcome as `auto_defer`, but by directly setting the value to `true` or `false`, which is idempotent and keeps Terraform state aligned with Atlas. If `auto_defer` is used to toggle the underlying flag, it will also affect the value of this attribute.
 * `auto_defer` - (Optional) Boolean flag to **toggle** automatic deferral on/off. Each change flips the current state (ON → OFF or OFF → ON). Achieves the same outcome as `auto_defer_once_enabled` but through a toggle operation, which can make the current state opaque to Terraform and introduce state drift. **For most use cases, prefer `auto_defer_once_enabled` instead.** <!-- see CLOUDP-375465 for details -->
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).


### PR DESCRIPTION
## Description

Clarifies the documentation to recommend  auto_defer_once_enabled field over auto_defer for enabling automatic maintenance window referral. 

Link to any related issue(s): [CLOUDP-375465](https://jira.mongodb.org/browse/CLOUDP-375465)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
