### PR TITLE
chore: Autogen - extend support for legacy import format

### DIFF
--- a/internal/common/autogen/custom_hooks.go
+++ b/internal/common/autogen/custom_hooks.go
@@ -37,3 +37,7 @@ type PreUpdateAPICallHook interface {
 type PostUpdateAPICallHook interface {
 	PostUpdateAPICall(APICallResult) APICallResult
 }
+
+type PreImportHook interface {
+	PreImport(id string) (string, error)
+}

--- a/internal/common/autogen/import.go
+++ b/internal/common/autogen/import.go
@@ -19,7 +19,7 @@ const (
 // It splits the request ID string by "/" delimiter and maps each part to the corresponding attribute specified in idAttributes.
 // If a resource implements PreImportHook, the ID is normalized first.
 // Example usage:
-//   - HandleImport(ctx, []string{"project_id", "name"}, req, resp)
+//   - HandleImport(ctx, []string{"project_id", "name"}, req, resp, r)
 //   - example import ID would be "5c9d0a239ccf643e6a35ddasdf/myCluster"
 func HandleImport(ctx context.Context, idAttrs []string, req resource.ImportStateRequest, resp *resource.ImportStateResponse, hook any) {
 	d := &resp.Diagnostics

--- a/internal/common/autogen/import.go
+++ b/internal/common/autogen/import.go
@@ -17,12 +17,24 @@ const (
 
 // HandleImport handles the import operation for Terraform resources.
 // It splits the request ID string by "/" delimiter and maps each part to the corresponding attribute specified in idAttributes.
+// If a resource implements PreImportHook, the ID is normalized first.
 // Example usage:
 //   - HandleImport(ctx, []string{"project_id", "name"}, req, resp)
 //   - example import ID would be "5c9d0a239ccf643e6a35ddasdf/myCluster"
-func HandleImport(ctx context.Context, idAttrs []string, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func HandleImport(ctx context.Context, idAttrs []string, req resource.ImportStateRequest, resp *resource.ImportStateResponse, hook any) {
 	d := &resp.Diagnostics
-	idAttrsWithValue, err := ProcessImportID(req.ID, idAttrs)
+
+	id := req.ID
+	if preImportHook, ok := hook.(PreImportHook); ok {
+		normalizedID, err := preImportHook.PreImport(id)
+		if err != nil {
+			addError(d, opImport, errProcessingImportID, err)
+			return
+		}
+		id = normalizedID
+	}
+
+	idAttrsWithValue, err := ProcessImportID(id, idAttrs)
 	if err != nil {
 		addError(d, opImport, errProcessingImportID, err)
 		return

--- a/internal/common/autogen/import_test.go
+++ b/internal/common/autogen/import_test.go
@@ -7,7 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/stretchr/testify/assert"

--- a/internal/common/autogen/import_test.go
+++ b/internal/common/autogen/import_test.go
@@ -94,7 +94,7 @@ func TestHandleImportWithCustomHook(t *testing.T) {
 			},
 		},
 		{
-			name:         "default format passes unchanged",
+			name:         "Default format passes unchanged",
 			importID:     "507f1f77bcf86cd799439011/myWorkspace/myConnection",
 			idAttributes: []string{"project_id", "workspace_name", "connection_name"},
 			expectedAttrs: map[string]string{
@@ -104,7 +104,7 @@ func TestHandleImportWithCustomHook(t *testing.T) {
 			},
 		},
 		{
-			name:          "invalid format returns error",
+			name:          "Invalid format returns error",
 			importID:      "bad-format",
 			idAttributes:  []string{"project_id", "workspace_name", "connection_name"},
 			expectedError: conversion.StringPtr("use one of the formats: {project_id}/{workspace_name}/{connection_name} or {workspace_name}-{project_id}-{connection_name}"),

--- a/internal/serviceapi/alertconfigurationapi/resource.go
+++ b/internal/serviceapi/alertconfigurationapi/resource.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/auditingapi/resource.go
+++ b/internal/serviceapi/auditingapi/resource.go
@@ -116,7 +116,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/clusterapi/resource.go
+++ b/internal/serviceapi/clusterapi/resource.go
@@ -165,7 +165,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/clusteroldapi/resource.go
+++ b/internal/serviceapi/clusteroldapi/resource.go
@@ -164,7 +164,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/customdbroleapi/resource.go
+++ b/internal/serviceapi/customdbroleapi/resource.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "role_name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/databaseuserapi/resource.go
+++ b/internal/serviceapi/databaseuserapi/resource.go
@@ -118,7 +118,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "database_name", "db_user"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/logintegration/resource.go
+++ b/internal/serviceapi/logintegration/resource.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "integration_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/maintenancewindowapi/resource.go
+++ b/internal/serviceapi/maintenancewindowapi/resource.go
@@ -116,7 +116,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/projectapi/resource.go
+++ b/internal/serviceapi/projectapi/resource.go
@@ -114,7 +114,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/projectserviceaccount/resource.go
+++ b/internal/serviceapi/projectserviceaccount/resource.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "client_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/projectserviceaccountsecret/resource.go
+++ b/internal/serviceapi/projectserviceaccountsecret/resource.go
@@ -93,7 +93,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "client_id", "secret_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
+++ b/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
@@ -13,6 +13,8 @@ type readAPIResponse struct {
 	Secrets []map[string]any
 }
 
+const errImportFormat = "use one of the formats: {project_id}/{workspace_name}/{connection_name} or {workspace_name}-{project_id}-{connection_name}"
+
 // PostReadAPICall Reads the secret from the API response Service Account secrets list and returns a new APICallResult with it.
 func (r *rs) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallResult) autogen.APICallResult {
 	id := req.State.(*TFModel).SecretId.ValueString()

--- a/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
+++ b/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
@@ -13,8 +13,6 @@ type readAPIResponse struct {
 	Secrets []map[string]any
 }
 
-const errImportFormat = "use one of the formats: {project_id}/{workspace_name}/{connection_name} or {workspace_name}-{project_id}-{connection_name}"
-
 // PostReadAPICall Reads the secret from the API response Service Account secrets list and returns a new APICallResult with it.
 func (r *rs) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallResult) autogen.APICallResult {
 	id := req.State.(*TFModel).SecretId.ValueString()

--- a/internal/serviceapi/projectsettingsapi/resource.go
+++ b/internal/serviceapi/projectsettingsapi/resource.go
@@ -108,7 +108,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/pushbasedlogexportapi/resource.go
+++ b/internal/serviceapi/pushbasedlogexportapi/resource.go
@@ -163,7 +163,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/resourcepolicyapi/resource.go
+++ b/internal/serviceapi/resourcepolicyapi/resource.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"org_id", "id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/searchdeploymentapi/resource.go
+++ b/internal/serviceapi/searchdeploymentapi/resource.go
@@ -165,7 +165,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "cluster_name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/searchindexapi/resource.go
+++ b/internal/serviceapi/searchindexapi/resource.go
@@ -152,7 +152,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "cluster_name", "index_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/serviceaccount/resource.go
+++ b/internal/serviceapi/serviceaccount/resource.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"org_id", "client_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/serviceaccountprojectassignment/resource.go
+++ b/internal/serviceapi/serviceaccountprojectassignment/resource.go
@@ -118,7 +118,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "client_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/serviceaccountsecret/resource.go
+++ b/internal/serviceapi/serviceaccountsecret/resource.go
@@ -93,7 +93,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"org_id", "client_id", "secret_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/streamconnectionapi/resource.go
+++ b/internal/serviceapi/streamconnectionapi/resource.go
@@ -166,7 +166,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "workspace_name", "connection_name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
+++ b/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
@@ -1,0 +1,28 @@
+package streamconnectionapi
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func (r *rs) PreImport(id string) (string, error) {
+	normalizedID, err := parseLegacyImportID(id)
+	if err == nil {
+		return normalizedID, nil
+	}
+
+	return "", fmt.Errorf("use the format {workspace_name}-{project_id}-{connection_name}")
+}
+
+func parseLegacyImportID(id string) (string, error) {
+	re := regexp.MustCompile(`^(.*)-([0-9a-fA-F]{24})-(.*)$`)
+	m := re.FindStringSubmatch(id)
+	if len(m) != 4 || m[1] == "" || m[3] == "" {
+		return "", fmt.Errorf("use the format {workspace_name}-{project_id}-{connection_name}")
+	}
+
+	workspaceName := m[1]
+	projectID := m[2]
+	connectionName := m[3]
+	return fmt.Sprintf("%s/%s/%s", projectID, workspaceName, connectionName), nil
+}

--- a/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
+++ b/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const errImportFormats = "use one of the formats: {project_id}/{workspace_name}/{connection_name} or {workspace_name}-{project_id}-{connection_name}"
-
 func (r *rs) PreImport(id string) (string, error) {
 	if strings.Contains(id, "/") {
 		return id, nil
@@ -18,14 +16,14 @@ func (r *rs) PreImport(id string) (string, error) {
 		return normalizedID, nil
 	}
 
-	return "", fmt.Errorf(errImportFormats)
+	return "", fmt.Errorf("use one of the formats: {project_id}/{workspace_name}/{connection_name} or {workspace_name}-{project_id}-{connection_name}")
 }
 
 func parseLegacyImportID(id string) (string, error) {
 	re := regexp.MustCompile(`^(.*)-([0-9a-fA-F]{24})-(.*)$`)
 	m := re.FindStringSubmatch(id)
 	if len(m) != 4 || m[1] == "" || m[3] == "" {
-		return "", fmt.Errorf("Invalid legacy import format")
+		return "", fmt.Errorf("invalid legacy import format")
 	}
 
 	workspaceName := m[1]

--- a/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
+++ b/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
@@ -3,26 +3,34 @@ package streamconnectionapi
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
+const errImportFormats = "use one of the formats: {project_id}/{workspace_name}/{connection_name} or {workspace_name}-{project_id}-{connection_name}"
+
 func (r *rs) PreImport(id string) (string, error) {
+	if strings.Contains(id, "/") {
+		return id, nil
+	}
+
 	normalizedID, err := parseLegacyImportID(id)
 	if err == nil {
 		return normalizedID, nil
 	}
 
-	return "", fmt.Errorf("use the format {workspace_name}-{project_id}-{connection_name}")
+	return "", fmt.Errorf(errImportFormats)
 }
 
 func parseLegacyImportID(id string) (string, error) {
 	re := regexp.MustCompile(`^(.*)-([0-9a-fA-F]{24})-(.*)$`)
 	m := re.FindStringSubmatch(id)
 	if len(m) != 4 || m[1] == "" || m[3] == "" {
-		return "", fmt.Errorf("use the format {workspace_name}-{project_id}-{connection_name}")
+		return "", fmt.Errorf("Invalid legacy import format")
 	}
 
 	workspaceName := m[1]
 	projectID := m[2]
 	connectionName := m[3]
+	// Normalize to default format: {project_id}/{workspace_name}/{connection_name}
 	return fmt.Sprintf("%s/%s/%s", projectID, workspaceName, connectionName), nil
 }

--- a/internal/serviceapi/streamconnectionapi/resource_test.go
+++ b/internal/serviceapi/streamconnectionapi/resource_test.go
@@ -143,6 +143,6 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 			return "", fmt.Errorf("import, attributes not found for: %s", resourceName)
 		}
 
-		return fmt.Sprintf("%s/%s/%s", projectID, workspaceName, connectionName), nil
+		return fmt.Sprintf("%s-%s-%s", workspaceName, projectID, connectionName), nil
 	}
 }

--- a/internal/serviceapi/streaminstanceapi/resource.go
+++ b/internal/serviceapi/streaminstanceapi/resource.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/internal/serviceapi/streamprocessorapi/resource.go
+++ b/internal/serviceapi/streamprocessorapi/resource.go
@@ -166,7 +166,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "tenant_name", "name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -190,7 +190,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{ {{range .IDAttributes }}"{{ . }}", {{- end }}}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "role_name"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/id-attributes.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/id-attributes.golden.go
@@ -92,7 +92,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"client_id", "id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/move-state.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/move-state.golden.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/no-op-delete-operation.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/no-op-delete-operation.golden.go
@@ -108,7 +108,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/path-params-with-aliases.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/path-params-with-aliases.golden.go
@@ -117,7 +117,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "integration_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
@@ -116,7 +116,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/unsupported-update-operation.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/unsupported-update-operation.golden.go
@@ -92,7 +92,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
@@ -116,7 +116,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {

--- a/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
@@ -163,7 +163,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogen.HandleImport(ctx, idAttributes, req, resp)
+	autogen.HandleImport(ctx, idAttributes, req, resp, r)
 }
 
 func readAPICallParams(model any) *config.APICallParams {


### PR DESCRIPTION
## Description

This change expands the import behaviour to support legacy import commands in a resource-specific way. 

A new custom hook `PreImport()` is added as a pre-processing step in the import flow, allowing each resource to provide custom import parsing and normalization logic.

 For `stream_connection_api`, this hook now parses the legacy format (`{workspace_name}-{project_id}-{connection_name}`) and normalizes it into the default shape expected by autogen import processing.

Additionally, it includes the following: 
- Updates acceptance test import ID generation for `stream_connection_api` to use the legacy format.
- Updates codegen resource golden fixtures to match current generated import call signatures.
- Generates `stream_connection_api` as part of validating this implementation path.

Link to any related issue(s): [CLOUDP-382035](https://jira.mongodb.org/browse/CLOUDP-382035)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
