### PR TITLE
No-op delete warning

### DIFF
--- a/internal/serviceapi/projectsettingsapi/resource.go
+++ b/internal/serviceapi/projectsettingsapi/resource.go
@@ -104,6 +104,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 }
 
 func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddWarning("Delete operation is a no-op", "This resource does no perform API calls during the delete operation. Terraform only removes the resource from state.")
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -185,7 +185,9 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	}
 	{{- end }}
 	autogen.HandleDelete(ctx, *reqHandle)
-    {{- end }}
+	{{- else}}
+	resp.Diagnostics.AddWarning("Delete operation is a no-op", "This resource does no perform API calls during the delete operation. Terraform only removes the resource from state.")
+	{{- end }}
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/tools/codegen/gofilegen/resource/testdata/no-op-delete-operation.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/no-op-delete-operation.golden.go
@@ -104,6 +104,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 }
 
 func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddWarning("Delete operation is a no-op", "This resource does no perform API calls during the delete operation. Terraform only removes the resource from state.")
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
## Description

This PR implements CLOUDP-382026 by introducing a warning diagnostic for autogenerated resources that do not perform any API calls during their delete operation. Previously, the `Delete` method for such resources was empty. Now, it will emit a warning to inform users that Terraform only removes the resource from state without interacting with the API.

**Suggested Warning Text:**
*   **Title:** `Delete operation is a no-op`
*   **Detail:** `This resource does no perform API calls during the delete operation. Terraform only removes the resource from state.`

This change updates the codegen template and an existing golden file test. Running `make autogen-generate-resources` was performed to update all relevant autogenerated resources, including `internal/serviceapi/projectsettingsapi/resource.go`.

Link to any related issue(s): [CLOUDP-382026](https://jira.mongodb.org/browse/CLOUDP-382026)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements (updated golden file test)
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

No acceptance tests were modified as there is no direct way to assert warning outputs in acceptance tests. The change is validated through golden file tests for the codegen and manual verification of the generated resource.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-48635ccd-8d85-40df-8559-4510ae2b7906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48635ccd-8d85-40df-8559-4510ae2b7906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

