### PR TITLE
chore: Add log_integration tests for Datadog, Splunk and OTel

### DIFF
--- a/internal/service/projectserviceaccountaccesslistentry/resource_test.go
+++ b/internal/service/projectserviceaccountaccesslistentry/resource_test.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/hcl"
 	"go.mongodb.org/atlas-sdk/v20250312014/admin"
 )
 
@@ -155,8 +155,7 @@ func configBasic(projectID, name string, entries []testEntry) string {
 		`, i, projectID, entry.hclStr())
 		resourceNames = append(resourceNames, fmt.Sprintf("%s_%d", resourceName, i))
 	}
-
-	resourceNamesStr := fmt.Sprintf("[%s]", `"`+strings.Join(resourceNames, `", "`)+`"`)
+	resourceNamesStr := hcl.StringSliceToHCL(resourceNames)
 
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project_service_account" "test" {

--- a/internal/service/serviceaccountaccesslistentry/resource_test.go
+++ b/internal/service/serviceaccountaccesslistentry/resource_test.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/hcl"
 	"go.mongodb.org/atlas-sdk/v20250312014/admin"
 )
 
@@ -155,8 +155,7 @@ func configBasic(orgID, name string, entries []testEntry) string {
 		`, i, orgID, entry.hclStr())
 		resourceNames = append(resourceNames, fmt.Sprintf("%s_%d", resourceName, i))
 	}
-
-	resourceNamesStr := fmt.Sprintf("[%s]", `"`+strings.Join(resourceNames, `", "`)+`"`)
+	resourceNamesStr := hcl.StringSliceToHCL(resourceNames)
 
 	return fmt.Sprintf(`
 		resource "mongodbatlas_service_account" "test" {

--- a/internal/serviceapi/serviceaccountprojectassignment/resource_test.go
+++ b/internal/serviceapi/serviceaccountprojectassignment/resource_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/hcl"
 	"go.mongodb.org/atlas-sdk/v20250312014/admin"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -83,7 +83,7 @@ func TestAccServiceAccountProjectAssignment_multipleAssignments(t *testing.T) {
 }
 
 func configBasic(orgID string, projectIDs, roles []string) string {
-	rolesStr := fmt.Sprintf("[%s]", `"`+strings.Join(roles, `", "`)+`"`)
+	rolesStr := hcl.StringSliceToHCL(roles)
 
 	assignmentsStr := ""
 	resourceNames := []string{}
@@ -103,8 +103,7 @@ func configBasic(orgID string, projectIDs, roles []string) string {
 		`, i, projectID, rolesStr)
 		resourceNames = append(resourceNames, fmt.Sprintf("%s_%d", resourceName, i))
 	}
-
-	resourceNamesStr := fmt.Sprintf("[%s]", `"`+strings.Join(resourceNames, `", "`)+`"`)
+	resourceNamesStr := hcl.StringSliceToHCL(resourceNames)
 
 	return fmt.Sprintf(`
 		resource "mongodbatlas_service_account" "test" {

--- a/internal/testutil/hcl/common.go
+++ b/internal/testutil/hcl/common.go
@@ -2,6 +2,7 @@ package hcl
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -72,8 +73,8 @@ func AddAttributes(t *testing.T, body *hclsyntax.Body, ret map[string]cty.Value)
 func PrettyHCL(tb testing.TB, content string) string {
 	tb.Helper()
 	builder := strings.Builder{}
-	fmt := getTF().Format(tb.Context(), io.NopCloser(strings.NewReader(content)), &builder)
-	require.NoError(tb, fmt)
+	err := getTF().Format(tb.Context(), io.NopCloser(strings.NewReader(content)), &builder)
+	require.NoError(tb, err)
 	formatted := builder.String()
 	return formatted
 }
@@ -98,4 +99,8 @@ func GetBlockBody(t *testing.T, block *hclwrite.Block) *hclsyntax.Body {
 	body, ok := parser.Body.(*hclsyntax.Body)
 	require.True(t, ok, "unexpected *hclsyntax.Body type: %T", parser.Body)
 	return body
+}
+
+func StringSliceToHCL(slice []string) string {
+	return fmt.Sprintf("[%s]", `"`+strings.Join(slice, `", "`)+`"`)
 }


### PR DESCRIPTION
## Description

Adding acceptance tests for the remaining log_integration types: Datadog, Splunk and OTel.
These do not require external infrastructure, we are safe to test with dummy values (discussed with API team).

Link to any related issue(s): CLOUDP-381529

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
