### PR TITLE
chore: Update log_integration with new Azure schema

### DIFF
--- a/docs/data-sources/log_integration.md
+++ b/docs/data-sources/log_integration.md
@@ -79,11 +79,10 @@ output "log_integrations_results" {
 - `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
 - `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
 - `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
-- `role_id` (String) Unique 24-character hexadecimal string that identifies the GCP service account role.
-- `service_principal_id` (String) Unique 24-character hexadecimal string that identifies the Service Principal.
+- `role_id` (String) Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
 - `storage_account_name` (String) Storage account name where logs will be stored.
 - `storage_container_name` (String) Storage container name for log files.
-- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
 
 <a id="nestedatt--otel_supplied_headers"></a>
 ### Nested Schema for `otel_supplied_headers`

--- a/docs/data-sources/log_integrations.md
+++ b/docs/data-sources/log_integrations.md
@@ -90,11 +90,10 @@ Read-Only:
 - `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--results--otel_supplied_headers))
 - `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
 - `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
-- `role_id` (String) Unique 24-character hexadecimal string that identifies the GCP service account role.
-- `service_principal_id` (String) Unique 24-character hexadecimal string that identifies the Service Principal.
+- `role_id` (String) Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
 - `storage_account_name` (String) Storage account name where logs will be stored.
 - `storage_container_name` (String) Storage container name for log files.
-- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
 
 <a id="nestedatt--results--otel_supplied_headers"></a>
 ### Nested Schema for `results.otel_supplied_headers`

--- a/docs/resources/log_integration.md
+++ b/docs/resources/log_integration.md
@@ -66,7 +66,7 @@ output "log_integrations_results" {
 
 - `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project.
-- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+- `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
 
 ### Optional
 
@@ -80,8 +80,7 @@ output "log_integrations_results" {
 - `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
 - `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
 - `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
-- `role_id` (String) Unique 24-character hexadecimal string that identifies the GCP service account role.
-- `service_principal_id` (String) Unique 24-character hexadecimal string that identifies the Service Principal.
+- `role_id` (String) Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
 - `storage_account_name` (String) Storage account name where logs will be stored.
 - `storage_container_name` (String) Storage container name for log files.
 

--- a/internal/serviceapi/logintegration/data_source_schema.go
+++ b/internal/serviceapi/logintegration/data_source_schema.go
@@ -87,11 +87,7 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"role_id": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the GCP service account role.",
-			},
-			"service_principal_id": dsschema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Service Principal.",
+				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
 			},
 			"storage_account_name": dsschema.StringAttribute{
 				Computed:            true,
@@ -103,7 +99,7 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"type": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.",
+				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.",
 			},
 		},
 	}
@@ -124,7 +120,6 @@ type TFDSModel struct {
 	ProjectId            types.String                                              `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
 	Region               types.String                                              `tfsdk:"region" autogen:"omitjson"`
 	RoleId               types.String                                              `tfsdk:"role_id" autogen:"omitjson"`
-	ServicePrincipalId   types.String                                              `tfsdk:"service_principal_id" autogen:"omitjson"`
 	StorageAccountName   types.String                                              `tfsdk:"storage_account_name" autogen:"omitjson"`
 	StorageContainerName types.String                                              `tfsdk:"storage_container_name" autogen:"omitjson"`
 	Type                 types.String                                              `tfsdk:"type" autogen:"omitjson"`

--- a/internal/serviceapi/logintegration/plural_data_source_schema.go
+++ b/internal/serviceapi/logintegration/plural_data_source_schema.go
@@ -97,11 +97,7 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"role_id": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Unique 24-character hexadecimal string that identifies the GCP service account role.",
-						},
-						"service_principal_id": dsschema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Service Principal.",
+							MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
 						},
 						"storage_account_name": dsschema.StringAttribute{
 							Computed:            true,
@@ -113,7 +109,7 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"type": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.",
+							MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.",
 						},
 					},
 				},
@@ -141,7 +137,6 @@ type TFPluralDSResultsModel struct {
 	PrefixPath           types.String                                                           `tfsdk:"prefix_path" autogen:"omitjson"`
 	Region               types.String                                                           `tfsdk:"region" autogen:"omitjson"`
 	RoleId               types.String                                                           `tfsdk:"role_id" autogen:"omitjson"`
-	ServicePrincipalId   types.String                                                           `tfsdk:"service_principal_id" autogen:"omitjson"`
 	StorageAccountName   types.String                                                           `tfsdk:"storage_account_name" autogen:"omitjson"`
 	StorageContainerName types.String                                                           `tfsdk:"storage_container_name" autogen:"omitjson"`
 	Type                 types.String                                                           `tfsdk:"type" autogen:"omitjson"`

--- a/internal/serviceapi/logintegration/resource_schema.go
+++ b/internal/serviceapi/logintegration/resource_schema.go
@@ -91,11 +91,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"role_id": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the GCP service account role.",
-			},
-			"service_principal_id": schema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Service Principal.",
+				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
 			},
 			"storage_account_name": schema.StringAttribute{
 				Optional:            true,
@@ -107,7 +103,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"type": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.",
+				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.",
 			},
 		},
 	}
@@ -128,7 +124,6 @@ type TFModel struct {
 	PrefixPath           types.String                                            `tfsdk:"prefix_path"`
 	Region               types.String                                            `tfsdk:"region"`
 	RoleId               types.String                                            `tfsdk:"role_id"`
-	ServicePrincipalId   types.String                                            `tfsdk:"service_principal_id"`
 	StorageAccountName   types.String                                            `tfsdk:"storage_account_name"`
 	StorageContainerName types.String                                            `tfsdk:"storage_container_name"`
 	Type                 types.String                                            `tfsdk:"type"`

--- a/internal/serviceapi/logintegration/resource_test.go
+++ b/internal/serviceapi/logintegration/resource_test.go
@@ -240,13 +240,13 @@ func configBasicAzure(projectID string, logTypes []string, config *azureConfig, 
 		%[2]s
 
 		resource "mongodbatlas_log_integration" "test" {
-			project_id  = %[3]q
-		    type        = "AZURE_LOG_EXPORT"
-			log_types   = %[4]s
-		    service_principal_id   = mongodbatlas_cloud_provider_access_authorization.azure_auth.role_id
+			project_id             = %[3]q
+		    type                   = "AZURE_LOG_EXPORT"
+			log_types              = %[4]s
+		    role_id                = mongodbatlas_cloud_provider_access_authorization.azure_auth.role_id
 		    storage_account_name   = azurerm_storage_account.log_storage.name
 		    storage_container_name = azurerm_storage_container.log_container.name
-			prefix_path = %[5]q
+			prefix_path            = %[5]q
 		}
 
 		%[6]s
@@ -258,7 +258,7 @@ func configBasicAzure(projectID string, logTypes []string, config *azureConfig, 
 }
 
 func checkBasicAzure(logTypes []string, config *azureConfig, withDS bool) resource.TestCheckFunc {
-	setChecks := []string{"integration_id", "service_principal_id", "storage_account_name"}
+	setChecks := []string{"integration_id", "role_id", "storage_account_name"}
 	mapChecks := map[string]string{
 		"storage_container_name": config.storageContainerName,
 		"prefix_path":            config.prefixPath,

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -4,56 +4,91 @@ schema:
         mapping:
             AZURE_LOG_EXPORT:
                 allowed:
-                    - prefix_path
-                    - service_principal_id
-                    - storage_account_name
-                    - storage_container_name
+                    - api_name: prefixPath
+                      tf_schema_name: prefix_path
+                    - api_name: roleId
+                      tf_schema_name: role_id
+                    - api_name: storageAccountName
+                      tf_schema_name: storage_account_name
+                    - api_name: storageContainerName
+                      tf_schema_name: storage_container_name
                 required:
-                    - prefix_path
-                    - service_principal_id
-                    - storage_account_name
-                    - storage_container_name
+                    - api_name: prefixPath
+                      tf_schema_name: prefix_path
+                    - api_name: roleId
+                      tf_schema_name: role_id
+                    - api_name: storageAccountName
+                      tf_schema_name: storage_account_name
+                    - api_name: storageContainerName
+                      tf_schema_name: storage_container_name
             DATADOG_LOG_EXPORT:
                 allowed:
-                    - api_key
-                    - region
+                    - api_name: apiKey
+                      tf_schema_name: api_key
+                    - api_name: region
+                      tf_schema_name: region
                 required:
-                    - api_key
-                    - region
+                    - api_name: apiKey
+                      tf_schema_name: api_key
+                    - api_name: region
+                      tf_schema_name: region
             GCS_LOG_EXPORT:
                 allowed:
-                    - bucket_name
-                    - prefix_path
-                    - role_id
+                    - api_name: bucketName
+                      tf_schema_name: bucket_name
+                    - api_name: prefixPath
+                      tf_schema_name: prefix_path
+                    - api_name: roleId
+                      tf_schema_name: role_id
                 required:
-                    - bucket_name
-                    - prefix_path
-                    - role_id
+                    - api_name: bucketName
+                      tf_schema_name: bucket_name
+                    - api_name: prefixPath
+                      tf_schema_name: prefix_path
+                    - api_name: roleId
+                      tf_schema_name: role_id
             OTEL_LOG_EXPORT:
                 allowed:
-                    - otel_endpoint
-                    - otel_supplied_headers
+                    - api_name: otelEndpoint
+                      tf_schema_name: otel_endpoint
+                    - api_name: otelSuppliedHeaders
+                      tf_schema_name: otel_supplied_headers
                 required:
-                    - otel_endpoint
-                    - otel_supplied_headers
+                    - api_name: otelEndpoint
+                      tf_schema_name: otel_endpoint
+                    - api_name: otelSuppliedHeaders
+                      tf_schema_name: otel_supplied_headers
             S3_LOG_EXPORT:
                 allowed:
-                    - bucket_name
-                    - iam_role_id
-                    - kms_key
-                    - prefix_path
+                    - api_name: bucketName
+                      tf_schema_name: bucket_name
+                    - api_name: iamRoleId
+                      tf_schema_name: iam_role_id
+                    - api_name: kmsKey
+                      tf_schema_name: kms_key
+                    - api_name: prefixPath
+                      tf_schema_name: prefix_path
                 required:
-                    - bucket_name
-                    - iam_role_id
-                    - prefix_path
+                    - api_name: bucketName
+                      tf_schema_name: bucket_name
+                    - api_name: iamRoleId
+                      tf_schema_name: iam_role_id
+                    - api_name: prefixPath
+                      tf_schema_name: prefix_path
             SPLUNK_LOG_EXPORT:
                 allowed:
-                    - hec_token
-                    - hec_url
+                    - api_name: hecToken
+                      tf_schema_name: hec_token
+                    - api_name: hecUrl
+                      tf_schema_name: hec_url
                 required:
-                    - hec_token
-                    - hec_url
-        property_name: type
+                    - api_name: hecToken
+                      tf_schema_name: hec_token
+                    - api_name: hecUrl
+                      tf_schema_name: hec_url
+        property_name:
+            api_name: type
+            tf_schema_name: type
     attributes:
         - string: {}
           description: API key for authentication.
@@ -234,22 +269,11 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Unique 24-character hexadecimal string that identifies the GCP service account role.
+          description: Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
           computed_optional_required: optional
           tf_schema_name: role_id
           tf_model_name: RoleId
           api_name: roleId
-          req_body_usage: all_request_bodies
-          sensitive: false
-          create_only: false
-          present_in_any_response: true
-          request_only_required_on_create: false
-        - string: {}
-          description: Unique 24-character hexadecimal string that identifies the Service Principal.
-          computed_optional_required: optional
-          tf_schema_name: service_principal_id
-          tf_model_name: ServicePrincipalId
-          api_name: servicePrincipalId
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
@@ -278,7 +302,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+          description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
           computed_optional_required: required
           tf_schema_name: type
           tf_model_name: Type
@@ -484,22 +508,11 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Unique 24-character hexadecimal string that identifies the GCP service account role.
+              description: Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
               computed_optional_required: computed
               tf_schema_name: role_id
               tf_model_name: RoleId
               api_name: roleId
-              req_body_usage: omit_always
-              sensitive: false
-              create_only: false
-              present_in_any_response: false
-              request_only_required_on_create: false
-            - string: {}
-              description: Unique 24-character hexadecimal string that identifies the Service Principal.
-              computed_optional_required: computed
-              tf_schema_name: service_principal_id
-              tf_model_name: ServicePrincipalId
-              api_name: servicePrincipalId
               req_body_usage: omit_always
               sensitive: false
               create_only: false
@@ -528,7 +541,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+              description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
               computed_optional_required: computed
               tf_schema_name: type
               tf_model_name: Type
@@ -568,56 +581,91 @@ data_sources:
                         mapping:
                             AZURE_LOG_EXPORT:
                                 allowed:
-                                    - prefix_path
-                                    - service_principal_id
-                                    - storage_account_name
-                                    - storage_container_name
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
+                                    - api_name: roleId
+                                      tf_schema_name: role_id
+                                    - api_name: storageAccountName
+                                      tf_schema_name: storage_account_name
+                                    - api_name: storageContainerName
+                                      tf_schema_name: storage_container_name
                                 required:
-                                    - prefix_path
-                                    - service_principal_id
-                                    - storage_account_name
-                                    - storage_container_name
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
+                                    - api_name: roleId
+                                      tf_schema_name: role_id
+                                    - api_name: storageAccountName
+                                      tf_schema_name: storage_account_name
+                                    - api_name: storageContainerName
+                                      tf_schema_name: storage_container_name
                             DATADOG_LOG_EXPORT:
                                 allowed:
-                                    - api_key
-                                    - region
+                                    - api_name: apiKey
+                                      tf_schema_name: api_key
+                                    - api_name: region
+                                      tf_schema_name: region
                                 required:
-                                    - api_key
-                                    - region
+                                    - api_name: apiKey
+                                      tf_schema_name: api_key
+                                    - api_name: region
+                                      tf_schema_name: region
                             GCS_LOG_EXPORT:
                                 allowed:
-                                    - bucket_name
-                                    - prefix_path
-                                    - role_id
+                                    - api_name: bucketName
+                                      tf_schema_name: bucket_name
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
+                                    - api_name: roleId
+                                      tf_schema_name: role_id
                                 required:
-                                    - bucket_name
-                                    - prefix_path
-                                    - role_id
+                                    - api_name: bucketName
+                                      tf_schema_name: bucket_name
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
+                                    - api_name: roleId
+                                      tf_schema_name: role_id
                             OTEL_LOG_EXPORT:
                                 allowed:
-                                    - otel_endpoint
-                                    - otel_supplied_headers
+                                    - api_name: otelEndpoint
+                                      tf_schema_name: otel_endpoint
+                                    - api_name: otelSuppliedHeaders
+                                      tf_schema_name: otel_supplied_headers
                                 required:
-                                    - otel_endpoint
-                                    - otel_supplied_headers
+                                    - api_name: otelEndpoint
+                                      tf_schema_name: otel_endpoint
+                                    - api_name: otelSuppliedHeaders
+                                      tf_schema_name: otel_supplied_headers
                             S3_LOG_EXPORT:
                                 allowed:
-                                    - bucket_name
-                                    - iam_role_id
-                                    - kms_key
-                                    - prefix_path
+                                    - api_name: bucketName
+                                      tf_schema_name: bucket_name
+                                    - api_name: iamRoleId
+                                      tf_schema_name: iam_role_id
+                                    - api_name: kmsKey
+                                      tf_schema_name: kms_key
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
                                 required:
-                                    - bucket_name
-                                    - iam_role_id
-                                    - prefix_path
+                                    - api_name: bucketName
+                                      tf_schema_name: bucket_name
+                                    - api_name: iamRoleId
+                                      tf_schema_name: iam_role_id
+                                    - api_name: prefixPath
+                                      tf_schema_name: prefix_path
                             SPLUNK_LOG_EXPORT:
                                 allowed:
-                                    - hec_token
-                                    - hec_url
+                                    - api_name: hecToken
+                                      tf_schema_name: hec_token
+                                    - api_name: hecUrl
+                                      tf_schema_name: hec_url
                                 required:
-                                    - hec_token
-                                    - hec_url
-                        property_name: type
+                                    - api_name: hecToken
+                                      tf_schema_name: hec_token
+                                    - api_name: hecUrl
+                                      tf_schema_name: hec_url
+                        property_name:
+                            api_name: type
+                            tf_schema_name: type
                     attributes:
                         - string: {}
                           description: API key for authentication.
@@ -786,22 +834,11 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Unique 24-character hexadecimal string that identifies the GCP service account role.
+                          description: Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
                           computed_optional_required: computed
                           tf_schema_name: role_id
                           tf_model_name: RoleId
                           api_name: roleId
-                          req_body_usage: omit_always
-                          sensitive: false
-                          create_only: false
-                          present_in_any_response: false
-                          request_only_required_on_create: false
-                        - string: {}
-                          description: Unique 24-character hexadecimal string that identifies the Service Principal.
-                          computed_optional_required: computed
-                          tf_schema_name: service_principal_id
-                          tf_model_name: ServicePrincipalId
-                          api_name: servicePrincipalId
                           req_body_usage: omit_always
                           sensitive: false
                           create_only: false
@@ -830,7 +867,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type.
+                          description: Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
                           computed_optional_required: computed
                           tf_schema_name: type
                           tf_model_name: Type


### PR DESCRIPTION
## Description

Re-generating now that API changes with latest suggestions are in cloud-dev.
- Changes Azure `service_principal_id` to `role_id`. This is the Atlas Cloud Provider Access role.
- Adds clarification in the `type` description that it cannot be changed after creation (we chose not to mark this field as CreateOnly and rely on documentation + API error).

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
