### PR TITLE
feat: Update log_integration with newly supported types

### DIFF
--- a/.changelog/4173.txt
+++ b/.changelog/4173.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_log_integration: Adds support for GCS, Azure, Datadog, Splunk and OTel integrations
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_log_integration: Adds support for GCS, Azure, Datadog, Splunk and OTel integrations
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_log_integrations: Adds support for GCS, Azure, Datadog, Splunk and OTel integrations
+```

--- a/docs/data-sources/log_integration.md
+++ b/docs/data-sources/log_integration.md
@@ -68,12 +68,30 @@ output "log_integrations_results" {
 
 ### Read-Only
 
-- `bucket_name` (String) Human-readable label that identifies the S3 bucket name for storing log files.
-- `iam_role_id` (String) Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.
+- `api_key` (String, Sensitive) API key for authentication.
+- `bucket_name` (String) Name of the bucket to store log files.
+- `hec_token` (String, Sensitive) HTTP Event Collector (HEC) token for authentication.
+- `hec_url` (String) HTTP Event Collector (HEC) endpoint URL.
+- `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
-- `log_types` (Set of String) Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.
-- `prefix_path` (String) S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.
-- `type` (String) Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.
+- `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+- `otel_endpoint` (String) OpenTelemetry collector endpoint URL.
+- `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
+- `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
+- `role_id` (String) Unique 24-character hexadecimal string that identifies the GCP service account role.
+- `service_principal_id` (String) Unique 24-character hexadecimal string that identifies the Service Principal.
+- `storage_account_name` (String) Storage account name where logs will be stored.
+- `storage_container_name` (String) Storage container name for log files.
+- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+
+<a id="nestedatt--otel_supplied_headers"></a>
+### Nested Schema for `otel_supplied_headers`
+
+Read-Only:
+
+- `name` (String) Header name.
+- `value` (String, Sensitive) Header value.
 
 For more information see: [MongoDB Atlas API - Log Integration](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/group/endpoint-push-based-log-export) Documentation.
 

--- a/docs/data-sources/log_integrations.md
+++ b/docs/data-sources/log_integrations.md
@@ -67,7 +67,7 @@ output "log_integrations_results" {
 
 ### Optional
 
-- `integration_type` (String) Optional filter by integration type (e.g., 'S3_LOG_EXPORT').
+- `integration_type` (String) Optional filter by integration type (e.g., `S3_LOG_EXPORT`).
 
 ### Read-Only
 
@@ -78,13 +78,31 @@ output "log_integrations_results" {
 
 Read-Only:
 
-- `bucket_name` (String) Human-readable label that identifies the S3 bucket name for storing log files.
-- `iam_role_id` (String) Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.
+- `api_key` (String, Sensitive) API key for authentication.
+- `bucket_name` (String) Name of the bucket to store log files.
+- `hec_token` (String, Sensitive) HTTP Event Collector (HEC) token for authentication.
+- `hec_url` (String) HTTP Event Collector (HEC) endpoint URL.
+- `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `integration_id` (String) Unique 24-character hexadecimal digit string that identifies the log integration configuration.
 - `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
-- `log_types` (Set of String) Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.
-- `prefix_path` (String) S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.
-- `type` (String) Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.
+- `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+- `otel_endpoint` (String) OpenTelemetry collector endpoint URL.
+- `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--results--otel_supplied_headers))
+- `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
+- `role_id` (String) Unique 24-character hexadecimal string that identifies the GCP service account role.
+- `service_principal_id` (String) Unique 24-character hexadecimal string that identifies the Service Principal.
+- `storage_account_name` (String) Storage account name where logs will be stored.
+- `storage_container_name` (String) Storage container name for log files.
+- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+
+<a id="nestedatt--results--otel_supplied_headers"></a>
+### Nested Schema for `results.otel_supplied_headers`
+
+Read-Only:
+
+- `name` (String) Header name.
+- `value` (String, Sensitive) Header value.
 
 For more information see: [MongoDB Atlas API - Log Integration](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/group/endpoint-push-based-log-export) Documentation.
 

--- a/docs/resources/log_integration.md
+++ b/docs/resources/log_integration.md
@@ -64,20 +64,38 @@ output "log_integrations_results" {
 
 ### Required
 
-- `bucket_name` (String) Human-readable label that identifies the S3 bucket name for storing log files.
-- `iam_role_id` (String) Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.
-- `log_types` (Set of String) Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.
-- `prefix_path` (String) S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.
+- `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project.
-- `type` (String) Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.
+- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
 
 ### Optional
 
+- `api_key` (String, Sensitive) API key for authentication.
+- `bucket_name` (String) Name of the bucket to store log files.
+- `hec_token` (String, Sensitive) HTTP Event Collector (HEC) token for authentication.
+- `hec_url` (String) HTTP Event Collector (HEC) endpoint URL.
+- `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+- `otel_endpoint` (String) OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.
+- `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
+- `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
+- `role_id` (String) Unique 24-character hexadecimal string that identifies the GCP service account role.
+- `service_principal_id` (String) Unique 24-character hexadecimal string that identifies the Service Principal.
+- `storage_account_name` (String) Storage account name where logs will be stored.
+- `storage_container_name` (String) Storage container name for log files.
 
 ### Read-Only
 
 - `integration_id` (String) Unique 24-character hexadecimal digit string that identifies the log integration configuration.
+
+<a id="nestedatt--otel_supplied_headers"></a>
+### Nested Schema for `otel_supplied_headers`
+
+Required:
+
+- `name` (String) Header name.
+- `value` (String, Sensitive) Header value.
 
 ## Import 
 Log integration resource can be imported using the project ID and log integration ID, separated by a slash, e.g.

--- a/internal/serviceapi/logintegration/data_source_schema.go
+++ b/internal/serviceapi/logintegration/data_source_schema.go
@@ -14,13 +14,27 @@ import (
 func DataSourceSchema(ctx context.Context) dsschema.Schema {
 	return dsschema.Schema{
 		Attributes: map[string]dsschema.Attribute{
+			"api_key": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "API key for authentication.",
+				Sensitive:           true,
+			},
 			"bucket_name": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Human-readable label that identifies the S3 bucket name for storing log files.",
+				MarkdownDescription: "Name of the bucket to store log files.",
+			},
+			"hec_token": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "HTTP Event Collector (HEC) token for authentication.",
+				Sensitive:           true,
+			},
+			"hec_url": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "HTTP Event Collector (HEC) endpoint URL.",
 			},
 			"iam_role_id": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.",
+				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.",
 			},
 			"integration_id": dsschema.StringAttribute{
 				Required:            true,
@@ -32,33 +46,90 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"log_types": dsschema.SetAttribute{
 				Computed:            true,
-				MarkdownDescription: "Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.",
+				MarkdownDescription: "Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.",
 				CustomType:          customtypes.NewSetType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
+			"otel_endpoint": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "OpenTelemetry collector endpoint URL.",
+			},
+			"otel_supplied_headers": dsschema.ListNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.",
+				Sensitive:           true,
+				CustomType:          customtypes.NewNestedListType[TFDSOtelSuppliedHeadersModel](ctx),
+				NestedObject: dsschema.NestedAttributeObject{
+					Attributes: map[string]dsschema.Attribute{
+						"name": dsschema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "Header name.",
+						},
+						"value": dsschema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "Header value.",
+							Sensitive:           true,
+						},
+					},
+				},
+			},
 			"prefix_path": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.",
+				MarkdownDescription: "Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.",
 			},
 			"project_id": dsschema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project.",
 			},
+			"region": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.",
+			},
+			"role_id": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the GCP service account role.",
+			},
+			"service_principal_id": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Service Principal.",
+			},
+			"storage_account_name": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Storage account name where logs will be stored.",
+			},
+			"storage_container_name": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Storage container name for log files.",
+			},
 			"type": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.",
+				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.",
 			},
 		},
 	}
 }
 
 type TFDSModel struct {
-	BucketName    types.String                       `tfsdk:"bucket_name" autogen:"omitjson"`
-	IamRoleId     types.String                       `tfsdk:"iam_role_id" autogen:"omitjson"`
-	IntegrationId types.String                       `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
-	KmsKey        types.String                       `tfsdk:"kms_key" autogen:"omitjson"`
-	LogTypes      customtypes.SetValue[types.String] `tfsdk:"log_types" autogen:"omitjson"`
-	PrefixPath    types.String                       `tfsdk:"prefix_path" autogen:"omitjson"`
-	ProjectId     types.String                       `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
-	Type          types.String                       `tfsdk:"type" autogen:"omitjson"`
+	ApiKey               types.String                                              `tfsdk:"api_key" autogen:"sensitive,omitjson"`
+	BucketName           types.String                                              `tfsdk:"bucket_name" autogen:"omitjson"`
+	HecToken             types.String                                              `tfsdk:"hec_token" autogen:"sensitive,omitjson"`
+	HecUrl               types.String                                              `tfsdk:"hec_url" autogen:"omitjson"`
+	IamRoleId            types.String                                              `tfsdk:"iam_role_id" autogen:"omitjson"`
+	IntegrationId        types.String                                              `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
+	KmsKey               types.String                                              `tfsdk:"kms_key" autogen:"omitjson"`
+	LogTypes             customtypes.SetValue[types.String]                        `tfsdk:"log_types" autogen:"omitjson"`
+	OtelEndpoint         types.String                                              `tfsdk:"otel_endpoint" autogen:"omitjson"`
+	OtelSuppliedHeaders  customtypes.NestedListValue[TFDSOtelSuppliedHeadersModel] `tfsdk:"otel_supplied_headers" autogen:"sensitive,omitjson"`
+	PrefixPath           types.String                                              `tfsdk:"prefix_path" autogen:"omitjson"`
+	ProjectId            types.String                                              `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
+	Region               types.String                                              `tfsdk:"region" autogen:"omitjson"`
+	RoleId               types.String                                              `tfsdk:"role_id" autogen:"omitjson"`
+	ServicePrincipalId   types.String                                              `tfsdk:"service_principal_id" autogen:"omitjson"`
+	StorageAccountName   types.String                                              `tfsdk:"storage_account_name" autogen:"omitjson"`
+	StorageContainerName types.String                                              `tfsdk:"storage_container_name" autogen:"omitjson"`
+	Type                 types.String                                              `tfsdk:"type" autogen:"omitjson"`
+}
+type TFDSOtelSuppliedHeadersModel struct {
+	Name  types.String `tfsdk:"name" autogen:"omitjson"`
+	Value types.String `tfsdk:"value" autogen:"sensitive,omitjson"`
 }

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -1173,6 +1173,8 @@ resources:
             description: *project_id_description
           integration_id:
             immutable_computed: true
+          otel_supplied_headers:
+            sensitive: true
     datasources:
       read:
         path: /api/atlas/v2/groups/{groupId}/logIntegrations/{id}
@@ -1188,3 +1190,5 @@ resources:
         overrides:
           project_id:
             description: *project_id_description
+          otel_supplied_headers:
+            sensitive: true

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -1,9 +1,20 @@
 schema:
-    description: Creates a new log integration configuration identified by a unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role. This is currently in preview. Please contact your Customer Success Manager (CSM) for access.
+    description: Creates a new log integration configuration identified by a unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
     attributes:
         - string: {}
-          description: Human-readable label that identifies the S3 bucket name for storing log files.
-          computed_optional_required: required
+          description: API key for authentication.
+          computed_optional_required: optional
+          tf_schema_name: api_key
+          tf_model_name: ApiKey
+          api_name: apiKey
+          req_body_usage: all_request_bodies
+          sensitive: true
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Name of the bucket to store log files.
+          computed_optional_required: optional
           tf_schema_name: bucket_name
           tf_model_name: BucketName
           api_name: bucketName
@@ -24,8 +35,30 @@ schema:
           present_in_any_response: false
           request_only_required_on_create: false
         - string: {}
-          description: Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.
-          computed_optional_required: required
+          description: HTTP Event Collector (HEC) token for authentication.
+          computed_optional_required: optional
+          tf_schema_name: hec_token
+          tf_model_name: HecToken
+          api_name: hecToken
+          req_body_usage: all_request_bodies
+          sensitive: true
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: HTTP Event Collector (HEC) endpoint URL.
+          computed_optional_required: optional
+          tf_schema_name: hec_url
+          tf_model_name: HecUrl
+          api_name: hecUrl
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
+          computed_optional_required: optional
           tf_schema_name: iam_role_id
           tf_model_name: IamRoleId
           api_name: iamRoleId
@@ -59,7 +92,7 @@ schema:
           request_only_required_on_create: false
         - set:
             element_type: 4
-          description: 'Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.'
+          description: Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
           custom_type:
             package: customtypes
             model: customtypes.SetValue[types.String]
@@ -74,8 +107,59 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.
-          computed_optional_required: required
+          description: OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.
+          computed_optional_required: optional
+          tf_schema_name: otel_endpoint
+          tf_model_name: OtelEndpoint
+          api_name: otelEndpoint
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - list_nested:
+            nested_object:
+                attributes:
+                    - string: {}
+                      description: Header name.
+                      computed_optional_required: required
+                      tf_schema_name: name
+                      tf_model_name: Name
+                      api_name: name
+                      req_body_usage: all_request_bodies
+                      sensitive: false
+                      create_only: false
+                      present_in_any_response: true
+                      request_only_required_on_create: false
+                    - string: {}
+                      description: Header value.
+                      computed_optional_required: required
+                      tf_schema_name: value
+                      tf_model_name: Value
+                      api_name: value
+                      req_body_usage: all_request_bodies
+                      sensitive: true
+                      create_only: false
+                      present_in_any_response: true
+                      request_only_required_on_create: false
+          description: HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.
+          custom_type:
+            package: customtypes
+            name: OtelSuppliedHeaders
+            model: customtypes.NestedListValue[TFOtelSuppliedHeadersModel]
+            schema: customtypes.NewNestedListType[TFOtelSuppliedHeadersModel](ctx)
+          computed_optional_required: optional
+          tf_schema_name: otel_supplied_headers
+          tf_model_name: OtelSuppliedHeaders
+          api_name: otelSuppliedHeaders
+          req_body_usage: all_request_bodies
+          sensitive: true
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+          computed_optional_required: optional
           tf_schema_name: prefix_path
           tf_model_name: PrefixPath
           api_name: prefixPath
@@ -85,7 +169,62 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.
+          description: 'Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
+          computed_optional_required: optional
+          tf_schema_name: region
+          tf_model_name: Region
+          api_name: region
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Unique 24-character hexadecimal string that identifies the GCP service account role.
+          computed_optional_required: optional
+          tf_schema_name: role_id
+          tf_model_name: RoleId
+          api_name: roleId
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Unique 24-character hexadecimal string that identifies the Service Principal.
+          computed_optional_required: optional
+          tf_schema_name: service_principal_id
+          tf_model_name: ServicePrincipalId
+          api_name: servicePrincipalId
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Storage account name where logs will be stored.
+          computed_optional_required: optional
+          tf_schema_name: storage_account_name
+          tf_model_name: StorageAccountName
+          api_name: storageAccountName
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Storage container name for log files.
+          computed_optional_required: optional
+          tf_schema_name: storage_container_name
+          tf_model_name: StorageContainerName
+          api_name: storageContainerName
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
+        - string: {}
+          description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
           computed_optional_required: required
           tf_schema_name: type
           tf_model_name: Type
@@ -111,10 +250,21 @@ operations:
     version_header: application/vnd.atlas.2025-03-12+json
 data_sources:
     schema:
-        singular_ds_description: Returns the configuration for one log integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role. This is currently in preview. Please contact your Customer Success Manager (CSM) for access.
+        singular_ds_description: Returns the configuration for one log integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
         singular_ds_attributes:
             - string: {}
-              description: Human-readable label that identifies the S3 bucket name for storing log files.
+              description: API key for authentication.
+              computed_optional_required: computed
+              tf_schema_name: api_key
+              tf_model_name: ApiKey
+              api_name: apiKey
+              req_body_usage: omit_always
+              sensitive: true
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Name of the bucket to store log files.
               computed_optional_required: computed
               tf_schema_name: bucket_name
               tf_model_name: BucketName
@@ -125,7 +275,29 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.
+              description: HTTP Event Collector (HEC) token for authentication.
+              computed_optional_required: computed
+              tf_schema_name: hec_token
+              tf_model_name: HecToken
+              api_name: hecToken
+              req_body_usage: omit_always
+              sensitive: true
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: HTTP Event Collector (HEC) endpoint URL.
+              computed_optional_required: computed
+              tf_schema_name: hec_url
+              tf_model_name: HecUrl
+              api_name: hecUrl
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
               computed_optional_required: computed
               tf_schema_name: iam_role_id
               tf_model_name: IamRoleId
@@ -159,7 +331,7 @@ data_sources:
               request_only_required_on_create: false
             - set:
                 element_type: 4
-              description: 'Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.'
+              description: Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
               custom_type:
                 package: customtypes
                 model: customtypes.SetValue[types.String]
@@ -174,7 +346,58 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.
+              description: OpenTelemetry collector endpoint URL.
+              computed_optional_required: computed
+              tf_schema_name: otel_endpoint
+              tf_model_name: OtelEndpoint
+              api_name: otelEndpoint
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - list_nested:
+                nested_object:
+                    attributes:
+                        - string: {}
+                          description: Header name.
+                          computed_optional_required: computed
+                          tf_schema_name: name
+                          tf_model_name: Name
+                          api_name: name
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Header value.
+                          computed_optional_required: computed
+                          tf_schema_name: value
+                          tf_model_name: Value
+                          api_name: value
+                          req_body_usage: omit_always
+                          sensitive: true
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+              description: HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.
+              custom_type:
+                package: customtypes
+                name: OtelSuppliedHeaders
+                model: customtypes.NestedListValue[TFOtelSuppliedHeadersModel]
+                schema: customtypes.NewNestedListType[TFOtelSuppliedHeadersModel](ctx)
+              computed_optional_required: computed
+              tf_schema_name: otel_supplied_headers
+              tf_model_name: OtelSuppliedHeaders
+              api_name: otelSuppliedHeaders
+              req_body_usage: omit_always
+              sensitive: true
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
               computed_optional_required: computed
               tf_schema_name: prefix_path
               tf_model_name: PrefixPath
@@ -196,7 +419,62 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.
+              description: 'Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
+              computed_optional_required: computed
+              tf_schema_name: region
+              tf_model_name: Region
+              api_name: region
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Unique 24-character hexadecimal string that identifies the GCP service account role.
+              computed_optional_required: computed
+              tf_schema_name: role_id
+              tf_model_name: RoleId
+              api_name: roleId
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Unique 24-character hexadecimal string that identifies the Service Principal.
+              computed_optional_required: computed
+              tf_schema_name: service_principal_id
+              tf_model_name: ServicePrincipalId
+              api_name: servicePrincipalId
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Storage account name where logs will be stored.
+              computed_optional_required: computed
+              tf_schema_name: storage_account_name
+              tf_model_name: StorageAccountName
+              api_name: storageAccountName
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Storage container name for log files.
+              computed_optional_required: computed
+              tf_schema_name: storage_container_name
+              tf_model_name: StorageContainerName
+              api_name: storageContainerName
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
+            - string: {}
+              description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
               computed_optional_required: computed
               tf_schema_name: type
               tf_model_name: Type
@@ -206,10 +484,10 @@ data_sources:
               create_only: false
               present_in_any_response: false
               request_only_required_on_create: false
-        plural_ds_description: Returns all log integration configurations for the project. Optionally filter by integration type. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role. This is currently in preview. Please contact your Customer Success Manager (CSM) for access.
+        plural_ds_description: Returns all log integration configurations for the project. Optionally filter by integration type. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
         plural_ds_attributes:
             - string: {}
-              description: Optional filter by integration type (e.g., 'S3_LOG_EXPORT').
+              description: Optional filter by integration type (e.g., `S3_LOG_EXPORT`).
               computed_optional_required: optional
               tf_schema_name: integration_type
               tf_model_name: IntegrationType
@@ -234,7 +512,18 @@ data_sources:
                 nested_object:
                     attributes:
                         - string: {}
-                          description: Human-readable label that identifies the S3 bucket name for storing log files.
+                          description: API key for authentication.
+                          computed_optional_required: computed
+                          tf_schema_name: api_key
+                          tf_model_name: ApiKey
+                          api_name: apiKey
+                          req_body_usage: omit_always
+                          sensitive: true
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Name of the bucket to store log files.
                           computed_optional_required: computed
                           tf_schema_name: bucket_name
                           tf_model_name: BucketName
@@ -245,7 +534,29 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.
+                          description: HTTP Event Collector (HEC) token for authentication.
+                          computed_optional_required: computed
+                          tf_schema_name: hec_token
+                          tf_model_name: HecToken
+                          api_name: hecToken
+                          req_body_usage: omit_always
+                          sensitive: true
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: HTTP Event Collector (HEC) endpoint URL.
+                          computed_optional_required: computed
+                          tf_schema_name: hec_url
+                          tf_model_name: HecUrl
+                          api_name: hecUrl
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
                           computed_optional_required: computed
                           tf_schema_name: iam_role_id
                           tf_model_name: IamRoleId
@@ -279,7 +590,7 @@ data_sources:
                           request_only_required_on_create: false
                         - set:
                             element_type: 4
-                          description: 'Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.'
+                          description: Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
                           custom_type:
                             package: customtypes
                             model: customtypes.SetValue[types.String]
@@ -294,7 +605,58 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.
+                          description: OpenTelemetry collector endpoint URL.
+                          computed_optional_required: computed
+                          tf_schema_name: otel_endpoint
+                          tf_model_name: OtelEndpoint
+                          api_name: otelEndpoint
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - list_nested:
+                            nested_object:
+                                attributes:
+                                    - string: {}
+                                      description: Header name.
+                                      computed_optional_required: computed
+                                      tf_schema_name: name
+                                      tf_model_name: Name
+                                      api_name: name
+                                      req_body_usage: omit_always
+                                      sensitive: false
+                                      create_only: false
+                                      present_in_any_response: false
+                                      request_only_required_on_create: false
+                                    - string: {}
+                                      description: Header value.
+                                      computed_optional_required: computed
+                                      tf_schema_name: value
+                                      tf_model_name: Value
+                                      api_name: value
+                                      req_body_usage: omit_always
+                                      sensitive: true
+                                      create_only: false
+                                      present_in_any_response: false
+                                      request_only_required_on_create: false
+                          description: HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.
+                          custom_type:
+                            package: customtypes
+                            name: ResultsOtelSuppliedHeaders
+                            model: customtypes.NestedListValue[TFResultsOtelSuppliedHeadersModel]
+                            schema: customtypes.NewNestedListType[TFResultsOtelSuppliedHeadersModel](ctx)
+                          computed_optional_required: computed
+                          tf_schema_name: otel_supplied_headers
+                          tf_model_name: OtelSuppliedHeaders
+                          api_name: otelSuppliedHeaders
+                          req_body_usage: omit_always
+                          sensitive: true
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
                           computed_optional_required: computed
                           tf_schema_name: prefix_path
                           tf_model_name: PrefixPath
@@ -305,7 +667,62 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.
+                          description: 'Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
+                          computed_optional_required: computed
+                          tf_schema_name: region
+                          tf_model_name: Region
+                          api_name: region
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Unique 24-character hexadecimal string that identifies the GCP service account role.
+                          computed_optional_required: computed
+                          tf_schema_name: role_id
+                          tf_model_name: RoleId
+                          api_name: roleId
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Unique 24-character hexadecimal string that identifies the Service Principal.
+                          computed_optional_required: computed
+                          tf_schema_name: service_principal_id
+                          tf_model_name: ServicePrincipalId
+                          api_name: servicePrincipalId
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Storage account name where logs will be stored.
+                          computed_optional_required: computed
+                          tf_schema_name: storage_account_name
+                          tf_model_name: StorageAccountName
+                          api_name: storageAccountName
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Storage container name for log files.
+                          computed_optional_required: computed
+                          tf_schema_name: storage_container_name
+                          tf_model_name: StorageContainerName
+                          api_name: storageContainerName
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - string: {}
+                          description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
                           computed_optional_required: computed
                           tf_schema_name: type
                           tf_model_name: Type


### PR DESCRIPTION
## Description

Using the cloud-dev api-spec to generate the updated resource, adding support for GCS, Azure, Datadog, Splunk and OTel integrations.

Acceptance tests will be included in a separate PR. Getting this merged to unblock the docs team to work on examples/docs.

Link to any related issue(s): [CLOUDP-379431](https://jira.mongodb.org/browse/CLOUDP-379431)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
