### PR TITLE
chore: Allow recent project deletion in cleanup

### DIFF
--- a/.github/workflows/cleanup-test-env.yml
+++ b/.github/workflows/cleanup-test-env.yml
@@ -3,6 +3,11 @@ name: 'Cleanup test env'
 # Cleans up our atlas cloud dev and qa organizations used for testing.
 on:
   workflow_dispatch: # workflow can be run manually
+    inputs:
+      skip-grace-period:
+        description: 'Skip the grace period for recent projects and delete all bot projects regardless of creation time.'
+        type: boolean
+        default: false
   workflow_call: # workflow runs from Test Suite
 
 jobs:  
@@ -20,6 +25,7 @@ jobs:
           MONGODB_ATLAS_ORG_ID: ${{ vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
           MONGODB_ATLAS_BASE_URL: ${{vars.MONGODB_ATLAS_BASE_URL}}
           MONGODB_ATLAS_CLEAN_RETRY_ATTEMPTS: "1" # Removing atlas clusters is slow, we don't want to block the TestSuite workflow, during next run we will retry again
+          MONGODB_ATLAS_CLEAN_SKIP_GRACE_PERIOD: ${{ github.event.inputs.skip-grace-period || 'false' }}
   cleanup-test-env-qa:
     runs-on: ubuntu-latest
     permissions: {}
@@ -34,3 +40,4 @@ jobs:
           MONGODB_ATLAS_ORG_ID: ${{ vars.MONGODB_ATLAS_ORG_ID_CLOUD_QA }}
           MONGODB_ATLAS_BASE_URL: ${{ vars.MONGODB_ATLAS_BASE_URL_QA }}
           MONGODB_ATLAS_CLEAN_RETRY_ATTEMPTS: "1" # Removing atlas clusters is slow, we don't want to block the TestSuite workflow, during next run we will retry again
+          MONGODB_ATLAS_CLEAN_SKIP_GRACE_PERIOD: ${{ github.event.inputs.skip-grace-period || 'false' }}

--- a/internal/service/clouduserprojectassignment/resource_migration_test.go
+++ b/internal/service/clouduserprojectassignment/resource_migration_test.go
@@ -26,7 +26,7 @@ func TestMigCloudUserProjectAssignmentRS_migrationJourney(t *testing.T) {
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		username    = acc.RandomEmail()
-		projectName = fmt.Sprintf("mig_user_project_%s", acc.RandomName())
+		projectName = acc.RandomProjectName()
 		roles       = []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_READ_ONLY"}
 	)
 

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -76,7 +76,11 @@ func TestCleanProjectAndClusters(t *testing.T) {
 	client := acc.ConnV2()
 	dryRun, _ := strconv.ParseBool(os.Getenv("DRY_RUN"))
 	onlyZeroClusters, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_ONLY_WHEN_NO_CLUSTERS"))
+	skipGracePeriod, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_SKIP_GRACE_PERIOD"))
 	skipProjectsAfter := time.Now().Add(-keepProjectsCreatedWithinHours * time.Hour)
+	if skipGracePeriod {
+		skipProjectsAfter = time.Now()
+	}
 	retryAttemptsStr := os.Getenv("MONGODB_ATLAS_CLEAN_RETRY_ATTEMPTS")
 	runRetries := retryAttempts
 	if retryAttemptsStr != "" {


### PR DESCRIPTION
## Description

Allow recent project deletion in cleanup using param `skip-grace-period`.

Also remove non-standard test projects starting with `mig_user_project_`.


Link to any related issue(s): CLOUDP-381099

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
