### PR TITLE
fix: Fix provider error in `mongodbatlas_cloud_user_org_assignment`

### DIFF
--- a/internal/service/clouduserorgassignment/resource.go
+++ b/internal/service/clouduserorgassignment/resource.go
@@ -109,7 +109,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("error fetching user(%s) from OrgID(%s):", userErrorDisplay, orgID), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("error fetching user(%s) from OrgID(%s)", userErrorDisplay, orgID), err.Error())
 		return
 	}
 

--- a/internal/service/clouduserorgassignment/resource.go
+++ b/internal/service/clouduserorgassignment/resource.go
@@ -81,9 +81,11 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	var userResp *admin.OrgUserResponse
 	var httpResp *http.Response
 	var err error
+	var userErrorDisplay string
 
 	if !state.UserId.IsNull() && state.UserId.ValueString() != "" {
 		userID := state.UserId.ValueString()
+		userErrorDisplay = userID
 		userResp, httpResp, err = connV2.MongoDBCloudUsersApi.GetOrgUser(ctx, orgID, userID).Execute()
 		if validate.StatusNotFound(httpResp) {
 			resp.State.RemoveResource(ctx)
@@ -91,6 +93,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 		}
 	} else if !state.Username.IsNull() && state.Username.ValueString() != "" { // required for import
 		username := state.Username.ValueString()
+		userErrorDisplay = username
 		params := &admin.ListOrgUsersApiParams{
 			OrgId:    orgID,
 			Username: &username,
@@ -106,7 +109,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("error fetching user(%s) from OrgID(%s):", userResp.Username, orgID), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("error fetching user(%s) from OrgID(%s):", userErrorDisplay, orgID), err.Error())
 		return
 	}
 


### PR DESCRIPTION
## Description

Fix provider error in `mongodbatlas_cloud_user_org_assignment`. `userResp` might be nil if there is an error.


This is to fix the issue in HELP-89165

```
{{panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=0x10195e5ec]

goroutine 52 [running]:
github.com/mongodb/terraform-provider-mongodbatlas/internal/service/clouduserorgassignment.(*rs).Read(0x1400098aa50, {0x102510ba8, 0x140006f6570}, {{{0x10
2519520, 0x140006e9f20}, {0x10212dee0, 0x140006e9a10}}, {0x10251fb10, 0x14000a12140}}, 0x0, ...}, ...)
github.com/mongodb/terraform-provider-mongodbatlas/internal/service/clouduserorgassignment/resource.go:109 +0x3fc
github.com/mongodb/terraform-provider-mongodbatlas/internal/config.(*RSCommon).Read(0x14000a0b440, {0x102510ba8, 0x14000a0b3e0}, {{{0x102519520, 0x140006e
9f20}, {0x10212dee0, 0x140006e9a10}}, {0x10251fb10, 0x14000a12140}}, 0x0, ...}, ...)
github.com/mongodb/terraform-provider-mongodbatlas/internal/config/resource_base.go:97 +0x100
github.com/hashicorp/ter}}
```

Link to any related issue(s): CLOUDP-382080

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
