### PR TITLE
chore: Adding aliasing support in discriminator model

### DIFF
--- a/internal/serviceapi/streamconnectionapi/resource_schema.go
+++ b/internal/serviceapi/streamconnectionapi/resource_schema.go
@@ -151,7 +151,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Optional:            true,
 								MarkdownDescription: "Reserved. Will be used by PRIVATE_LINK connection type.",
 							},
-							"connection_name": schema.StringAttribute{
+							"name": schema.StringAttribute{
 								Optional:            true,
 								MarkdownDescription: "Reserved. Will be used by PRIVATE_LINK connection type.",
 							},
@@ -293,10 +293,10 @@ type TFNetworkingModel struct {
 	Access customtypes.ObjectValue[TFNetworkingAccessModel] `tfsdk:"access"`
 }
 type TFNetworkingAccessModel struct {
-	ConnectionId   types.String `tfsdk:"connection_id"`
-	ConnectionName types.String `tfsdk:"connection_name" apiname:"name"`
-	TgwRouteId     types.String `tfsdk:"tgw_route_id"`
-	Type           types.String `tfsdk:"type"`
+	ConnectionId types.String `tfsdk:"connection_id"`
+	Name         types.String `tfsdk:"name"`
+	TgwRouteId   types.String `tfsdk:"tgw_route_id"`
+	Type         types.String `tfsdk:"type"`
 }
 type TFSchemaRegistryAuthenticationModel struct {
 	Password types.String `tfsdk:"password" autogen:"sensitive"`

--- a/tools/codegen/codespec/api_to_provider_spec_mapper.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper.go
@@ -204,7 +204,7 @@ func apiSpecResourceToCodeSpecModel(oasResource APISpecResource, resourceConfig 
 		IDAttributes: resourceConfig.IDAttributes,
 	}
 
-	if err := applyTransformationsWithConfigOpts(resourceConfig, resource); err != nil {
+	if err := ApplyTransformationsWithConfigOpts(resourceConfig, resource); err != nil {
 		return nil, err
 	}
 

--- a/tools/codegen/codespec/api_to_provider_spec_mapper.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper.go
@@ -204,7 +204,7 @@ func apiSpecResourceToCodeSpecModel(oasResource APISpecResource, resourceConfig 
 		IDAttributes: resourceConfig.IDAttributes,
 	}
 
-	if err := ApplyTransformationsWithConfigOpts(resourceConfig, resource); err != nil {
+	if err := ApplyTransformationsToResource(resourceConfig, resource); err != nil {
 		return nil, err
 	}
 

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -1580,39 +1580,40 @@ func TestConvertToProviderSpec_polymorphicResource(t *testing.T) {
 	// Verify root-level discriminator is populated
 	disc := schema.Discriminator
 	require.NotNil(t, disc, "Root discriminator should be populated")
-	assert.Equal(t, "type", disc.PropertyName, "Discriminator property name should be snake_case")
+	assert.Equal(t, "type", disc.PropertyName.TFSchemaName, "Discriminator property name should be snake_case")
+	assert.Equal(t, "type", disc.PropertyName.APIName, "Discriminator API property name should be preserved")
 
 	// Verify TypeA mapping
 	typeA, ok := disc.Mapping["TypeA"]
 	require.True(t, ok, "TypeA variant should exist in mapping")
 	// type_a_only_attr, type_a_optional_attr, computed_type_a_attr from request
 	// response adds response_only_attr and response_required_attr
-	assert.Contains(t, typeA.Allowed, "type_a_only_attr")
-	assert.Contains(t, typeA.Allowed, "type_a_optional_attr")
-	assert.Contains(t, typeA.Allowed, "computed_type_a_attr")
-	assert.Contains(t, typeA.Allowed, "response_only_attr", "Response-only attribute should be in allowed via merge")
-	assert.Contains(t, typeA.Allowed, "response_required_attr", "Response-only required attribute should be in allowed via merge")
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOnlyAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOptionalAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("computedTypeAAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("responseOnlyAttr"), "Response-only attribute should be in allowed via merge")
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("responseRequiredAttr"), "Response-only required attribute should be in allowed via merge")
 	// type is excluded from variant mappings (it's the discriminator property itself)
-	assert.NotContains(t, typeA.Allowed, "type", "Discriminator property itself should be excluded from allowed")
+	assert.NotContains(t, typeA.Allowed, codespec.NewAttributeName("type"), "Discriminator property itself should be excluded from allowed")
 
 	// Required: type_a_only_attr from request; computed_type_a_attr is readOnly so excluded from required.
 	// response_required_attr is required in the response discriminator but response-only properties
 	// should not contribute to required (required is driven by the request discriminator only).
-	assert.Contains(t, typeA.Required, "type_a_only_attr", "Non-readOnly required should be in required")
-	assert.NotContains(t, typeA.Required, "computed_type_a_attr", "ReadOnly required should be excluded from required")
-	assert.NotContains(t, typeA.Required, "response_required_attr", "Response-only required should not appear in merged required")
+	assert.Contains(t, typeA.Required, codespec.NewAttributeName("typeAOnlyAttr"), "Non-readOnly required should be in required")
+	assert.NotContains(t, typeA.Required, codespec.NewAttributeName("computedTypeAAttr"), "ReadOnly required should be excluded from required")
+	assert.NotContains(t, typeA.Required, codespec.NewAttributeName("responseRequiredAttr"), "Response-only required should not appear in merged required")
 
 	// Verify TypeB mapping
 	typeB, ok := disc.Mapping["TypeB"]
 	require.True(t, ok, "TypeB variant should exist in mapping")
-	assert.Contains(t, typeB.Allowed, "type_b_only_attr")
-	assert.NotContains(t, typeB.Allowed, "type", "Discriminator property itself should be excluded from allowed")
-	assert.Contains(t, typeB.Required, "type_b_only_attr")
+	assert.Contains(t, typeB.Allowed, codespec.NewAttributeName("typeBOnlyAttr"))
+	assert.NotContains(t, typeB.Allowed, codespec.NewAttributeName("type"), "Discriminator property itself should be excluded from allowed")
+	assert.Contains(t, typeB.Required, codespec.NewAttributeName("typeBOnlyAttr"))
 
 	// Verify common attributes are NOT in any variant's allowed list
 	// commonAttr is a base property, not type-specific
 	for _, variant := range disc.Mapping {
-		assert.NotContains(t, variant.Allowed, "common_attr", "Common attributes should not appear in variant allowed lists")
+		assert.NotContains(t, variant.Allowed, codespec.NewAttributeName("commonAttr"), "Common attributes should not appear in variant allowed lists")
 	}
 
 	// Verify response-only attributes are present as computed attributes in the schema
@@ -1661,20 +1662,20 @@ func TestConvertToProviderSpec_nestedPolymorphicResource(t *testing.T) {
 	// Verify nested discriminator is populated
 	nestedDisc := nestedPolyAttr.SingleNested.NestedObject.Discriminator
 	require.NotNil(t, nestedDisc, "Nested discriminator should be populated")
-	assert.Equal(t, "type", nestedDisc.PropertyName)
+	assert.Equal(t, codespec.NewAttributeName("type"), nestedDisc.PropertyName)
 
 	// Verify TypeA mapping at nested level
 	typeA, ok := nestedDisc.Mapping["TypeA"]
 	require.True(t, ok, "TypeA variant should exist in nested mapping")
-	assert.Contains(t, typeA.Allowed, "type_a_only_attr")
-	assert.Contains(t, typeA.Allowed, "type_a_optional_attr")
-	assert.Contains(t, typeA.Allowed, "computed_type_a_attr")
-	assert.NotContains(t, typeA.Allowed, "type")
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOnlyAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOptionalAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("computedTypeAAttr"))
+	assert.NotContains(t, typeA.Allowed, codespec.NewAttributeName("type"))
 
 	// Verify TypeB mapping at nested level
 	typeB, ok := nestedDisc.Mapping["TypeB"]
 	require.True(t, ok, "TypeB variant should exist in nested mapping")
-	assert.Contains(t, typeB.Allowed, "type_b_only_attr")
+	assert.Contains(t, typeB.Allowed, codespec.NewAttributeName("typeBOnlyAttr"))
 }
 
 func TestConvertToProviderSpec_ignoreSchemaAndIdAttributes(t *testing.T) {

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -1588,32 +1588,32 @@ func TestConvertToProviderSpec_polymorphicResource(t *testing.T) {
 	require.True(t, ok, "TypeA variant should exist in mapping")
 	// type_a_only_attr, type_a_optional_attr, computed_type_a_attr from request
 	// response adds response_only_attr and response_required_attr
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOnlyAttr"))
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOptionalAttr"))
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("computedTypeAAttr"))
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("responseOnlyAttr"), "Response-only attribute should be in allowed via merge")
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("responseRequiredAttr"), "Response-only required attribute should be in allowed via merge")
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("typeAOnlyAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("typeAOptionalAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("computedTypeAAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("responseOnlyAttr"), "Response-only attribute should be in allowed via merge")
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("responseRequiredAttr"), "Response-only required attribute should be in allowed via merge")
 	// type is excluded from variant mappings (it's the discriminator property itself)
-	assert.NotContains(t, typeA.Allowed, codespec.NewAttributeName("type"), "Discriminator property itself should be excluded from allowed")
+	assert.NotContains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("type"), "Discriminator property itself should be excluded from allowed")
 
 	// Required: type_a_only_attr from request; computed_type_a_attr is readOnly so excluded from required.
 	// response_required_attr is required in the response discriminator but response-only properties
 	// should not contribute to required (required is driven by the request discriminator only).
-	assert.Contains(t, typeA.Required, codespec.NewAttributeName("typeAOnlyAttr"), "Non-readOnly required should be in required")
-	assert.NotContains(t, typeA.Required, codespec.NewAttributeName("computedTypeAAttr"), "ReadOnly required should be excluded from required")
-	assert.NotContains(t, typeA.Required, codespec.NewAttributeName("responseRequiredAttr"), "Response-only required should not appear in merged required")
+	assert.Contains(t, typeA.Required, codespec.NewDiscriminatorAttrName("typeAOnlyAttr"), "Non-readOnly required should be in required")
+	assert.NotContains(t, typeA.Required, codespec.NewDiscriminatorAttrName("computedTypeAAttr"), "ReadOnly required should be excluded from required")
+	assert.NotContains(t, typeA.Required, codespec.NewDiscriminatorAttrName("responseRequiredAttr"), "Response-only required should not appear in merged required")
 
 	// Verify TypeB mapping
 	typeB, ok := disc.Mapping["TypeB"]
 	require.True(t, ok, "TypeB variant should exist in mapping")
-	assert.Contains(t, typeB.Allowed, codespec.NewAttributeName("typeBOnlyAttr"))
-	assert.NotContains(t, typeB.Allowed, codespec.NewAttributeName("type"), "Discriminator property itself should be excluded from allowed")
-	assert.Contains(t, typeB.Required, codespec.NewAttributeName("typeBOnlyAttr"))
+	assert.Contains(t, typeB.Allowed, codespec.NewDiscriminatorAttrName("typeBOnlyAttr"))
+	assert.NotContains(t, typeB.Allowed, codespec.NewDiscriminatorAttrName("type"), "Discriminator property itself should be excluded from allowed")
+	assert.Contains(t, typeB.Required, codespec.NewDiscriminatorAttrName("typeBOnlyAttr"))
 
 	// Verify common attributes are NOT in any variant's allowed list
 	// commonAttr is a base property, not type-specific
 	for _, variant := range disc.Mapping {
-		assert.NotContains(t, variant.Allowed, codespec.NewAttributeName("commonAttr"), "Common attributes should not appear in variant allowed lists")
+		assert.NotContains(t, variant.Allowed, codespec.NewDiscriminatorAttrName("commonAttr"), "Common attributes should not appear in variant allowed lists")
 	}
 
 	// Verify response-only attributes are present as computed attributes in the schema
@@ -1662,20 +1662,20 @@ func TestConvertToProviderSpec_nestedPolymorphicResource(t *testing.T) {
 	// Verify nested discriminator is populated
 	nestedDisc := nestedPolyAttr.SingleNested.NestedObject.Discriminator
 	require.NotNil(t, nestedDisc, "Nested discriminator should be populated")
-	assert.Equal(t, codespec.NewAttributeName("type"), nestedDisc.PropertyName)
+	assert.Equal(t, codespec.NewDiscriminatorAttrName("type"), nestedDisc.PropertyName)
 
 	// Verify TypeA mapping at nested level
 	typeA, ok := nestedDisc.Mapping["TypeA"]
 	require.True(t, ok, "TypeA variant should exist in nested mapping")
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOnlyAttr"))
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("typeAOptionalAttr"))
-	assert.Contains(t, typeA.Allowed, codespec.NewAttributeName("computedTypeAAttr"))
-	assert.NotContains(t, typeA.Allowed, codespec.NewAttributeName("type"))
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("typeAOnlyAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("typeAOptionalAttr"))
+	assert.Contains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("computedTypeAAttr"))
+	assert.NotContains(t, typeA.Allowed, codespec.NewDiscriminatorAttrName("type"))
 
 	// Verify TypeB mapping at nested level
 	typeB, ok := nestedDisc.Mapping["TypeB"]
 	require.True(t, ok, "TypeB variant should exist in nested mapping")
-	assert.Contains(t, typeB.Allowed, codespec.NewAttributeName("typeBOnlyAttr"))
+	assert.Contains(t, typeB.Allowed, codespec.NewDiscriminatorAttrName("typeBOnlyAttr"))
 }
 
 func TestConvertToProviderSpec_ignoreSchemaAndIdAttributes(t *testing.T) {

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -442,19 +442,12 @@ func applyAliasesToDiscriminator(disc *Discriminator, aliases map[string]string,
 	}
 }
 
-// resolveAliasAtLevel constructs the full alias key from an API name and the parent path,
-// then performs a direct lookup in the aliases map.
-func resolveAliasAtLevel(apiName string, aliases map[string]string, parentAPIPath string) (string, bool) {
-	fullPath := apiName
-	if parentAPIPath != "" {
-		fullPath = parentAPIPath + "." + apiName
-	}
-	alias, ok := aliases[fullPath]
-	return alias, ok
-}
-
 func applyAliasToAttributeName(name *AttributeName, aliases map[string]string, parentAPIPath string) {
-	if alias, ok := resolveAliasAtLevel(name.APIName, aliases, parentAPIPath); ok {
+	fullPath := name.APIName
+	if parentAPIPath != "" {
+		fullPath = parentAPIPath + "." + name.APIName
+	}
+	if alias, ok := aliases[fullPath]; ok {
 		name.TFSchemaName = stringcase.ToSnakeCase(alias)
 	}
 }

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -22,7 +22,7 @@ func ApplyTransformationsToResource(resourceConfig *config.Resource, resource *R
 		return nil
 	}
 	parentPaths := &attrPaths{schemaPath: "", apiPath: ""}
-	if err := applyAttributeTransformationsList(resourceConfig.SchemaOptions, &resource.Schema.Attributes, parentPaths, transformations); err != nil {
+	if err := applyAttributeTransformationsList(resourceConfig.SchemaOptions, &resource.Schema.Attributes, parentPaths, resourceTransformations); err != nil {
 		return fmt.Errorf("failed to apply attribute transformations: %w", err)
 	}
 	applyCommonAliasTransformations(&resource.Operations, resourceConfig.SchemaOptions.Aliases, resource.Schema.Discriminator, &resource.Schema.Attributes)
@@ -109,7 +109,7 @@ type attrPaths struct {
 // Implementations may mutate the attribute in-place.
 type AttributeTransformation func(attr *Attribute, paths *attrPaths, schemaOptions config.SchemaOptions) error
 
-var transformations = []AttributeTransformation{
+var resourceTransformations = []AttributeTransformation{
 	aliasTransformation,
 	commonRSAndDSOverridesTransformation,
 	immutableComputedOverrideTransformation,

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -191,7 +191,7 @@ func shouldIgnoreAttribute(attrPathName string, ignoredAttrs map[string]bool) bo
 	return ignoredAttrs[attrPathName]
 }
 
-func applyAliasToAttribute(attr *Attribute, paths *attrPaths, schemaOptions config.SchemaOptions) {
+func aliasTransformation(attr *Attribute, paths *attrPaths, schemaOptions config.SchemaOptions) error {
 	// Config uses full camelCase for aliases (e.g., groupId: projectId, nestedObject.innerAttr: renamedAttr)
 	// The apiPath is built from APIName values which preserve the original casing (e.g., "MongoDBMajorVersion")
 	// This avoids the lossy conversion from snake to camel case.
@@ -214,13 +214,6 @@ func applyAliasToAttribute(attr *Attribute, paths *attrPaths, schemaOptions conf
 		// Note: apiPath is not updated because it's only used for alias lookup,
 		// and aliases are defined using original API names
 	}
-}
-
-// Transformations
-func aliasTransformation(attr *Attribute, paths *attrPaths, schemaOptions config.SchemaOptions) error {
-	// Alias transformation runs first, updating TFSchemaName and paths.schemaPath.
-	// Subsequent overrides should use the aliased snake_case path (e.g., nested_list_array_attr.inner_num_attr_alias)
-	applyAliasToAttribute(attr, paths, schemaOptions)
 	return nil
 }
 

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -2,6 +2,7 @@ package codespec
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/stringcase"
@@ -16,14 +17,17 @@ const DeleteOnCreateTimeoutDescription = "Indicates whether to delete the resour
 	"deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a " +
 	"transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`."
 
-func applyTransformationsWithConfigOpts(resourceConfig *config.Resource, resource *Resource) error {
+func ApplyTransformationsWithConfigOpts(resourceConfig *config.Resource, resource *Resource) error {
 	if resource == nil || resource.Schema == nil {
 		return nil
 	}
 	// Start with empty paths for both schemaPath (snake_case) and apiPath (camelCase)
-	if err := applyAttributeTransformations(resourceConfig.SchemaOptions, &resource.Schema.Attributes, &attrPaths{schemaPath: "", apiPath: ""}); err != nil {
+	if err := applyAttributeTransformations(resourceConfig.SchemaOptions, &resource.Schema.Attributes); err != nil {
 		return fmt.Errorf("failed to apply attribute transformations: %w", err)
 	}
+	// Reconcile discriminator property names and variant attribute names after aliases are applied.
+	// This is resource-specific since discriminators are only relevant for resources.
+	applyAliasesToDiscriminators(resource.Schema, resourceConfig.SchemaOptions.Aliases)
 	applyAliasToPathParams(&resource.Operations, resourceConfig.SchemaOptions.Aliases)
 	ApplyDeleteOnCreateTimeoutTransformation(resource)
 	ApplyTimeoutTransformation(resource)
@@ -31,17 +35,17 @@ func applyTransformationsWithConfigOpts(resourceConfig *config.Resource, resourc
 }
 
 // ApplyTransformationsToDataSources applies schema transformations and path param aliasing to data sources.
-// This mirrors applyTransformationsWithConfigOpts for resources, without timeout-related and create-only transformations.
+// This mirrors ApplyTransformationsWithConfigOpts for resources, without timeout-related and create-only transformations.
 // Exported for testing purposes.
 func ApplyTransformationsToDataSources(dsConfig *config.DataSources, ds *DataSources) error {
 	if ds == nil || ds.Schema == nil {
 		return nil
 	}
 
-	if err := applyDataSourceAttributeTransformations(dsConfig.SchemaOptions, ds.Schema.SingularDSAttributes, &attrPaths{schemaPath: "", apiPath: ""}); err != nil {
+	if err := applyDataSourceAttributeTransformations(dsConfig.SchemaOptions, ds.Schema.SingularDSAttributes); err != nil {
 		return fmt.Errorf("failed to apply attribute transformations for singular data source: %w", err)
 	}
-	if err := applyDataSourceAttributeTransformations(dsConfig.SchemaOptions, ds.Schema.PluralDSAttributes, &attrPaths{schemaPath: "", apiPath: ""}); err != nil {
+	if err := applyDataSourceAttributeTransformations(dsConfig.SchemaOptions, ds.Schema.PluralDSAttributes); err != nil {
 		return fmt.Errorf("failed to apply attribute transformations for plural data source: %w", err)
 	}
 
@@ -106,11 +110,13 @@ var dataSourceTransformations = []AttributeTransformation{
 	// Note: resource-specific transformations (createOnly, requestOnlyRequiredOnCreate, immutableComputed) are excluded for data sources
 }
 
-func applyAttributeTransformations(schemaOptions config.SchemaOptions, attributes *Attributes, parentPaths *attrPaths) error {
+func applyAttributeTransformations(schemaOptions config.SchemaOptions, attributes *Attributes) error {
+	parentPaths := &attrPaths{schemaPath: "", apiPath: ""}
 	return applyAttributeTransformationsList(schemaOptions, attributes, parentPaths, transformations)
 }
 
-func applyDataSourceAttributeTransformations(schemaOptions config.SchemaOptions, attributes *Attributes, parentPaths *attrPaths) error {
+func applyDataSourceAttributeTransformations(schemaOptions config.SchemaOptions, attributes *Attributes) error {
+	parentPaths := &attrPaths{schemaPath: "", apiPath: ""}
 	return applyAttributeTransformationsList(schemaOptions, attributes, parentPaths, dataSourceTransformations)
 }
 
@@ -410,6 +416,114 @@ func setCreateOnlyValue(attr *Attribute) {
 
 func attrPathForOverrides(attrPathName string) string {
 	return strings.TrimPrefix(attrPathName, "results.")
+}
+
+// applyAliasesToDiscriminators walks the schema tree and applies alias renames to all discriminators
+// found at the root level and within nested attributes. This is called after attribute transformations
+// so that the attribute tree structure (including type overrides like list->set) is already finalized.
+func applyAliasesToDiscriminators(schema *Schema, aliases map[string]string) {
+	if schema == nil || len(aliases) == 0 {
+		return
+	}
+	applyAliasesToDiscriminator(schema.Discriminator, aliases, "")
+	applyAliasesToNestedDiscriminators(schema.Attributes, aliases, "")
+}
+
+// applyAliasesToNestedDiscriminators recursively walks attributes and applies alias renames
+// to discriminators found on nested attribute objects.
+func applyAliasesToNestedDiscriminators(attributes Attributes, aliases map[string]string, parentAPIPath string) {
+	for i := range attributes {
+		attr := &attributes[i]
+		apiPath := buildPath(parentAPIPath, attr.APIName)
+
+		switch {
+		case attr.ListNested != nil:
+			applyAliasesToDiscriminator(attr.ListNested.NestedObject.Discriminator, aliases, apiPath)
+			applyAliasesToNestedDiscriminators(attr.ListNested.NestedObject.Attributes, aliases, apiPath)
+		case attr.SingleNested != nil:
+			applyAliasesToDiscriminator(attr.SingleNested.NestedObject.Discriminator, aliases, apiPath)
+			applyAliasesToNestedDiscriminators(attr.SingleNested.NestedObject.Attributes, aliases, apiPath)
+		case attr.SetNested != nil:
+			applyAliasesToDiscriminator(attr.SetNested.NestedObject.Discriminator, aliases, apiPath)
+			applyAliasesToNestedDiscriminators(attr.SetNested.NestedObject.Attributes, aliases, apiPath)
+		case attr.MapNested != nil:
+			applyAliasesToDiscriminator(attr.MapNested.NestedObject.Discriminator, aliases, apiPath)
+			applyAliasesToNestedDiscriminators(attr.MapNested.NestedObject.Attributes, aliases, apiPath)
+		}
+	}
+}
+
+// applyAliasesToDiscriminator reconciles discriminator property names and variant attribute names
+// when aliases have been applied. It renames PropertyName and all entries in Allowed/Required lists
+// according to the aliases applicable at this nesting level.
+func applyAliasesToDiscriminator(disc *Discriminator, aliases map[string]string, parentAPIPath string) {
+	if disc == nil || len(aliases) == 0 {
+		return
+	}
+
+	// Build a rename map: old_snake -> new_snake for aliases at this nesting level.
+	// Aliases use camelCase API names (e.g., "groupId: projectId" or "nestedObject.innerAttr: renamedAttr").
+	// We need to match aliases that apply at this level (either path-based or attribute-name only).
+	renameMap := make(map[string]string)
+	for original, alias := range aliases {
+		var apiName string
+		if parentAPIPath != "" {
+			// Check path-based alias (e.g., "nestedObject.innerAttr")
+			prefix := parentAPIPath + "."
+			if strings.HasPrefix(original, prefix) {
+				apiName = strings.TrimPrefix(original, prefix)
+			}
+		}
+		if apiName == "" {
+			// Fall back to attribute-name only (no dot means root-level alias)
+			if !strings.Contains(original, ".") {
+				apiName = original
+			} else if parentAPIPath == "" {
+				// At root level, also check path-based aliases without parent prefix
+				apiName = original
+			}
+		}
+		if apiName != "" {
+			oldSnake := stringcase.ToSnakeCase(apiName)
+			newSnake := stringcase.ToSnakeCase(alias)
+			if oldSnake != newSnake {
+				renameMap[oldSnake] = newSnake
+			}
+		}
+	}
+
+	if len(renameMap) == 0 {
+		return
+	}
+
+	// Rename PropertyName if aliased
+	if newName, found := renameMap[disc.PropertyName]; found {
+		disc.PropertyName = newName
+	}
+
+	// Rename entries in Allowed and Required lists
+	for key, variant := range disc.Mapping {
+		variant.Allowed = renameStringSlice(variant.Allowed, renameMap)
+		variant.Required = renameStringSlice(variant.Required, renameMap)
+		disc.Mapping[key] = variant
+	}
+}
+
+// renameStringSlice applies renames from the map to a string slice, returning a new sorted slice.
+func renameStringSlice(items []string, renameMap map[string]string) []string {
+	if len(items) == 0 {
+		return items
+	}
+	result := make([]string, len(items))
+	for i, item := range items {
+		if newName, found := renameMap[item]; found {
+			result[i] = newName
+		} else {
+			result[i] = item
+		}
+	}
+	sort.Strings(result)
+	return result
 }
 
 // tagsAndLabelsAsMapTypeTransformation transforms attributes that represent collections of key/value pairs (tags and labels) from a nested list of objects into a Map type.

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -197,9 +197,7 @@ func applyAliasToAttribute(attr *Attribute, paths *attrPaths, schemaOptions conf
 	// The apiPath is built from APIName values which preserve the original casing (e.g., "MongoDBMajorVersion")
 	// This avoids the lossy conversion from snake to camel case.
 
-	// Lookup by full apiPath only. At root level apiPath equals attr.APIName so non-dotted
-	// aliases like "groupId: projectId" still match. At nested levels only explicitly
-	// path-scoped aliases (e.g., "nestedObj.innerAttr: renamedAttr") apply.
+	// Lookup by full apiPath only. We do not want to implicitly apply aliases to nested-level attributes.
 	aliasCamel, found := schemaOptions.Aliases[paths.apiPath]
 
 	if found {

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -426,23 +426,23 @@ func applyAliasesToNestedDiscriminators(attributes Attributes, aliases map[strin
 }
 
 // applyAliasesToDiscriminator reconciles discriminator property names and variant attribute names
-// when aliases have been applied. It looks up each AttributeName.APIName in the aliases map
+// when aliases have been applied. It looks up each DiscriminatorAttrName.APIName in the aliases map
 // and updates the corresponding TFSchemaName when a match is found.
 func applyAliasesToDiscriminator(disc *Discriminator, aliases map[string]string, parentAPIPath string) {
 	if disc == nil || len(aliases) == 0 {
 		return
 	}
 
-	applyAliasToAttributeName(&disc.PropertyName, aliases, parentAPIPath)
+	applyAliasToDiscriminatorAttrName(&disc.PropertyName, aliases, parentAPIPath)
 
 	for key, variant := range disc.Mapping {
-		applyAliasToAttributeNames(variant.Allowed, aliases, parentAPIPath)
-		applyAliasToAttributeNames(variant.Required, aliases, parentAPIPath)
+		applyAliasToDiscriminatorAttrNames(variant.Allowed, aliases, parentAPIPath)
+		applyAliasToDiscriminatorAttrNames(variant.Required, aliases, parentAPIPath)
 		disc.Mapping[key] = variant
 	}
 }
 
-func applyAliasToAttributeName(name *AttributeName, aliases map[string]string, parentAPIPath string) {
+func applyAliasToDiscriminatorAttrName(name *DiscriminatorAttrName, aliases map[string]string, parentAPIPath string) {
 	fullPath := name.APIName
 	if parentAPIPath != "" {
 		fullPath = parentAPIPath + "." + name.APIName
@@ -452,11 +452,11 @@ func applyAliasToAttributeName(name *AttributeName, aliases map[string]string, p
 	}
 }
 
-func applyAliasToAttributeNames(names []AttributeName, aliases map[string]string, parentAPIPath string) {
+func applyAliasToDiscriminatorAttrNames(names []DiscriminatorAttrName, aliases map[string]string, parentAPIPath string) {
 	for i := range names {
-		applyAliasToAttributeName(&names[i], aliases, parentAPIPath)
+		applyAliasToDiscriminatorAttrName(&names[i], aliases, parentAPIPath)
 	}
-	sortAttributeNames(names)
+	sortDiscriminatorAttrNames(names)
 }
 
 // tagsAndLabelsAsMapTypeTransformation transforms attributes that represent collections of key/value pairs (tags and labels) from a nested list of objects into a Map type.

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -56,10 +56,9 @@ func ApplyTransformationsToDataSources(dsConfig *config.DataSources, ds *DataSou
 
 func applyAliasToDiscriminator(aliases map[string]string, rootDiscriminator *Discriminator, attributes *Attributes) {
 	applyAliasesToDiscriminator(rootDiscriminator, aliases, "")
-	if attributes == nil {
-		return
+	if attributes != nil {
+		applyAliasesToNestedDiscriminators(*attributes, aliases, "")
 	}
-	applyAliasesToNestedDiscriminators(*attributes, aliases, "")
 }
 
 // applyAliasToPathParams replaces path parameter placeholders with their aliased names in all operation paths.

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -461,15 +461,15 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 			inputResource: &codespec.Resource{
 				Schema: &codespec.Schema{
 					Discriminator: &codespec.Discriminator{
-						PropertyName: codespec.NewAttributeName("typeField"),
+						PropertyName: codespec.NewDiscriminatorAttrName("typeField"),
 						Mapping: map[string]codespec.DiscriminatorType{
 							"VariantA": {
-								Allowed:  []codespec.AttributeName{codespec.NewAttributeName("typeField"), codespec.NewAttributeName("variantAAttr")},
-								Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
+								Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("typeField"), codespec.NewDiscriminatorAttrName("variantAAttr")},
+								Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("typeField")},
 							},
 							"VariantB": {
-								Allowed:  []codespec.AttributeName{codespec.NewAttributeName("typeField"), codespec.NewAttributeName("variantBAttr")},
-								Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
+								Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("typeField"), codespec.NewDiscriminatorAttrName("variantBAttr")},
+								Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("typeField")},
 							},
 						},
 					},
@@ -516,15 +516,15 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 				},
 			},
 			expectedDiscrim: &codespec.Discriminator{
-				PropertyName: codespec.AttributeName{APIName: "typeField", TFSchemaName: "kind"},
+				PropertyName: codespec.DiscriminatorAttrName{APIName: "typeField", TFSchemaName: "kind"},
 				Mapping: map[string]codespec.DiscriminatorType{
 					"VariantA": {
-						Allowed:  []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "variantAAttr", TFSchemaName: "variant_a_attr"}},
-						Required: []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}},
+						Allowed:  []codespec.DiscriminatorAttrName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "variantAAttr", TFSchemaName: "variant_a_attr"}},
+						Required: []codespec.DiscriminatorAttrName{{APIName: "typeField", TFSchemaName: "kind"}},
 					},
 					"VariantB": {
-						Allowed:  []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "variantBAttr", TFSchemaName: "variant_b_attr"}},
-						Required: []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}},
+						Allowed:  []codespec.DiscriminatorAttrName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "variantBAttr", TFSchemaName: "variant_b_attr"}},
+						Required: []codespec.DiscriminatorAttrName{{APIName: "typeField", TFSchemaName: "kind"}},
 					},
 				},
 			},
@@ -548,11 +548,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 							SingleNested: &codespec.SingleNestedAttribute{
 								NestedObject: codespec.NestedAttributeObject{
 									Discriminator: &codespec.Discriminator{
-										PropertyName: codespec.NewAttributeName("innerType"),
+										PropertyName: codespec.NewDiscriminatorAttrName("innerType"),
 										Mapping: map[string]codespec.DiscriminatorType{
 											"TypeA": {
-												Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("innerType")},
-												Required: []codespec.AttributeName{codespec.NewAttributeName("innerType")},
+												Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("innerType")},
+												Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("innerType")},
 											},
 										},
 									},
@@ -594,11 +594,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 					SingleNested: &codespec.SingleNestedAttribute{
 						NestedObject: codespec.NestedAttributeObject{
 							Discriminator: &codespec.Discriminator{
-								PropertyName: codespec.AttributeName{APIName: "innerType", TFSchemaName: "inner_kind"},
+								PropertyName: codespec.DiscriminatorAttrName{APIName: "innerType", TFSchemaName: "inner_kind"},
 								Mapping: map[string]codespec.DiscriminatorType{
 									"TypeA": {
-										Allowed:  []codespec.AttributeName{{APIName: "attrA", TFSchemaName: "attr_a"}, {APIName: "innerType", TFSchemaName: "inner_kind"}},
-										Required: []codespec.AttributeName{{APIName: "innerType", TFSchemaName: "inner_kind"}},
+										Allowed:  []codespec.DiscriminatorAttrName{{APIName: "attrA", TFSchemaName: "attr_a"}, {APIName: "innerType", TFSchemaName: "inner_kind"}},
+										Required: []codespec.DiscriminatorAttrName{{APIName: "innerType", TFSchemaName: "inner_kind"}},
 									},
 								},
 							},
@@ -637,11 +637,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 			inputResource: &codespec.Resource{
 				Schema: &codespec.Schema{
 					Discriminator: &codespec.Discriminator{
-						PropertyName: codespec.NewAttributeName("typeField"),
+						PropertyName: codespec.NewDiscriminatorAttrName("typeField"),
 						Mapping: map[string]codespec.DiscriminatorType{
 							"VariantA": {
-								Allowed:  []codespec.AttributeName{codespec.NewAttributeName("rootAttr"), codespec.NewAttributeName("typeField")},
-								Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
+								Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("rootAttr"), codespec.NewDiscriminatorAttrName("typeField")},
+								Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("typeField")},
 							},
 						},
 					},
@@ -662,11 +662,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 							SingleNested: &codespec.SingleNestedAttribute{
 								NestedObject: codespec.NestedAttributeObject{
 									Discriminator: &codespec.Discriminator{
-										PropertyName: codespec.NewAttributeName("typeField"),
+										PropertyName: codespec.NewDiscriminatorAttrName("typeField"),
 										Mapping: map[string]codespec.DiscriminatorType{
 											"InnerA": {
-												Allowed:  []codespec.AttributeName{codespec.NewAttributeName("innerAttr"), codespec.NewAttributeName("typeField")},
-												Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
+												Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("innerAttr"), codespec.NewDiscriminatorAttrName("typeField")},
+												Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("typeField")},
 											},
 										},
 									},
@@ -700,11 +700,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 				},
 			},
 			expectedDiscrim: &codespec.Discriminator{
-				PropertyName: codespec.AttributeName{APIName: "typeField", TFSchemaName: "kind"},
+				PropertyName: codespec.DiscriminatorAttrName{APIName: "typeField", TFSchemaName: "kind"},
 				Mapping: map[string]codespec.DiscriminatorType{
 					"VariantA": {
-						Allowed:  []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "rootAttr", TFSchemaName: "root_attr"}},
-						Required: []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}},
+						Allowed:  []codespec.DiscriminatorAttrName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "rootAttr", TFSchemaName: "root_attr"}},
+						Required: []codespec.DiscriminatorAttrName{{APIName: "typeField", TFSchemaName: "kind"}},
 					},
 				},
 			},
@@ -726,11 +726,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 						NestedObject: codespec.NestedAttributeObject{
 							Discriminator: &codespec.Discriminator{
 								// NOT renamed - non-dotted alias only applies at root level
-								PropertyName: codespec.NewAttributeName("typeField"),
+								PropertyName: codespec.NewDiscriminatorAttrName("typeField"),
 								Mapping: map[string]codespec.DiscriminatorType{
 									"InnerA": {
-										Allowed:  []codespec.AttributeName{codespec.NewAttributeName("innerAttr"), codespec.NewAttributeName("typeField")},
-										Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
+										Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("innerAttr"), codespec.NewDiscriminatorAttrName("typeField")},
+										Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("typeField")},
 									},
 								},
 							},

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -461,15 +461,15 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 			inputResource: &codespec.Resource{
 				Schema: &codespec.Schema{
 					Discriminator: &codespec.Discriminator{
-						PropertyName: "type_field",
+						PropertyName: codespec.NewAttributeName("typeField"),
 						Mapping: map[string]codespec.DiscriminatorType{
 							"VariantA": {
-								Allowed:  []string{"type_field", "variant_a_attr"},
-								Required: []string{"type_field"},
+								Allowed:  []codespec.AttributeName{codespec.NewAttributeName("typeField"), codespec.NewAttributeName("variantAAttr")},
+								Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
 							},
 							"VariantB": {
-								Allowed:  []string{"type_field", "variant_b_attr"},
-								Required: []string{"type_field"},
+								Allowed:  []codespec.AttributeName{codespec.NewAttributeName("typeField"), codespec.NewAttributeName("variantBAttr")},
+								Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
 							},
 						},
 					},
@@ -516,15 +516,15 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 				},
 			},
 			expectedDiscrim: &codespec.Discriminator{
-				PropertyName: "kind",
+				PropertyName: codespec.AttributeName{APIName: "typeField", TFSchemaName: "kind"},
 				Mapping: map[string]codespec.DiscriminatorType{
 					"VariantA": {
-						Allowed:  []string{"kind", "variant_a_attr"},
-						Required: []string{"kind"},
+						Allowed:  []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "variantAAttr", TFSchemaName: "variant_a_attr"}},
+						Required: []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}},
 					},
 					"VariantB": {
-						Allowed:  []string{"kind", "variant_b_attr"},
-						Required: []string{"kind"},
+						Allowed:  []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "variantBAttr", TFSchemaName: "variant_b_attr"}},
+						Required: []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}},
 					},
 				},
 			},
@@ -548,11 +548,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 							SingleNested: &codespec.SingleNestedAttribute{
 								NestedObject: codespec.NestedAttributeObject{
 									Discriminator: &codespec.Discriminator{
-										PropertyName: "inner_type",
+										PropertyName: codespec.NewAttributeName("innerType"),
 										Mapping: map[string]codespec.DiscriminatorType{
 											"TypeA": {
-												Allowed:  []string{"inner_type", "attr_a"},
-												Required: []string{"inner_type"},
+												Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("innerType")},
+												Required: []codespec.AttributeName{codespec.NewAttributeName("innerType")},
 											},
 										},
 									},
@@ -594,11 +594,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 					SingleNested: &codespec.SingleNestedAttribute{
 						NestedObject: codespec.NestedAttributeObject{
 							Discriminator: &codespec.Discriminator{
-								PropertyName: "inner_kind",
+								PropertyName: codespec.AttributeName{APIName: "innerType", TFSchemaName: "inner_kind"},
 								Mapping: map[string]codespec.DiscriminatorType{
 									"TypeA": {
-										Allowed:  []string{"attr_a", "inner_kind"},
-										Required: []string{"inner_kind"},
+										Allowed:  []codespec.AttributeName{{APIName: "attrA", TFSchemaName: "attr_a"}, {APIName: "innerType", TFSchemaName: "inner_kind"}},
+										Required: []codespec.AttributeName{{APIName: "innerType", TFSchemaName: "inner_kind"}},
 									},
 								},
 							},
@@ -637,11 +637,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 			inputResource: &codespec.Resource{
 				Schema: &codespec.Schema{
 					Discriminator: &codespec.Discriminator{
-						PropertyName: "type_field",
+						PropertyName: codespec.NewAttributeName("typeField"),
 						Mapping: map[string]codespec.DiscriminatorType{
 							"VariantA": {
-								Allowed:  []string{"type_field", "root_attr"},
-								Required: []string{"type_field"},
+								Allowed:  []codespec.AttributeName{codespec.NewAttributeName("rootAttr"), codespec.NewAttributeName("typeField")},
+								Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
 							},
 						},
 					},
@@ -662,11 +662,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 							SingleNested: &codespec.SingleNestedAttribute{
 								NestedObject: codespec.NestedAttributeObject{
 									Discriminator: &codespec.Discriminator{
-										PropertyName: "type_field",
+										PropertyName: codespec.NewAttributeName("typeField"),
 										Mapping: map[string]codespec.DiscriminatorType{
 											"InnerA": {
-												Allowed:  []string{"inner_attr", "type_field"},
-												Required: []string{"type_field"},
+												Allowed:  []codespec.AttributeName{codespec.NewAttributeName("innerAttr"), codespec.NewAttributeName("typeField")},
+												Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
 											},
 										},
 									},
@@ -700,11 +700,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 				},
 			},
 			expectedDiscrim: &codespec.Discriminator{
-				PropertyName: "kind",
+				PropertyName: codespec.AttributeName{APIName: "typeField", TFSchemaName: "kind"},
 				Mapping: map[string]codespec.DiscriminatorType{
 					"VariantA": {
-						Allowed:  []string{"kind", "root_attr"},
-						Required: []string{"kind"},
+						Allowed:  []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}, {APIName: "rootAttr", TFSchemaName: "root_attr"}},
+						Required: []codespec.AttributeName{{APIName: "typeField", TFSchemaName: "kind"}},
 					},
 				},
 			},
@@ -726,11 +726,11 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 						NestedObject: codespec.NestedAttributeObject{
 							Discriminator: &codespec.Discriminator{
 								// NOT renamed - non-dotted alias only applies at root level
-								PropertyName: "type_field",
+								PropertyName: codespec.NewAttributeName("typeField"),
 								Mapping: map[string]codespec.DiscriminatorType{
 									"InnerA": {
-										Allowed:  []string{"inner_attr", "type_field"},
-										Required: []string{"type_field"},
+										Allowed:  []codespec.AttributeName{codespec.NewAttributeName("innerAttr"), codespec.NewAttributeName("typeField")},
+										Required: []codespec.AttributeName{codespec.NewAttributeName("typeField")},
 									},
 								},
 							},

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -184,7 +184,7 @@ func TestApplyDeleteOnCreateTimeoutTransformation(t *testing.T) {
 	}
 }
 
-func TestApplyTransformationsWithConfigOpts_AliasAttributeTransformation(t *testing.T) {
+func TestApplyTransformationsToResource_AliasAttributeTransformation(t *testing.T) {
 	tests := map[string]struct {
 		inputResource      *codespec.Resource
 		inputConfig        *config.Resource
@@ -436,14 +436,14 @@ func TestApplyTransformationsWithConfigOpts_AliasAttributeTransformation(t *test
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := codespec.ApplyTransformationsWithConfigOpts(tc.inputConfig, tc.inputResource)
+			err := codespec.ApplyTransformationsToResource(tc.inputConfig, tc.inputResource)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedAttributes, tc.inputResource.Schema.Attributes)
 		})
 	}
 }
 
-func TestApplyTransformationsWithConfigOpts_AliasDiscriminatorTransformation(t *testing.T) {
+func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *testing.T) {
 	tests := map[string]struct {
 		inputResource      *codespec.Resource
 		inputConfig        *config.Resource
@@ -763,7 +763,7 @@ func TestApplyTransformationsWithConfigOpts_AliasDiscriminatorTransformation(t *
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := codespec.ApplyTransformationsWithConfigOpts(tc.inputConfig, tc.inputResource)
+			err := codespec.ApplyTransformationsToResource(tc.inputConfig, tc.inputResource)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedAttributes, tc.inputResource.Schema.Attributes)
 			if tc.expectedDiscrim != nil {

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -665,7 +665,7 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 										PropertyName: "type_field",
 										Mapping: map[string]codespec.DiscriminatorType{
 											"InnerA": {
-												Allowed:  []string{"type_field", "inner_attr"},
+												Allowed:  []string{"inner_attr", "type_field"},
 												Required: []string{"type_field"},
 											},
 										},

--- a/tools/codegen/codespec/discriminator.go
+++ b/tools/codegen/codespec/discriminator.go
@@ -9,6 +9,15 @@ import (
 	"github.com/pb33f/libopenapi/orderedmap"
 )
 
+// NewAttributeName creates an AttributeName from a camelCase API property name,
+// deriving the TF schema name via snake_case conversion.
+func NewAttributeName(apiName string) AttributeName {
+	return AttributeName{
+		APIName:      apiName,
+		TFSchemaName: stringcase.ToSnakeCase(apiName),
+	}
+}
+
 // extractDiscriminator converts a raw XGenDiscriminator into an intermediate model Discriminator.
 // It converts API property names (camelCase) to TF schema names (snake_case),
 // excludes the discriminator property itself from variant mappings,
@@ -29,37 +38,32 @@ func extractDiscriminator(schema *APISpecSchema) *Discriminator {
 		return nil
 	}
 
-	propertyNameSnake := stringcase.ToSnakeCase(xGenDisc.PropertyName)
+	propertyName := NewAttributeName(xGenDisc.PropertyName)
 
 	mapping := make(map[string]DiscriminatorType, len(xGenDisc.Mapping))
 	for discriminatorValue, variantType := range xGenDisc.Mapping {
-		var allowed []string
-		var required []string
+		var allowed []AttributeName
+		var required []AttributeName
 
 		for _, prop := range variantType.Properties {
-			snakeProp := stringcase.ToSnakeCase(prop)
-			// Exclude the discriminator property itself from variant mappings
-			if snakeProp == propertyNameSnake {
+			if prop == xGenDisc.PropertyName {
 				continue
 			}
-			allowed = append(allowed, snakeProp)
+			allowed = append(allowed, NewAttributeName(prop))
 		}
 
 		for _, prop := range variantType.Required {
-			snakeProp := stringcase.ToSnakeCase(prop)
-			// Exclude the discriminator property itself
-			if snakeProp == propertyNameSnake {
+			if prop == xGenDisc.PropertyName {
 				continue
 			}
-			// Filter readOnly properties from required (they map to Computed in TF)
 			if isReadOnlyProperty(schema, prop) {
 				continue
 			}
-			required = append(required, snakeProp)
+			required = append(required, NewAttributeName(prop))
 		}
 
-		sort.Strings(allowed)
-		sort.Strings(required)
+		sortAttributeNames(allowed)
+		sortAttributeNames(required)
 
 		mapping[discriminatorValue] = DiscriminatorType{
 			Allowed:  allowed,
@@ -72,12 +76,12 @@ func extractDiscriminator(schema *APISpecSchema) *Discriminator {
 	}
 
 	return &Discriminator{
-		PropertyName: propertyNameSnake,
+		PropertyName: propertyName,
 		Mapping:      mapping,
 	}
 }
 
-// mergeDiscriminators merges discriminator data from two sources (typically request and response schemas).
+// MergeDiscriminators merges discriminator data from two sources (typically request and response schemas).
 // allowed = union of both sources (captures response-only computed properties).
 // required = union of request sources only; response data never contributes to required.
 // If either argument is nil, the other is returned as-is.
@@ -87,7 +91,6 @@ func MergeDiscriminators(existing, incoming *Discriminator, incomingIsFromRespon
 	}
 	if existing == nil {
 		if incomingIsFromResponse {
-			// Response-only discriminator: clear all required lists since response properties are Computed
 			return clearRequired(incoming)
 		}
 		return incoming
@@ -96,13 +99,11 @@ func MergeDiscriminators(existing, incoming *Discriminator, incomingIsFromRespon
 		return existing
 	}
 
-	// Both are non-nil; merge variant mappings
 	merged := &Discriminator{
 		PropertyName: existing.PropertyName,
 		Mapping:      make(map[string]DiscriminatorType, len(existing.Mapping)),
 	}
 
-	// Start with existing variants
 	for key, variant := range existing.Mapping {
 		merged.Mapping[key] = DiscriminatorType{
 			Allowed:  slices.Clone(variant.Allowed),
@@ -110,16 +111,13 @@ func MergeDiscriminators(existing, incoming *Discriminator, incomingIsFromRespon
 		}
 	}
 
-	// Merge incoming variants
 	for key, incomingVariant := range incoming.Mapping {
 		if existingVariant, found := merged.Mapping[key]; found {
-			// Union allowed lists
-			mergedAllowed := unionStrings(existingVariant.Allowed, incomingVariant.Allowed)
+			mergedAllowed := unionAttributeNames(existingVariant.Allowed, incomingVariant.Allowed)
 
-			// required comes only from request sources
 			mergedRequired := existingVariant.Required
 			if !incomingIsFromResponse {
-				mergedRequired = unionStrings(existingVariant.Required, incomingVariant.Required)
+				mergedRequired = unionAttributeNames(existingVariant.Required, incomingVariant.Required)
 			}
 
 			merged.Mapping[key] = DiscriminatorType{
@@ -127,7 +125,6 @@ func MergeDiscriminators(existing, incoming *Discriminator, incomingIsFromRespon
 				Required: mergedRequired,
 			}
 		} else {
-			// New variant from incoming source
 			newVariant := DiscriminatorType{
 				Allowed: slices.Clone(incomingVariant.Allowed),
 			}
@@ -173,7 +170,6 @@ func clearRequired(disc *Discriminator) *Discriminator {
 	for key, variant := range disc.Mapping {
 		result.Mapping[key] = DiscriminatorType{
 			Allowed: slices.Clone(variant.Allowed),
-			// Required intentionally omitted (nil/empty)
 		}
 	}
 	return result
@@ -188,19 +184,25 @@ func AllVariantsEmpty(mapping map[string]DiscriminatorType) bool {
 	return true
 }
 
-// unionStrings returns the sorted union of two string slices with no duplicates.
-func unionStrings(a, b []string) []string {
-	seen := make(map[string]bool, len(a)+len(b))
-	for _, s := range a {
-		seen[s] = true
+// unionAttributeNames returns the sorted union of two AttributeName slices, deduplicating by APIName.
+func unionAttributeNames(a, b []AttributeName) []AttributeName {
+	seen := make(map[string]AttributeName, len(a)+len(b))
+	for _, n := range a {
+		seen[n.APIName] = n
 	}
-	for _, s := range b {
-		seen[s] = true
+	for _, n := range b {
+		seen[n.APIName] = n
 	}
-	result := make([]string, 0, len(seen))
-	for s := range seen {
-		result = append(result, s)
+	result := make([]AttributeName, 0, len(seen))
+	for _, n := range seen {
+		result = append(result, n)
 	}
-	sort.Strings(result)
+	sortAttributeNames(result)
 	return result
+}
+
+func sortAttributeNames(names []AttributeName) {
+	sort.Slice(names, func(i, j int) bool {
+		return names[i].TFSchemaName < names[j].TFSchemaName
+	})
 }

--- a/tools/codegen/codespec/discriminator_test.go
+++ b/tools/codegen/codespec/discriminator_test.go
@@ -10,7 +10,7 @@ import (
 func TestAllVariantsEmpty_AllEmpty(t *testing.T) {
 	mapping := map[string]codespec.DiscriminatorType{
 		"METRIC_A": {Allowed: nil},
-		"METRIC_B": {Allowed: []string{}},
+		"METRIC_B": {Allowed: []codespec.AttributeName{}},
 		"METRIC_C": {},
 	}
 	assert.True(t, codespec.AllVariantsEmpty(mapping))
@@ -23,11 +23,11 @@ func TestMergeDiscriminators_BothNil(t *testing.T) {
 
 func TestMergeDiscriminators_ExistingNilIncomingRequest(t *testing.T) {
 	incoming := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_a"},
-				Required: []string{"attr_a"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
 			},
 		},
 	}
@@ -37,28 +37,27 @@ func TestMergeDiscriminators_ExistingNilIncomingRequest(t *testing.T) {
 
 func TestMergeDiscriminators_ExistingNilIncomingResponse(t *testing.T) {
 	incoming := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_a", "computed_attr"},
-				Required: []string{"attr_a"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("computedAttr")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
 			},
 		},
 	}
 	result := codespec.MergeDiscriminators(nil, incoming, true)
-	// Response-only: required should be cleared
-	assert.Equal(t, "type", result.PropertyName)
-	assert.Equal(t, []string{"attr_a", "computed_attr"}, result.Mapping["TypeA"].Allowed)
+	assert.Equal(t, codespec.NewAttributeName("type").TFSchemaName, result.PropertyName.TFSchemaName)
+	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("computedAttr")}, result.Mapping["TypeA"].Allowed)
 	assert.Empty(t, result.Mapping["TypeA"].Required)
 }
 
 func TestMergeDiscriminators_IncomingNil(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_a"},
-				Required: []string{"attr_a"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
 			},
 		},
 	}
@@ -68,83 +67,79 @@ func TestMergeDiscriminators_IncomingNil(t *testing.T) {
 
 func TestMergeDiscriminators_MergeAllowedUnion(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_a", "attr_b"},
-				Required: []string{"attr_a"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
 			},
 		},
 	}
 	incoming := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_b", "attr_c"},
-				Required: []string{"attr_b"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrB"), codespec.NewAttributeName("attrC")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrB")},
 			},
 		},
 	}
 
-	// Incoming is from response: allowed = union, required = existing only
 	result := codespec.MergeDiscriminators(existing, incoming, true)
-	assert.Equal(t, []string{"attr_a", "attr_b", "attr_c"}, result.Mapping["TypeA"].Allowed)
-	assert.Equal(t, []string{"attr_a"}, result.Mapping["TypeA"].Required)
+	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB"), codespec.NewAttributeName("attrC")}, result.Mapping["TypeA"].Allowed)
+	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA")}, result.Mapping["TypeA"].Required)
 }
 
 func TestMergeDiscriminators_MergeRequiredFromRequest(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_a"},
-				Required: []string{"attr_a"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
 			},
 		},
 	}
 	incoming := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_a", "attr_b"},
-				Required: []string{"attr_a", "attr_b"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")},
 			},
 		},
 	}
 
-	// Incoming is from request: required = union of both
 	result := codespec.MergeDiscriminators(existing, incoming, false)
-	assert.Equal(t, []string{"attr_a", "attr_b"}, result.Mapping["TypeA"].Allowed)
-	assert.Equal(t, []string{"attr_a", "attr_b"}, result.Mapping["TypeA"].Required)
+	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")}, result.Mapping["TypeA"].Allowed)
+	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")}, result.Mapping["TypeA"].Required)
 }
 
 func TestMergeDiscriminators_NewVariantFromResponse(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []string{"attr_a"},
-				Required: []string{"attr_a"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
 			},
 		},
 	}
 	incoming := &codespec.Discriminator{
-		PropertyName: "type",
+		PropertyName: codespec.NewAttributeName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed: []string{"attr_a"},
+				Allowed: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
 			},
 			"TypeB": {
-				Allowed:  []string{"attr_b"},
-				Required: []string{"attr_b"},
+				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrB")},
+				Required: []codespec.AttributeName{codespec.NewAttributeName("attrB")},
 			},
 		},
 	}
 
 	result := codespec.MergeDiscriminators(existing, incoming, true)
-	// TypeA: required preserved from existing
-	assert.Equal(t, []string{"attr_a"}, result.Mapping["TypeA"].Required)
-	// TypeB: new from response, required should be empty
-	assert.Equal(t, []string{"attr_b"}, result.Mapping["TypeB"].Allowed)
+	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA")}, result.Mapping["TypeA"].Required)
+	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrB")}, result.Mapping["TypeB"].Allowed)
 	assert.Empty(t, result.Mapping["TypeB"].Required)
 }

--- a/tools/codegen/codespec/discriminator_test.go
+++ b/tools/codegen/codespec/discriminator_test.go
@@ -10,7 +10,7 @@ import (
 func TestAllVariantsEmpty_AllEmpty(t *testing.T) {
 	mapping := map[string]codespec.DiscriminatorType{
 		"METRIC_A": {Allowed: nil},
-		"METRIC_B": {Allowed: []codespec.AttributeName{}},
+		"METRIC_B": {Allowed: []codespec.DiscriminatorAttrName{}},
 		"METRIC_C": {},
 	}
 	assert.True(t, codespec.AllVariantsEmpty(mapping))
@@ -23,11 +23,11 @@ func TestMergeDiscriminators_BothNil(t *testing.T) {
 
 func TestMergeDiscriminators_ExistingNilIncomingRequest(t *testing.T) {
 	incoming := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
 			},
 		},
 	}
@@ -37,27 +37,27 @@ func TestMergeDiscriminators_ExistingNilIncomingRequest(t *testing.T) {
 
 func TestMergeDiscriminators_ExistingNilIncomingResponse(t *testing.T) {
 	incoming := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("computedAttr")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("computedAttr")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
 			},
 		},
 	}
 	result := codespec.MergeDiscriminators(nil, incoming, true)
-	assert.Equal(t, codespec.NewAttributeName("type").TFSchemaName, result.PropertyName.TFSchemaName)
-	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("computedAttr")}, result.Mapping["TypeA"].Allowed)
+	assert.Equal(t, codespec.NewDiscriminatorAttrName("type").TFSchemaName, result.PropertyName.TFSchemaName)
+	assert.Equal(t, []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("computedAttr")}, result.Mapping["TypeA"].Allowed)
 	assert.Empty(t, result.Mapping["TypeA"].Required)
 }
 
 func TestMergeDiscriminators_IncomingNil(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
 			},
 		},
 	}
@@ -67,79 +67,79 @@ func TestMergeDiscriminators_IncomingNil(t *testing.T) {
 
 func TestMergeDiscriminators_MergeAllowedUnion(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("attrB")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
 			},
 		},
 	}
 	incoming := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrB"), codespec.NewAttributeName("attrC")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrB")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrB"), codespec.NewDiscriminatorAttrName("attrC")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrB")},
 			},
 		},
 	}
 
 	result := codespec.MergeDiscriminators(existing, incoming, true)
-	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB"), codespec.NewAttributeName("attrC")}, result.Mapping["TypeA"].Allowed)
-	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA")}, result.Mapping["TypeA"].Required)
+	assert.Equal(t, []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("attrB"), codespec.NewDiscriminatorAttrName("attrC")}, result.Mapping["TypeA"].Allowed)
+	assert.Equal(t, []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")}, result.Mapping["TypeA"].Required)
 }
 
 func TestMergeDiscriminators_MergeRequiredFromRequest(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
 			},
 		},
 	}
 	incoming := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("attrB")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("attrB")},
 			},
 		},
 	}
 
 	result := codespec.MergeDiscriminators(existing, incoming, false)
-	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")}, result.Mapping["TypeA"].Allowed)
-	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA"), codespec.NewAttributeName("attrB")}, result.Mapping["TypeA"].Required)
+	assert.Equal(t, []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("attrB")}, result.Mapping["TypeA"].Allowed)
+	assert.Equal(t, []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA"), codespec.NewDiscriminatorAttrName("attrB")}, result.Mapping["TypeA"].Required)
 }
 
 func TestMergeDiscriminators_NewVariantFromResponse(t *testing.T) {
 	existing := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrA")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
 			},
 		},
 	}
 	incoming := &codespec.Discriminator{
-		PropertyName: codespec.NewAttributeName("type"),
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
 		Mapping: map[string]codespec.DiscriminatorType{
 			"TypeA": {
-				Allowed: []codespec.AttributeName{codespec.NewAttributeName("attrA")},
+				Allowed: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")},
 			},
 			"TypeB": {
-				Allowed:  []codespec.AttributeName{codespec.NewAttributeName("attrB")},
-				Required: []codespec.AttributeName{codespec.NewAttributeName("attrB")},
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrB")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrB")},
 			},
 		},
 	}
 
 	result := codespec.MergeDiscriminators(existing, incoming, true)
-	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrA")}, result.Mapping["TypeA"].Required)
-	assert.Equal(t, []codespec.AttributeName{codespec.NewAttributeName("attrB")}, result.Mapping["TypeB"].Allowed)
+	assert.Equal(t, []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")}, result.Mapping["TypeA"].Required)
+	assert.Equal(t, []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrB")}, result.Mapping["TypeB"].Allowed)
 	assert.Empty(t, result.Mapping["TypeB"].Required)
 }

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -100,23 +100,23 @@ type Schema struct {
 	Attributes Attributes `yaml:"attributes"`
 }
 
-// AttributeName pairs the original API property name with the Terraform schema name.
+// DiscriminatorAttrName pairs the original API property name with the Terraform schema name.
 // TFSchemaName will have aliasing configurations applied.
-type AttributeName struct {
+type DiscriminatorAttrName struct {
 	APIName      string `yaml:"api_name"`
 	TFSchemaName string `yaml:"tf_schema_name"`
 }
 
 type Discriminator struct {
 	Mapping      map[string]DiscriminatorType `yaml:"mapping"`
-	PropertyName AttributeName                `yaml:"property_name"`
+	PropertyName DiscriminatorAttrName        `yaml:"property_name"`
 }
 
 type DiscriminatorType struct {
 	// Allowed enumerates every sub-type specific attributes valid for this discriminator value.
-	Allowed []AttributeName `yaml:"allowed"`
+	Allowed []DiscriminatorAttrName `yaml:"allowed"`
 	// Required is a subset of Allowed that the user must explicitly set in their configuration.
-	Required []AttributeName `yaml:"required,omitempty"`
+	Required []DiscriminatorAttrName `yaml:"required,omitempty"`
 }
 
 type Attributes []Attribute

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -100,16 +100,23 @@ type Schema struct {
 	Attributes Attributes `yaml:"attributes"`
 }
 
+// AttributeName pairs the original API property name with the Terraform schema name.
+// TFSchemaName will have aliasing configurations applied.
+type AttributeName struct {
+	APIName      string `yaml:"api_name"`
+	TFSchemaName string `yaml:"tf_schema_name"`
+}
+
 type Discriminator struct {
 	Mapping      map[string]DiscriminatorType `yaml:"mapping"`
-	PropertyName string                       `yaml:"property_name"`
+	PropertyName AttributeName                `yaml:"property_name"`
 }
 
 type DiscriminatorType struct {
 	// Allowed enumerates every sub-type specific attributes valid for this discriminator value.
-	Allowed []string `yaml:"allowed"`
+	Allowed []AttributeName `yaml:"allowed"`
 	// Required is a subset of Allowed that the user must explicitly set in their configuration.
-	Required []string `yaml:"required,omitempty"`
+	Required []AttributeName `yaml:"required,omitempty"`
 }
 
 type Attributes []Attribute

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -1185,6 +1185,7 @@ resources:
           groupId: projectId
           alertConfigId: integrationId
           id: integrationId
+          results.id: integrationId 
         overrides:
           project_id:
             description: *project_id_description

--- a/tools/codegen/models/cluster_api.yaml
+++ b/tools/codegen/models/cluster_api.yaml
@@ -668,35 +668,59 @@ schema:
                                 mapping:
                                     AWS:
                                         allowed:
-                                            - analytics_auto_scaling
-                                            - analytics_specs
-                                            - auto_scaling
-                                            - effective_analytics_specs
-                                            - effective_electable_specs
-                                            - effective_read_only_specs
-                                            - read_only_specs
+                                            - api_name: analyticsAutoScaling
+                                              tf_schema_name: analytics_auto_scaling
+                                            - api_name: analyticsSpecs
+                                              tf_schema_name: analytics_specs
+                                            - api_name: autoScaling
+                                              tf_schema_name: auto_scaling
+                                            - api_name: effectiveAnalyticsSpecs
+                                              tf_schema_name: effective_analytics_specs
+                                            - api_name: effectiveElectableSpecs
+                                              tf_schema_name: effective_electable_specs
+                                            - api_name: effectiveReadOnlySpecs
+                                              tf_schema_name: effective_read_only_specs
+                                            - api_name: readOnlySpecs
+                                              tf_schema_name: read_only_specs
                                     AZURE:
                                         allowed:
-                                            - analytics_auto_scaling
-                                            - analytics_specs
-                                            - auto_scaling
-                                            - effective_analytics_specs
-                                            - effective_electable_specs
-                                            - effective_read_only_specs
-                                            - read_only_specs
+                                            - api_name: analyticsAutoScaling
+                                              tf_schema_name: analytics_auto_scaling
+                                            - api_name: analyticsSpecs
+                                              tf_schema_name: analytics_specs
+                                            - api_name: autoScaling
+                                              tf_schema_name: auto_scaling
+                                            - api_name: effectiveAnalyticsSpecs
+                                              tf_schema_name: effective_analytics_specs
+                                            - api_name: effectiveElectableSpecs
+                                              tf_schema_name: effective_electable_specs
+                                            - api_name: effectiveReadOnlySpecs
+                                              tf_schema_name: effective_read_only_specs
+                                            - api_name: readOnlySpecs
+                                              tf_schema_name: read_only_specs
                                     GCP:
                                         allowed:
-                                            - analytics_auto_scaling
-                                            - analytics_specs
-                                            - auto_scaling
-                                            - effective_analytics_specs
-                                            - effective_electable_specs
-                                            - effective_read_only_specs
-                                            - read_only_specs
+                                            - api_name: analyticsAutoScaling
+                                              tf_schema_name: analytics_auto_scaling
+                                            - api_name: analyticsSpecs
+                                              tf_schema_name: analytics_specs
+                                            - api_name: autoScaling
+                                              tf_schema_name: auto_scaling
+                                            - api_name: effectiveAnalyticsSpecs
+                                              tf_schema_name: effective_analytics_specs
+                                            - api_name: effectiveElectableSpecs
+                                              tf_schema_name: effective_electable_specs
+                                            - api_name: effectiveReadOnlySpecs
+                                              tf_schema_name: effective_read_only_specs
+                                            - api_name: readOnlySpecs
+                                              tf_schema_name: read_only_specs
                                     TENANT:
                                         allowed:
-                                            - backing_provider_name
-                                property_name: provider_name
+                                            - api_name: backingProviderName
+                                              tf_schema_name: backing_provider_name
+                                property_name:
+                                    api_name: providerName
+                                    tf_schema_name: provider_name
                             attributes:
                                 - single_nested:
                                     nested_object:

--- a/tools/codegen/models/cluster_old_api.yaml
+++ b/tools/codegen/models/cluster_old_api.yaml
@@ -670,26 +670,41 @@ schema:
                                 mapping:
                                     AWS:
                                         allowed:
-                                            - analytics_auto_scaling
-                                            - analytics_specs
-                                            - auto_scaling
-                                            - read_only_specs
+                                            - api_name: analyticsAutoScaling
+                                              tf_schema_name: analytics_auto_scaling
+                                            - api_name: analyticsSpecs
+                                              tf_schema_name: analytics_specs
+                                            - api_name: autoScaling
+                                              tf_schema_name: auto_scaling
+                                            - api_name: readOnlySpecs
+                                              tf_schema_name: read_only_specs
                                     AZURE:
                                         allowed:
-                                            - analytics_auto_scaling
-                                            - analytics_specs
-                                            - auto_scaling
-                                            - read_only_specs
+                                            - api_name: analyticsAutoScaling
+                                              tf_schema_name: analytics_auto_scaling
+                                            - api_name: analyticsSpecs
+                                              tf_schema_name: analytics_specs
+                                            - api_name: autoScaling
+                                              tf_schema_name: auto_scaling
+                                            - api_name: readOnlySpecs
+                                              tf_schema_name: read_only_specs
                                     GCP:
                                         allowed:
-                                            - analytics_auto_scaling
-                                            - analytics_specs
-                                            - auto_scaling
-                                            - read_only_specs
+                                            - api_name: analyticsAutoScaling
+                                              tf_schema_name: analytics_auto_scaling
+                                            - api_name: analyticsSpecs
+                                              tf_schema_name: analytics_specs
+                                            - api_name: autoScaling
+                                              tf_schema_name: auto_scaling
+                                            - api_name: readOnlySpecs
+                                              tf_schema_name: read_only_specs
                                     TENANT:
                                         allowed:
-                                            - backing_provider_name
-                                property_name: provider_name
+                                            - api_name: backingProviderName
+                                              tf_schema_name: backing_provider_name
+                                property_name:
+                                    api_name: providerName
+                                    tf_schema_name: provider_name
                             attributes:
                                 - single_nested:
                                     nested_object:

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -4,12 +4,19 @@ schema:
         mapping:
             S3_LOG_EXPORT:
                 allowed:
-                    - bucket_name
-                    - iam_role_id
-                    - kms_key
-                    - log_types
-                    - prefix_path
-        property_name: type
+                    - api_name: bucketName
+                      tf_schema_name: bucket_name
+                    - api_name: iamRoleId
+                      tf_schema_name: iam_role_id
+                    - api_name: kmsKey
+                      tf_schema_name: kms_key
+                    - api_name: logTypes
+                      tf_schema_name: log_types
+                    - api_name: prefixPath
+                      tf_schema_name: prefix_path
+        property_name:
+            api_name: type
+            tf_schema_name: type
     attributes:
         - string: {}
           description: Human-readable label that identifies the S3 bucket name for storing log files.
@@ -246,16 +253,26 @@ data_sources:
                         mapping:
                             S3_LOG_EXPORT:
                                 allowed:
-                                    - bucket_name
-                                    - iam_role_id
-                                    - kms_key
-                                    - log_types
-                                    - prefix_path
+                                    - api_name: bucketName
+                                      tf_schema_name: bucket_name
+                                    - api_name: iamRoleId
+                                      tf_schema_name: iam_role_id
+                                    - api_name: kmsKey
+                                      tf_schema_name: kms_key
+                                    - api_name: logTypes
+                                      tf_schema_name: log_types
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
                                 required:
-                                    - bucket_name
-                                    - iam_role_id
-                                    - prefix_path
-                        property_name: type
+                                    - api_name: bucketName
+                                      tf_schema_name: bucket_name
+                                    - api_name: iamRoleId
+                                      tf_schema_name: iam_role_id
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
+                        property_name:
+                            api_name: type
+                            tf_schema_name: type
                     attributes:
                         - string: {}
                           description: Human-readable label that identifies the S3 bucket name for storing log files.

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -4,11 +4,15 @@ schema:
         mapping:
             search:
                 allowed:
-                    - synonym_mapping_status
-                    - synonym_mapping_status_detail
+                    - api_name: synonymMappingStatus
+                      tf_schema_name: synonym_mapping_status
+                    - api_name: synonymMappingStatusDetail
+                      tf_schema_name: synonym_mapping_status_detail
             vectorSearch:
                 allowed: []
-        property_name: type
+        property_name:
+            api_name: type
+            tf_schema_name: type
     attributes:
         - string: {}
           description: Name of the cluster that contains the collection on which to create an Atlas Search index.

--- a/tools/codegen/models/stream_connection_api.yaml
+++ b/tools/codegen/models/stream_connection_api.yaml
@@ -11,8 +11,8 @@ schema:
                     - aws
             Cluster:
                 allowed:
-                    - cluster_group_id
                     - cluster_name
+                    - cluster_project_id
                     - db_role_to_execute
             Https:
                 allowed:
@@ -33,12 +33,12 @@ schema:
                 allowed: []
             SchemaRegistry:
                 allowed:
-                    - provider
                     - schema_registry_authentication
+                    - schema_registry_provider
                     - schema_registry_urls
                 required:
-                    - provider
                     - schema_registry_authentication
+                    - schema_registry_provider
                     - schema_registry_urls
         property_name: type
     attributes:

--- a/tools/codegen/models/stream_connection_api.yaml
+++ b/tools/codegen/models/stream_connection_api.yaml
@@ -4,43 +4,66 @@ schema:
         mapping:
             AWSKinesisDataStreams:
                 allowed:
-                    - aws
-                    - networking
+                    - api_name: aws
+                      tf_schema_name: aws
+                    - api_name: networking
+                      tf_schema_name: networking
             AWSLambda:
                 allowed:
-                    - aws
+                    - api_name: aws
+                      tf_schema_name: aws
             Cluster:
                 allowed:
-                    - cluster_name
-                    - cluster_project_id
-                    - db_role_to_execute
+                    - api_name: clusterName
+                      tf_schema_name: cluster_name
+                    - api_name: clusterGroupId
+                      tf_schema_name: cluster_project_id
+                    - api_name: dbRoleToExecute
+                      tf_schema_name: db_role_to_execute
             Https:
                 allowed:
-                    - headers
-                    - url
+                    - api_name: headers
+                      tf_schema_name: headers
+                    - api_name: url
+                      tf_schema_name: url
             Kafka:
                 allowed:
-                    - authentication
-                    - bootstrap_servers
-                    - config
-                    - networking
-                    - security
+                    - api_name: authentication
+                      tf_schema_name: authentication
+                    - api_name: bootstrapServers
+                      tf_schema_name: bootstrap_servers
+                    - api_name: config
+                      tf_schema_name: config
+                    - api_name: networking
+                      tf_schema_name: networking
+                    - api_name: security
+                      tf_schema_name: security
             S3:
                 allowed:
-                    - aws
-                    - networking
+                    - api_name: aws
+                      tf_schema_name: aws
+                    - api_name: networking
+                      tf_schema_name: networking
             Sample:
                 allowed: []
             SchemaRegistry:
                 allowed:
-                    - schema_registry_authentication
-                    - schema_registry_provider
-                    - schema_registry_urls
+                    - api_name: schemaRegistryAuthentication
+                      tf_schema_name: schema_registry_authentication
+                    - api_name: provider
+                      tf_schema_name: schema_registry_provider
+                    - api_name: schemaRegistryUrls
+                      tf_schema_name: schema_registry_urls
                 required:
-                    - schema_registry_authentication
-                    - schema_registry_provider
-                    - schema_registry_urls
-        property_name: type
+                    - api_name: schemaRegistryAuthentication
+                      tf_schema_name: schema_registry_authentication
+                    - api_name: provider
+                      tf_schema_name: schema_registry_provider
+                    - api_name: schemaRegistryUrls
+                      tf_schema_name: schema_registry_urls
+        property_name:
+            api_name: type
+            tf_schema_name: type
     attributes:
         - single_nested:
             nested_object:
@@ -458,12 +481,18 @@ schema:
                             allowed: []
                         USER_INFO:
                             allowed:
-                                - password
-                                - username
+                                - api_name: password
+                                  tf_schema_name: password
+                                - api_name: username
+                                  tf_schema_name: username
                             required:
-                                - password
-                                - username
-                    property_name: type
+                                - api_name: password
+                                  tf_schema_name: password
+                                - api_name: username
+                                  tf_schema_name: username
+                    property_name:
+                        api_name: type
+                        tf_schema_name: type
                 attributes:
                     - string: {}
                       description: Password or Private Key for authentication.

--- a/tools/codegen/models/stream_connection_api.yaml
+++ b/tools/codegen/models/stream_connection_api.yaml
@@ -379,8 +379,8 @@ schema:
                                 - string: {}
                                   description: Reserved. Will be used by PRIVATE_LINK connection type.
                                   computed_optional_required: optional
-                                  tf_schema_name: connection_name
-                                  tf_model_name: ConnectionName
+                                  tf_schema_name: name
+                                  tf_model_name: Name
                                   api_name: name
                                   req_body_usage: all_request_bodies
                                   sensitive: false

--- a/tools/codegen/models/stream_instance_api.yaml
+++ b/tools/codegen/models/stream_instance_api.yaml
@@ -7,43 +7,66 @@ schema:
                     mapping:
                         AWSKinesisDataStreams:
                             allowed:
-                                - aws
-                                - networking
+                                - api_name: aws
+                                  tf_schema_name: aws
+                                - api_name: networking
+                                  tf_schema_name: networking
                         AWSLambda:
                             allowed:
-                                - aws
+                                - api_name: aws
+                                  tf_schema_name: aws
                         Cluster:
                             allowed:
-                                - cluster_group_id
-                                - cluster_name
-                                - db_role_to_execute
+                                - api_name: clusterGroupId
+                                  tf_schema_name: cluster_group_id
+                                - api_name: clusterName
+                                  tf_schema_name: cluster_name
+                                - api_name: dbRoleToExecute
+                                  tf_schema_name: db_role_to_execute
                         Https:
                             allowed:
-                                - headers
-                                - url
+                                - api_name: headers
+                                  tf_schema_name: headers
+                                - api_name: url
+                                  tf_schema_name: url
                         Kafka:
                             allowed:
-                                - authentication
-                                - bootstrap_servers
-                                - config
-                                - networking
-                                - security
+                                - api_name: authentication
+                                  tf_schema_name: authentication
+                                - api_name: bootstrapServers
+                                  tf_schema_name: bootstrap_servers
+                                - api_name: config
+                                  tf_schema_name: config
+                                - api_name: networking
+                                  tf_schema_name: networking
+                                - api_name: security
+                                  tf_schema_name: security
                         S3:
                             allowed:
-                                - aws
-                                - networking
+                                - api_name: aws
+                                  tf_schema_name: aws
+                                - api_name: networking
+                                  tf_schema_name: networking
                         Sample:
                             allowed: []
                         SchemaRegistry:
                             allowed:
-                                - provider
-                                - schema_registry_authentication
-                                - schema_registry_urls
+                                - api_name: provider
+                                  tf_schema_name: provider
+                                - api_name: schemaRegistryAuthentication
+                                  tf_schema_name: schema_registry_authentication
+                                - api_name: schemaRegistryUrls
+                                  tf_schema_name: schema_registry_urls
                             required:
-                                - provider
-                                - schema_registry_authentication
-                                - schema_registry_urls
-                    property_name: type
+                                - api_name: provider
+                                  tf_schema_name: provider
+                                - api_name: schemaRegistryAuthentication
+                                  tf_schema_name: schema_registry_authentication
+                                - api_name: schemaRegistryUrls
+                                  tf_schema_name: schema_registry_urls
+                    property_name:
+                        api_name: type
+                        tf_schema_name: type
                 attributes:
                     - single_nested:
                         nested_object:
@@ -450,12 +473,18 @@ schema:
                                         allowed: []
                                     USER_INFO:
                                         allowed:
-                                            - password
-                                            - username
+                                            - api_name: password
+                                              tf_schema_name: password
+                                            - api_name: username
+                                              tf_schema_name: username
                                         required:
-                                            - password
-                                            - username
-                                property_name: type
+                                            - api_name: password
+                                              tf_schema_name: password
+                                            - api_name: username
+                                              tf_schema_name: username
+                                property_name:
+                                    api_name: type
+                                    tf_schema_name: type
                             attributes:
                                 - string: {}
                                   description: Password or Private Key for authentication.


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-379812 (follow up from https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4165)

### Relevant changes:

- New applyAliasesToDiscriminators() function walks the schema tree after attribute transformations are applied and renames `discriminator` PropertyName and variant Allowed/Required entries to match any configured aliases. Supports both root-level and path-based nested aliases.
- Opportunistic refactor: Remove implicit root-level aliases propagating to nested-level attributes. Previously, non-dotted aliases (e.g. `name: connectionName`) applied at every nesting level. This was problematic because it could silently rename unrelated nested fields that happened to share a name with a root-level alias, while also introducing more complexity in the implementation. Now aliases are strictly path-scoped: a non-dotted alias like groupId: projectId only matches at root level (where apiPath == "groupId"), while nested attributes require an explicit dotted alias (e.g., results.id: integrationId). This aligns applyAliasesToDiscriminator with the same deterministic lookup pattern.
- Modify discriminator model to preserve orginal API Name values (camel case). This enables simplifying aliasing logic while keeping traceability of original names.

### Testing

Added unit testing for existing aliasing logic (we did not have before).

## Type of change: 

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
