### PR TITLE
chore: Add log_integrations GCS acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -208,6 +208,12 @@ on:
         required: true
       slack_webhook_url_stream:
         required: true
+      gcp_project_id:
+        required: true
+      gcp_workload_identity_provider:
+        required: true
+      gcp_service_account_email:
+        required: true
 
 env:
   TF_ACC: 1
@@ -611,7 +617,9 @@ jobs:
       group: ${{ github.repository }}-resource-policy-concurrency
     if: ${{ needs.change-detection.outputs.autogen_fast == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_fast' }}
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -623,6 +631,10 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ secrets.gcp_workload_identity_provider }}
+          service_account: ${{ secrets.gcp_service_account_email }}
       - name: Enable autogen
         run: make tools enable-autogen
       - name: Acceptance Tests
@@ -637,6 +649,7 @@ jobs:
           AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
           AZURE_ATLAS_APP_ID: ${{ inputs.azure_atlas_app_id }}
           AZURE_SERVICE_PRINCIPAL_ID: ${{ inputs.azure_service_principal_id }}
+          GCP_PROJECT_ID: ${{ secrets.gcp_project_id }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/serviceapi/alertconfigurationapi

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -119,6 +119,9 @@ jobs:
       slack_oncall_tag: ${{ secrets.SLACK_ONCALL_TAG }}
       slack_oncall_tag_stream: ${{ secrets.SLACK_ONCALL_TAG_STREAM }}
       slack_webhook_url_stream: ${{ secrets.SLACK_WEBHOOK_URL_STREAM }}
+      gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+      gcp_workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
     with:
       terraform_version: ${{ inputs.terraform_version || '1.14.x' }}

--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -87,7 +87,7 @@ func TestMigEncryptionAtRest_basicGCP(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheck(t); acc.PreCheckGCPEnv(t) },
+		PreCheck:     func() { mig.PreCheck(t); acc.PreCheckEncryptionAtRestEnvGCP(t) },
 		CheckDestroy: acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -176,7 +176,7 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckGCPEnv(t) },
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckEncryptionAtRestEnvGCP(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.EARDestroy,
 		Steps: []resource.TestStep{

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -148,7 +148,7 @@ func PreCheckPublicKey2(tb testing.TB) {
 	}
 }
 
-func PreCheckGCPEnv(tb testing.TB) {
+func PreCheckEncryptionAtRestEnvGCP(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("GCP_SERVICE_ACCOUNT_KEY") == "" || os.Getenv("GCP_KEY_VERSION_RESOURCE_ID") == "" {
 		tb.Fatal("`GCP_SERVICE_ACCOUNT_KEY` and `GCP_KEY_VERSION_RESOURCE_ID` must be set for acceptance testing")
@@ -219,6 +219,13 @@ func PreCheckEncryptionAtRestEnvAzureWithUpdate(tb testing.TB) {
 		'AZURE_RESOURCE_GROUP_NAME', 'AZURE_APP_SECRET',
 		, 'AZURE_KEY_VAULT_NAME', 'AZURE_KEY_IDENTIFIER', 'AZURE_KEY_VAULT_NAME_UPDATED',
 		'AZURE_KEY_IDENTIFIER_UPDATED', and 'AZURE_TENANT_ID' must be set for Encryption At Rest acceptance testing`)
+	}
+}
+
+func PreCheckGCPEnvBasic(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("GCP_PROJECT_ID") == "" {
+		tb.Fatal(`'GCP_PROJECT_ID' must be set for acceptance testing`)
 	}
 }
 

--- a/internal/testutil/acc/provider.go
+++ b/internal/testutil/acc/provider.go
@@ -11,6 +11,7 @@ const AwsProviderVersion = "5.1.0"
 const azurermProviderVersion = "4.60.0"
 const azapiProviderVersion = "1.15.0"
 const confluentProviderVersion = "2.12.0"
+const googleProviderVersion = "7.0.0"
 
 func ExternalProviders(versionAtlasProvider string) map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
@@ -56,6 +57,12 @@ func ExternalProvidersOnlyConfluent() map[string]resource.ExternalProvider {
 	}
 }
 
+func ExternalProvidersOnlyGoogle() map[string]resource.ExternalProvider {
+	return map[string]resource.ExternalProvider{
+		"google": *providerGoogle(),
+	}
+}
+
 func providerAtlas(versionAtlasProvider string) *resource.ExternalProvider {
 	return &resource.ExternalProvider{
 		VersionConstraint: versionAtlasProvider,
@@ -88,6 +95,13 @@ func providerConfluent() *resource.ExternalProvider {
 	return &resource.ExternalProvider{
 		VersionConstraint: confluentProviderVersion,
 		Source:            "confluentinc/confluent",
+	}
+}
+
+func providerGoogle() *resource.ExternalProvider {
+	return &resource.ExternalProvider{
+		VersionConstraint: googleProviderVersion,
+		Source:            "hashicorp/google",
 	}
 }
 
@@ -142,4 +156,12 @@ func ConfigAzurermProvider(subscriptionID, clientID, clientSecret, tenantID stri
 
 func ConfigConfluentProvider() string {
 	return `provider "confluent" {}`
+}
+
+func ConfigGoogleProvider(projectID string) string {
+	return fmt.Sprintf(`
+		provider "google" {
+			project = %[1]q
+		}
+	`, projectID)
 }


### PR DESCRIPTION
## Description

Add acceptance tests for log_integration with GCS.
- I am enabling GCP support in gh actions in this repo as part of this, so we can now run acceptance tests that require GCP setup

Link to any related issue(s): CLOUDP-381529

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
