### PR TITLE
chore: Add missing log integration tests to autogen fast job

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -630,12 +630,14 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_KMS_KEY_ID: ${{ secrets.aws_kms_key_id }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/serviceapi/alertconfigurationapi
             ./internal/serviceapi/auditingapi
             ./internal/serviceapi/customdbroleapi
             ./internal/serviceapi/databaseuserapi
+            ./internal/serviceapi/logintegration
             ./internal/serviceapi/maintenancewindowapi
             ./internal/serviceapi/projectapi
             ./internal/serviceapi/projectsettingsapi

--- a/internal/serviceapi/logintegration/resource_test.go
+++ b/internal/serviceapi/logintegration/resource_test.go
@@ -167,7 +167,7 @@ func awsIAMRoleAuthAndS3Config(projectID string, config *s3Config) string {
 		}
 
 		resource "aws_iam_role" "test_role" {
-		    name = %[1]q
+		    name = %[3]q
 		    max_session_duration = 43200
 
 		    assume_role_policy = <<-EOF
@@ -242,7 +242,7 @@ func awsIAMRoleAuthAndS3Config(projectID string, config *s3Config) string {
 				}
 				EOF
 		}
-	`, projectID, config.bucketName, config.iamRoleName, config.iamRolePolicyName, config.bucketName)
+	`, projectID, config.bucketName, config.iamRoleName, config.iamRolePolicyName, config.bucketPolicyName)
 }
 
 func checkExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

Log integration tests are not currently running due to missing package in autogen_fast job. 

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
