### PR TITLE
test: Update test to use unique names for connection deletion

### DIFF
--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -337,7 +337,6 @@ func (r *streamConnectionRS) ImportState(ctx context.Context, req resource.Impor
 		resp.Diagnostics.AddError("error splitting stream connection import ID", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("instance_name"), workspaceName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_name"), workspaceName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), projectID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connection_name"), connectionName)...)

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -272,7 +272,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 				),
 			},
 			{
-				Config:      networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-ssl-2", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config:      networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				ExpectError: regexp.MustCompile("STREAM_NETWORKING_CANNOT_BE_MODIFIED"),
 			},
 			{

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -272,7 +272,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 				),
 			},
 			{
-				Config:      networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config:      networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-ssl-2", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				ExpectError: regexp.MustCompile("STREAM_NETWORKING_CANNOT_BE_MODIFIED"),
 			},
 			{


### PR DESCRIPTION
## Description

When testing connection deletion, parallel tests are trying to access the same connection by name which is causing an error. 
Use a unique connection name for each test. 

Link to any related issue(s):
https://jira.mongodb.org/browse/CLOUDP-382174
https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/22081797092

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments



Current Errors:

```
Error: -17T01:05:30.157Z [ERROR] sdk.proto: Response contains error diagnostic: tf_req_id=ae8d0c11-cfaa-abd0-5c88-20d6859d9882 tf_provider_addr=registry.terraform.io/hashicorp/mongodbatlas tf_proto_version=6.10 tf_rpc=ValidateResourceConfig tf_resource_type=mongodbatlas_stream_connection diagnostic_summary="Invalid Attribute Combination" diagnostic_detail="Attribute \"workspace_name\" cannot be specified when \"instance_name\" is specified" diagnostic_severity=ERROR diagnostic_attribute="AttributeName(\"instance_name\")"
Error: -17T01:05:30.170Z [ERROR] sdk.proto: Response contains error diagnostic: tf_req_id=ae8d0c11-cfaa-abd0-5c88-20d6859d9882 tf_provider_addr=registry.terraform.io/hashicorp/mongodbatlas tf_resource_type=mongodbatlas_stream_connection diagnostic_summary="Invalid Attribute Combination" diagnostic_attribute="AttributeName(\"workspace_name\")" tf_proto_version=6.10 tf_rpc=ValidateResourceConfig diagnostic_detail="Attribute \"instance_name\" cannot be specified when \"workspace_name\" is specified" diagnostic_severity=ERROR
```

```
Error: -17T01:05:45.949Z [ERROR] sdk.proto: Response contains error diagnostic: tf_resource_type=mongodbatlas_stream_connection diagnostic_severity=ERROR diagnostic_summary="error waiting for stream connection to be ready" diagnostic_detail="couldn't find resource (4 retries)" tf_req_id=e75317b5-ba55-9ee6-d2fa-78fb0210425e tf_provider_addr=registry.terraform.io/hashicorp/mongodbatlas tf_proto_version=6.10 tf_rpc=ApplyResourceChange
Error: -17T01:05:45.955Z [ERROR] sdk.helper_resource: Unexpected error: test_working_directory=/tmp/plugintest3612633145 test_step_number=1
```