### PR TITLE
chore: Implement string validator for discriminator sibling attributes

### DIFF
--- a/internal/common/autogen/validator/string_discriminator_validator.go
+++ b/internal/common/autogen/validator/string_discriminator_validator.go
@@ -26,7 +26,7 @@ type DiscriminatorDefinition struct {
 //   - If the discriminator value is unknown, null, or not found in Mapping all checks are skipped.
 //   - Required attributes for the active variant must be non-null (unknown is accepted as "set").
 //   - Type-specific attributes from other variants must be null.
-//   - Note: Unset Optional+Computed attributes are null in the config, they only become unknown later duringPlanResourceChange
+//   - Note: Unset Optional+Computed attributes are null in the config, they only become unknown later during PlanResourceChange
 func ValidateDiscriminator(def DiscriminatorDefinition) schemavalidator.String {
 	return discriminatorValidator{def: def}
 }

--- a/internal/common/autogen/validator/string_discriminator_validator.go
+++ b/internal/common/autogen/validator/string_discriminator_validator.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-// VariantDefinition describes which sibling attributes are allowed and required
-// when a particular discriminator value is active.
+// VariantDefinition describes which sibling attributes are allowed and required when a particular discriminator value is active.
+// Required attributes must also be present in the Allowed list.
 type VariantDefinition struct {
 	Allowed  []string
 	Required []string

--- a/internal/common/autogen/validator/string_discriminator_validator.go
+++ b/internal/common/autogen/validator/string_discriminator_validator.go
@@ -1,0 +1,143 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	schemavalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// VariantDefinition describes which sibling attributes are allowed and required
+// when a particular discriminator value is active.
+type VariantDefinition struct {
+	Allowed  []string
+	Required []string
+}
+
+type DiscriminatorDefinition struct {
+	Mapping map[string]VariantDefinition
+}
+
+// ValidateDiscriminator returns a plan-phase string validator that checks sibling
+// attribute presence/absence based on the active discriminator value.
+//   - If the discriminator value is unknown, null, or not found in Mapping all checks are skipped.
+//   - Required attributes for the active variant must be non-null.
+//   - Type-specific attributes from other variants must be null.
+func ValidateDiscriminator(def DiscriminatorDefinition) schemavalidator.String {
+	return discriminatorValidator{def: def}
+}
+
+type discriminatorValidator struct {
+	def DiscriminatorDefinition
+}
+
+func (v discriminatorValidator) Description(_ context.Context) string {
+	return "validates sibling attributes based on the selected discriminator value"
+}
+
+func (v discriminatorValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v discriminatorValidator) ValidateString(_ context.Context, req schemavalidator.StringRequest, resp *schemavalidator.StringResponse) {
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	discriminatorValue := req.ConfigValue.ValueString()
+	variant, ok := v.def.Mapping[discriminatorValue]
+	if !ok {
+		return
+	}
+
+	parentPath := req.Path.ParentPath()
+	discriminatorName := lastPathStepName(req.Path)
+
+	allTypeSpecific := allTypeSpecificAttrs(v.def)
+	activeAllowed := toSet(variant.Allowed)
+
+	for _, name := range variant.Required {
+		siblingPath := parentPath.AtName(name)
+		if isNullOrUnknownInConfig(req.Config, siblingPath) {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Missing Required Attribute",
+				fmt.Sprintf("Attribute %q must be set when %s is %q", name, discriminatorName, discriminatorValue),
+			)
+		}
+	}
+
+	for name := range allTypeSpecific {
+		if activeAllowed[name] {
+			continue
+		}
+		siblingPath := parentPath.AtName(name)
+		if !isNullOrUnknownInConfig(req.Config, siblingPath) {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid Attribute Combination",
+				fmt.Sprintf("Attribute %q is not allowed when %s is %q", name, discriminatorName, discriminatorValue),
+			)
+		}
+	}
+}
+
+func allTypeSpecificAttrs(def DiscriminatorDefinition) map[string]bool {
+	result := make(map[string]bool)
+	for _, variant := range def.Mapping {
+		for _, name := range variant.Allowed {
+			result[name] = true
+		}
+	}
+	return result
+}
+
+func toSet(names []string) map[string]bool {
+	result := make(map[string]bool, len(names))
+	for _, name := range names {
+		result[name] = true
+	}
+	return result
+}
+
+func lastPathStepName(p path.Path) string {
+	steps := p.Steps()
+	if len(steps) == 0 {
+		return ""
+	}
+	if nameStep, ok := steps[len(steps)-1].(path.PathStepAttributeName); ok {
+		return string(nameStep)
+	}
+	return ""
+}
+
+func isNullOrUnknownInConfig(config tfsdk.Config, attrPath path.Path) bool {
+	tfPath := pathToTFTypesPath(attrPath)
+	rawVal, remaining, err := tftypes.WalkAttributePath(config.Raw, tfPath)
+	if err != nil || len(remaining.Steps()) > 0 {
+		return true
+	}
+	val, ok := rawVal.(tftypes.Value)
+	if !ok {
+		return true
+	}
+	return val.IsNull() || !val.IsKnown()
+}
+
+func pathToTFTypesPath(p path.Path) *tftypes.AttributePath {
+	result := tftypes.NewAttributePath()
+	for _, step := range p.Steps() {
+		switch s := step.(type) {
+		case path.PathStepAttributeName:
+			result = result.WithAttributeName(string(s))
+		case path.PathStepElementKeyInt:
+			result = result.WithElementKeyInt(int(s))
+		case path.PathStepElementKeyString:
+			result = result.WithElementKeyString(string(s))
+		}
+	}
+	return result
+}

--- a/internal/common/autogen/validator/string_discriminator_validator_test.go
+++ b/internal/common/autogen/validator/string_discriminator_validator_test.go
@@ -18,17 +18,17 @@ import (
 func TestValidateDiscriminator(t *testing.T) {
 	rootObjType := tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
-			"type":        tftypes.String,
-			"role_arn":    tftypes.String,
-			"service_url": tftypes.String,
+			"type":           tftypes.String,
+			"aws_specific":   tftypes.String,
+			"azure_specific": tftypes.String,
 		},
 	}
 
 	innerObjType := tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
-			"type":        tftypes.String,
-			"role_arn":    tftypes.String,
-			"service_url": tftypes.String,
+			"type":           tftypes.String,
+			"aws_specific":   tftypes.String,
+			"azure_specific": tftypes.String,
 		},
 	}
 
@@ -41,12 +41,12 @@ func TestValidateDiscriminator(t *testing.T) {
 	def := validator.DiscriminatorDefinition{
 		Mapping: map[string]validator.VariantDefinition{
 			"AWS": {
-				Allowed:  []string{"role_arn"},
-				Required: []string{"role_arn"},
+				Allowed:  []string{"aws_specific"},
+				Required: []string{"aws_specific"},
 			},
 			"AZURE": {
-				Allowed:  []string{"service_url"},
-				Required: []string{"service_url"},
+				Allowed:  []string{"azure_specific"},
+				Required: []string{"azure_specific"},
 			},
 		},
 	}
@@ -66,12 +66,12 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringValue("AWS"),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "AWS"),
-				"role_arn":    tftypes.NewValue(tftypes.String, nil),
-				"service_url": tftypes.NewValue(tftypes.String, nil),
+				"type":           tftypes.NewValue(tftypes.String, "AWS"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, nil),
+				"azure_specific": tftypes.NewValue(tftypes.String, nil),
 			}),
 			expectErrors:   1,
-			expectInDetail: []string{`"role_arn" must be set when type is "AWS"`},
+			expectInDetail: []string{`"aws_specific" must be set when type is "AWS"`},
 		},
 		{
 			name:        "disallowed attribute present emits not-allowed diagnostic",
@@ -79,12 +79,12 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringValue("AWS"),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "AWS"),
-				"role_arn":    tftypes.NewValue(tftypes.String, "some-arn"),
-				"service_url": tftypes.NewValue(tftypes.String, "some-url"),
+				"type":           tftypes.NewValue(tftypes.String, "AWS"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, "some-arn"),
+				"azure_specific": tftypes.NewValue(tftypes.String, "some-url"),
 			}),
 			expectErrors:   1,
-			expectInDetail: []string{`"service_url" is not allowed when type is "AWS"`},
+			expectInDetail: []string{`"azure_specific" is not allowed when type is "AWS"`},
 		},
 		{
 			name:        "unknown discriminator value skips all checks",
@@ -92,9 +92,9 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringValue("GCP"),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "GCP"),
-				"role_arn":    tftypes.NewValue(tftypes.String, "some-arn"),
-				"service_url": tftypes.NewValue(tftypes.String, "some-url"),
+				"type":           tftypes.NewValue(tftypes.String, "GCP"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, "some-arn"),
+				"azure_specific": tftypes.NewValue(tftypes.String, "some-url"),
 			}),
 			expectErrors: 0,
 		},
@@ -104,9 +104,9 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringNull(),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, nil),
-				"role_arn":    tftypes.NewValue(tftypes.String, nil),
-				"service_url": tftypes.NewValue(tftypes.String, nil),
+				"type":           tftypes.NewValue(tftypes.String, nil),
+				"aws_specific":   tftypes.NewValue(tftypes.String, nil),
+				"azure_specific": tftypes.NewValue(tftypes.String, nil),
 			}),
 			expectErrors: 0,
 		},
@@ -116,9 +116,9 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringUnknown(),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-				"role_arn":    tftypes.NewValue(tftypes.String, nil),
-				"service_url": tftypes.NewValue(tftypes.String, nil),
+				"type":           tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"aws_specific":   tftypes.NewValue(tftypes.String, nil),
+				"azure_specific": tftypes.NewValue(tftypes.String, nil),
 			}),
 			expectErrors: 0,
 		},
@@ -128,9 +128,9 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringValue("AWS"),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "AWS"),
-				"role_arn":    tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
-				"service_url": tftypes.NewValue(tftypes.String, nil),
+				"type":           tftypes.NewValue(tftypes.String, "AWS"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
+				"azure_specific": tftypes.NewValue(tftypes.String, nil),
 			}),
 			expectErrors: 0,
 		},
@@ -141,13 +141,13 @@ func TestValidateDiscriminator(t *testing.T) {
 			configPath:  path.Root("nested").AtName("type"),
 			raw: tftypes.NewValue(nestedObjType, map[string]tftypes.Value{
 				"nested": tftypes.NewValue(innerObjType, map[string]tftypes.Value{
-					"type":        tftypes.NewValue(tftypes.String, "AWS"),
-					"role_arn":    tftypes.NewValue(tftypes.String, nil),
-					"service_url": tftypes.NewValue(tftypes.String, nil),
+					"type":           tftypes.NewValue(tftypes.String, "AWS"),
+					"aws_specific":   tftypes.NewValue(tftypes.String, nil),
+					"azure_specific": tftypes.NewValue(tftypes.String, nil),
 				}),
 			}),
 			expectErrors:   1,
-			expectInDetail: []string{`"role_arn" must be set when type is "AWS"`},
+			expectInDetail: []string{`"aws_specific" must be set when type is "AWS"`},
 		},
 		{
 			name:        "unrelated sibling with unknown value emits no diagnostics",
@@ -156,16 +156,16 @@ func TestValidateDiscriminator(t *testing.T) {
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(tftypes.Object{
 				AttributeTypes: map[string]tftypes.Type{
-					"type":        tftypes.String,
-					"role_arn":    tftypes.String,
-					"service_url": tftypes.String,
-					"name":        tftypes.String,
+					"type":           tftypes.String,
+					"aws_specific":   tftypes.String,
+					"azure_specific": tftypes.String,
+					"name":           tftypes.String,
 				},
 			}, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "AWS"),
-				"role_arn":    tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
-				"service_url": tftypes.NewValue(tftypes.String, nil),
-				"name":        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"type":           tftypes.NewValue(tftypes.String, "AWS"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
+				"azure_specific": tftypes.NewValue(tftypes.String, nil),
+				"name":           tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 			}),
 			expectErrors: 0,
 		},
@@ -175,9 +175,9 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringValue("AWS"),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "AWS"),
-				"role_arn":    tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
-				"service_url": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"type":           tftypes.NewValue(tftypes.String, "AWS"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
+				"azure_specific": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 			}),
 			expectErrors: 0,
 		},
@@ -187,12 +187,12 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringValue("AWS"),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "AWS"),
-				"role_arn":    tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-				"service_url": tftypes.NewValue(tftypes.String, nil),
+				"type":           tftypes.NewValue(tftypes.String, "AWS"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"azure_specific": tftypes.NewValue(tftypes.String, nil),
 			}),
 			expectErrors:   1,
-			expectInDetail: []string{`"role_arn" must be set when type is "AWS"`},
+			expectInDetail: []string{`"aws_specific" must be set when type is "AWS"`},
 		},
 		{
 			name:        "both required missing and disallowed present emit multiple diagnostics",
@@ -200,14 +200,14 @@ func TestValidateDiscriminator(t *testing.T) {
 			configValue: types.StringValue("AZURE"),
 			configPath:  path.Root("type"),
 			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
-				"type":        tftypes.NewValue(tftypes.String, "AZURE"),
-				"role_arn":    tftypes.NewValue(tftypes.String, "some-arn"),
-				"service_url": tftypes.NewValue(tftypes.String, nil),
+				"type":           tftypes.NewValue(tftypes.String, "AZURE"),
+				"aws_specific":   tftypes.NewValue(tftypes.String, "some-arn"),
+				"azure_specific": tftypes.NewValue(tftypes.String, nil),
 			}),
 			expectErrors: 2,
 			expectInDetail: []string{
-				`"service_url" must be set when type is "AZURE"`,
-				`"role_arn" is not allowed when type is "AZURE"`,
+				`"azure_specific" must be set when type is "AZURE"`,
+				`"aws_specific" is not allowed when type is "AZURE"`,
 			},
 		},
 	}

--- a/internal/common/autogen/validator/string_discriminator_validator_test.go
+++ b/internal/common/autogen/validator/string_discriminator_validator_test.go
@@ -1,0 +1,255 @@
+package validator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	schemavalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/validator"
+)
+
+func TestValidateDiscriminator(t *testing.T) {
+	rootObjType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"type":        tftypes.String,
+			"role_arn":    tftypes.String,
+			"service_url": tftypes.String,
+		},
+	}
+
+	innerObjType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"type":        tftypes.String,
+			"role_arn":    tftypes.String,
+			"service_url": tftypes.String,
+		},
+	}
+
+	nestedObjType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"nested": innerObjType,
+		},
+	}
+
+	def := validator.DiscriminatorDefinition{
+		Mapping: map[string]validator.VariantDefinition{
+			"AWS": {
+				Allowed:  []string{"role_arn"},
+				Required: []string{"role_arn"},
+			},
+			"AZURE": {
+				Allowed:  []string{"service_url"},
+				Required: []string{"service_url"},
+			},
+		},
+	}
+
+	tests := []struct {
+		raw            tftypes.Value
+		def            validator.DiscriminatorDefinition
+		configValue    basetypes.StringValue
+		name           string
+		configPath     path.Path
+		expectInDetail []string
+		expectErrors   int
+	}{
+		{
+			name:        "required attribute missing emits must-be-set diagnostic",
+			def:         def,
+			configValue: types.StringValue("AWS"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "AWS"),
+				"role_arn":    tftypes.NewValue(tftypes.String, nil),
+				"service_url": tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectErrors:   1,
+			expectInDetail: []string{`"role_arn" must be set when type is "AWS"`},
+		},
+		{
+			name:        "disallowed attribute present emits not-allowed diagnostic",
+			def:         def,
+			configValue: types.StringValue("AWS"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "AWS"),
+				"role_arn":    tftypes.NewValue(tftypes.String, "some-arn"),
+				"service_url": tftypes.NewValue(tftypes.String, "some-url"),
+			}),
+			expectErrors:   1,
+			expectInDetail: []string{`"service_url" is not allowed when type is "AWS"`},
+		},
+		{
+			name:        "unknown discriminator value skips all checks",
+			def:         def,
+			configValue: types.StringValue("GCP"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "GCP"),
+				"role_arn":    tftypes.NewValue(tftypes.String, "some-arn"),
+				"service_url": tftypes.NewValue(tftypes.String, "some-url"),
+			}),
+			expectErrors: 0,
+		},
+		{
+			name:        "null discriminator config value skips all checks",
+			def:         def,
+			configValue: types.StringNull(),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, nil),
+				"role_arn":    tftypes.NewValue(tftypes.String, nil),
+				"service_url": tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectErrors: 0,
+		},
+		{
+			name:        "unknown discriminator config value skips all checks",
+			def:         def,
+			configValue: types.StringUnknown(),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"role_arn":    tftypes.NewValue(tftypes.String, nil),
+				"service_url": tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectErrors: 0,
+		},
+		{
+			name:        "valid configuration for active variant emits no diagnostics",
+			def:         def,
+			configValue: types.StringValue("AWS"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "AWS"),
+				"role_arn":    tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
+				"service_url": tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectErrors: 0,
+		},
+		{
+			name:        "nested path sibling resolution works",
+			def:         def,
+			configValue: types.StringValue("AWS"),
+			configPath:  path.Root("nested").AtName("type"),
+			raw: tftypes.NewValue(nestedObjType, map[string]tftypes.Value{
+				"nested": tftypes.NewValue(innerObjType, map[string]tftypes.Value{
+					"type":        tftypes.NewValue(tftypes.String, "AWS"),
+					"role_arn":    tftypes.NewValue(tftypes.String, nil),
+					"service_url": tftypes.NewValue(tftypes.String, nil),
+				}),
+			}),
+			expectErrors:   1,
+			expectInDetail: []string{`"role_arn" must be set when type is "AWS"`},
+		},
+		{
+			name:        "unrelated sibling with unknown value emits no diagnostics",
+			def:         def,
+			configValue: types.StringValue("AWS"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"type":        tftypes.String,
+					"role_arn":    tftypes.String,
+					"service_url": tftypes.String,
+					"name":        tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "AWS"),
+				"role_arn":    tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
+				"service_url": tftypes.NewValue(tftypes.String, nil),
+				"name":        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			}),
+			expectErrors: 0,
+		},
+		{
+			name:        "unknown disallowed sibling skips not-allowed check",
+			def:         def,
+			configValue: types.StringValue("AWS"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "AWS"),
+				"role_arn":    tftypes.NewValue(tftypes.String, "arn:aws:iam::role"),
+				"service_url": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			}),
+			expectErrors: 0,
+		},
+		{
+			name:        "unknown required sibling emits must-be-set diagnostic",
+			def:         def,
+			configValue: types.StringValue("AWS"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "AWS"),
+				"role_arn":    tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"service_url": tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectErrors:   1,
+			expectInDetail: []string{`"role_arn" must be set when type is "AWS"`},
+		},
+		{
+			name:        "both required missing and disallowed present emit multiple diagnostics",
+			def:         def,
+			configValue: types.StringValue("AZURE"),
+			configPath:  path.Root("type"),
+			raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+				"type":        tftypes.NewValue(tftypes.String, "AZURE"),
+				"role_arn":    tftypes.NewValue(tftypes.String, "some-arn"),
+				"service_url": tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectErrors: 2,
+			expectInDetail: []string{
+				`"service_url" must be set when type is "AZURE"`,
+				`"role_arn" is not allowed when type is "AZURE"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := validator.ValidateDiscriminator(tt.def)
+
+			req := schemavalidator.StringRequest{
+				ConfigValue: tt.configValue,
+				Path:        tt.configPath,
+				Config: tfsdk.Config{
+					Raw: tt.raw,
+				},
+			}
+			resp := &schemavalidator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			v.ValidateString(t.Context(), req, resp)
+
+			errors := resp.Diagnostics.Errors()
+			if len(errors) != tt.expectErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tt.expectErrors, len(errors), errors)
+			}
+
+			for _, msg := range tt.expectInDetail {
+				if !diagnosticContains(errors, msg) {
+					t.Errorf("expected diagnostic detail containing %q, got: %v", msg, errors)
+				}
+			}
+		})
+	}
+}
+
+func diagnosticContains(diagnostics diag.Diagnostics, substr string) bool {
+	for _, d := range diagnostics {
+		if strings.Contains(d.Detail(), substr) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-381487

Implements a config-phase string validator for discriminator sibling attributes. Given a discriminator attribute (e.g., `type`) and a mapping of variant values to their allowed/required sibling attributes, the validator enforces:

- **Required sibling check**: attributes listed as `Required` for the active variant must be present (non-null) in the config.
- **Disallowed sibling check**: type-specific attributes belonging to *other* variants must not be set.
- If the discriminator value itself is unknown, null, or not found in the mapping, all checks are skipped.


### Key consideration: Handling of unknown values in config

During `ValidateResourceConfig`, the config reflects exactly what the practitioner wrote:
- **null** = attribute was not set
- **unknown** = attribute was set to an unresolved expression (e.g., `cluster_name = mongodbatlas_cluster.test.name`)
- **known** = attribute was set to a literal or resolved expression

Unset `Optional+Computed` attributes are **null** in the config at this phase — they only become unknown later during `PlanResourceChange` when the framework marks them so the provider can compute a value.

Given this, both checks use a null-only check (`isNullInConfig`):
- **Required siblings**: error only if null. Unknown means the user set it to a reference — no false positive.
- **Disallowed siblings**: error if non-null (known *or* unknown). Unknown means the user explicitly set a disallowed attribute — correctly flagged.


<details>
<summary><h3>Manual testing<h3></summary>

The validator was temporarily wired to the `mongodbatlas_stream_connection` resource's type attribute to verify behavior against real terraform plan runs. The discriminator was configured with Cluster (requiring cluster_name) and Kafka (requiring bootstrap_servers) variants.

#### Test 1: Unknown required sibling (false positive prevention)
Config where cluster_name references another resource, making it unknown at validation time:

```
resource "mongodbatlas_stream_connection" "test" {
  project_id      = mongodbatlas_project.test.id
  instance_name   = mongodbatlas_stream_instance.test.instance_name
  connection_name = "test-cluster-conn"
  type            = "Cluster"
  cluster_name    = mongodbatlas_cluster.test.name  # unknown at validation
}
```

Result: No false positive. The validator correctly accepts the unknown value as "user set this attribute".

#### Test 2: Unset Optional+Computed disallowed sibling
Config with type = "Cluster" where networking (an Optional+Computed attribute from the Kafka variant) is not set by the user:
```
resource "mongodbatlas_stream_connection" "test" {
  project_id      = mongodbatlas_project.test.id
  instance_name   = mongodbatlas_stream_instance.test.instance_name
  connection_name = "test-cluster-conn"
  type            = "Cluster"
  cluster_name    = "my-cluster"
  # networking is Optional+Computed, belongs to Kafka variant, not set here
}
```

Result: No false positive. Unset Optional+Computed attributes appear as null (not unknown) in the config during validation, so the disallowed check correctly ignores them.
</details>

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
