### PR TITLE
chore: Fix err shadow in `mongodbatlas_cloud_user_org_assignment`

### DIFF
--- a/internal/service/clouduserorgassignment/resource.go
+++ b/internal/service/clouduserorgassignment/resource.go
@@ -98,13 +98,14 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 			OrgId:    orgID,
 			Username: &username,
 		}
-		usersResp, _, err := connV2.MongoDBCloudUsersApi.ListOrgUsersWithParams(ctx, params).Execute()
-		if err == nil && usersResp != nil && usersResp.Results != nil {
-			if len(*usersResp.Results) == 0 {
+		var usersResp *admin.PaginatedOrgUser
+		usersResp, _, err = connV2.MongoDBCloudUsersApi.ListOrgUsersWithParams(ctx, params).Execute()
+		if err == nil {
+			if len(usersResp.GetResults()) == 0 {
 				resp.State.RemoveResource(ctx)
 				return
 			}
-			userResp = &(*usersResp.Results)[0]
+			userResp = &usersResp.GetResults()[0]
 		}
 	}
 


### PR DESCRIPTION
## Description

Fix err shadow in `mongodbatlas_cloud_user_org_assignment`. This is a follow-up to https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4182

Although this is not the error in HELP-89165, it's incorrect and could cause some problems. The main issue is that `err` is shadowed in the if scope so the external `err` is always nil if going that branch.   Also results len check is simplified.

Link to any related issue(s): CLOUDP-382080

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
