### PR TITLE
feat: Add support for asynchronous deletion for streams connections

### DIFF
--- a/.changelog/4193.txt
+++ b/.changelog/4193.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds support for asynchronous deletion by waiting for deletion to complete
+```

--- a/.changelog/4193.txt
+++ b/.changelog/4193.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/mongodbatlas_stream_connection: Adds support for asynchronous deletion by waiting for deletion to complete
 ```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds configurable `delete` timeout (default 10 minutes)
+```

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -315,12 +315,14 @@ resource "mongodbatlas_stream_connection" "example" {
   timeouts = {
     create = "30m"
     update = "30m"
+    delete = "15m"
   }
 }
 ```
 
 * `create` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after creation. Defaults to `20m` (20 minutes).
 * `update` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after an update. Defaults to `20m` (20 minutes).
+* `delete` - (Optional) The maximum time to wait for the stream connection to be fully deleted. Defaults to `10m` (10 minutes).
 
 ## Import
 

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -16,7 +16,10 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 )
 
-const defaultCreateUpdateTimeoutDoc = "20m"
+const (
+	defaultCreateUpdateTimeoutDoc = "20m"
+	defaultDeleteTimeoutDoc       = "10m"
+)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
@@ -204,12 +207,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 
-			// Timeouts for create and update operations
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create:            true,
 				Update:            true,
+				Delete:            true,
 				CreateDescription: constant.TimeoutDescriptionCreateReadUpdate(defaultCreateUpdateTimeoutDoc),
 				UpdateDescription: constant.TimeoutDescriptionCreateReadUpdate(defaultCreateUpdateTimeoutDoc),
+				DeleteDescription: constant.TimeoutDescriptionDelete(defaultDeleteTimeoutDoc),
 			}),
 		},
 	}

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -210,7 +210,7 @@ func (r *streamConnectionRS) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	apiResp, err = WaitStateTransitionWithTimeout(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, createTimeout)
+	apiResp, err = WaitStateTransition(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, createTimeout, []string{StatePending}, []string{StateReady, StateFailed})
 	if err != nil {
 		resp.Diagnostics.AddError("error waiting for stream connection to be ready", err.Error())
 		return
@@ -294,7 +294,7 @@ func (r *streamConnectionRS) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	apiResp, err := WaitStateTransitionWithTimeout(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, updateTimeout)
+	apiResp, err := WaitStateTransition(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, updateTimeout, []string{StatePending}, []string{StateReady, StateFailed})
 	if err != nil {
 		resp.Diagnostics.AddError("error waiting for stream connection to be ready", err.Error())
 		return

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -209,7 +209,9 @@ func (r *streamConnectionRS) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	apiResp, err = WaitStateTransition(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, createTimeout, []string{StatePending}, []string{StateReady, StateFailed})
+	// StateNotFound is a pending state for create - handles eventual consistency where
+	// the resource may briefly return 404 after creation before becoming visible.
+	apiResp, err = WaitStateTransition(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, createTimeout, []string{StatePending, StateNotFound}, []string{StateReady, StateFailed})
 	if err != nil {
 		resp.Diagnostics.AddError("error waiting for stream connection to be ready", err.Error())
 		return

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"regexp"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -325,7 +324,12 @@ func (r *streamConnectionRS) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 	connectionName := streamConnectionState.ConnectionName.ValueString()
-	if err := DeleteStreamConnection(ctx, connV2.StreamsApi, projectID, instanceName, connectionName, 10*time.Minute); err != nil {
+
+	deleteTimeout := cleanup.ResolveTimeout(ctx, &streamConnectionState.Timeouts, cleanup.OperationDelete, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := DeleteStreamConnection(ctx, connV2.StreamsApi, projectID, instanceName, connectionName, deleteTimeout); err != nil {
 		resp.Diagnostics.AddError("error deleting resource", err.Error())
 		return
 	}

--- a/internal/service/streamconnection/state_transition.go
+++ b/internal/service/streamconnection/state_transition.go
@@ -21,10 +21,11 @@ const (
 	StateReady    = "READY"
 	StateDeleting = "DELETING"
 	StateFailed   = "FAILED"
+	StateDeleted  = "DELETED" // Virtual state used when resource is not found (404)
 )
 
 func DeleteStreamConnection(ctx context.Context, api admin.StreamsApi, projectID, instanceName, connectionName string, timeout time.Duration) error {
-	return retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		resp, err := api.DeleteStreamConnection(ctx, projectID, instanceName, connectionName).Execute()
 		if err == nil {
 			return nil
@@ -37,6 +38,66 @@ func DeleteStreamConnection(ctx context.Context, api admin.StreamsApi, projectID
 		}
 		return retry.NonRetryableError(err)
 	})
+	if err != nil {
+		return err
+	}
+
+	// Wait for delete to complete - some connections (e.g., Kafka VPC) are deleted asynchronously
+	// and go through a DELETING state before being fully removed
+	model, err := WaitDeleteStateTransition(ctx, projectID, instanceName, connectionName, api, timeout)
+	if err != nil {
+		return err
+	}
+	if model != nil && model.GetState() == StateFailed {
+		return errors.New("stream connection deletion failed")
+	}
+	return nil
+}
+
+// WaitDeleteStateTransition waits for a stream connection to be fully deleted.
+// It polls the GET endpoint until the connection returns 404 (not found) or reaches a FAILED state.
+// Returns the final model so the caller can inspect the state (e.g., to check for FAILED).
+func WaitDeleteStateTransition(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi, timeout time.Duration) (*admin.StreamsConnection, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{StateDeleting, StateReady, StatePending},
+		Target:     []string{StateDeleted, StateFailed},
+		Refresh:    deleteStreamConnectionRefreshFunc(ctx, projectID, workspaceName, connectionName, client),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      0,
+	}
+
+	result, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if connectionResp, ok := result.(*admin.StreamsConnection); ok {
+		return connectionResp, nil
+	}
+	return nil, nil
+}
+
+// deleteStreamConnectionRefreshFunc returns a function that polls the stream connection state during deletion.
+func deleteStreamConnectionRefreshFunc(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		model, resp, err := client.GetStreamConnection(ctx, projectID, workspaceName, connectionName).Execute()
+		if err != nil && model == nil && resp == nil {
+			return nil, "", err
+		}
+		if err != nil {
+			if validate.StatusNotFound(resp) {
+				// Resource is deleted
+				return &admin.StreamsConnection{}, StateDeleted, nil
+			}
+			return nil, "", err
+		}
+		state := model.GetState()
+		if state == "" {
+			// If state is not present, treat as still existing (will continue polling)
+			return model, StateReady, nil
+		}
+		return model, state, nil
+	}
 }
 
 // WaitStateTransition waits for a stream connection to reach a READY or FAILED state after create or update operations.

--- a/internal/service/streamconnection/state_transition.go
+++ b/internal/service/streamconnection/state_transition.go
@@ -3,16 +3,12 @@ package streamconnection
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"go.mongodb.org/atlas-sdk/v20250312014/admin"
-)
-
-const (
-	defaultCreateUpdateTimeout = 20 * time.Minute // The amount of time to wait before timeout for create/update
-	notFoundChecks             = 3                // Number of consecutive 404s allowed before failing (~1.4s with exponential backoff)
 )
 
 // Connection state constants
@@ -24,9 +20,9 @@ const (
 	StateDeleted  = "DELETED" // Virtual state used when resource is not found (404)
 )
 
-func DeleteStreamConnection(ctx context.Context, api admin.StreamsApi, projectID, instanceName, connectionName string, timeout time.Duration) error {
+func DeleteStreamConnection(ctx context.Context, api admin.StreamsApi, projectID, workspaceName, connectionName string, timeout time.Duration) error {
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
-		resp, err := api.DeleteStreamConnection(ctx, projectID, instanceName, connectionName).Execute()
+		resp, err := api.DeleteStreamConnection(ctx, projectID, workspaceName, connectionName).Execute()
 		if err == nil {
 			return nil
 		}
@@ -44,78 +40,25 @@ func DeleteStreamConnection(ctx context.Context, api admin.StreamsApi, projectID
 
 	// Wait for delete to complete - some connections (e.g., Kafka VPC) are deleted asynchronously
 	// and go through a DELETING state before being fully removed
-	model, err := WaitDeleteStateTransition(ctx, projectID, instanceName, connectionName, api, timeout)
+	pendingStates := []string{StateDeleting}
+	targetStates := []string{StateDeleted, StateFailed}
+	model, err := WaitStateTransition(ctx, projectID, workspaceName, connectionName, api, timeout, pendingStates, targetStates)
 	if err != nil {
 		return err
 	}
 	if model != nil && model.GetState() == StateFailed {
-		return errors.New("stream connection deletion failed")
+		return fmt.Errorf("stream connection deletion failed for connection '%s' in workspace '%s' (project: %s)", connectionName, workspaceName, projectID)
 	}
 	return nil
 }
 
-// WaitDeleteStateTransition waits for a stream connection to be fully deleted.
-// It polls the GET endpoint until the connection returns 404 (not found) or reaches a FAILED state.
-// Returns the final model so the caller can inspect the state (e.g., to check for FAILED).
-func WaitDeleteStateTransition(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi, timeout time.Duration) (*admin.StreamsConnection, error) {
+// WaitStateTransition waits for a stream connection to reach the specified target states.
+func WaitStateTransition(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi, timeout time.Duration, pendingStates, targetStates []string) (*admin.StreamsConnection, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{StateDeleting, StateReady, StatePending},
-		Target:     []string{StateDeleted, StateFailed},
-		Refresh:    deleteStreamConnectionRefreshFunc(ctx, projectID, workspaceName, connectionName, client),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
-		Delay:      0,
-	}
-
-	result, err := stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if connectionResp, ok := result.(*admin.StreamsConnection); ok {
-		return connectionResp, nil
-	}
-	return nil, nil
-}
-
-// deleteStreamConnectionRefreshFunc returns a function that polls the stream connection state during deletion.
-func deleteStreamConnectionRefreshFunc(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi) retry.StateRefreshFunc {
-	return func() (any, string, error) {
-		model, resp, err := client.GetStreamConnection(ctx, projectID, workspaceName, connectionName).Execute()
-		if err != nil && model == nil && resp == nil {
-			return nil, "", err
-		}
-		if err != nil {
-			if validate.StatusNotFound(resp) {
-				// Resource is deleted
-				return &admin.StreamsConnection{}, StateDeleted, nil
-			}
-			return nil, "", err
-		}
-		state := model.GetState()
-		if state == "" {
-			// If state is not present, treat as still existing (will continue polling)
-			return model, StateReady, nil
-		}
-		return model, state, nil
-	}
-}
-
-// WaitStateTransition waits for a stream connection to reach a READY or FAILED state after create or update operations.
-// It polls the GET endpoint until the connection is no longer in a PENDING state.
-// Some connections may be READY immediately, so there is no minimum wait time.
-func WaitStateTransition(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi) (*admin.StreamsConnection, error) {
-	return WaitStateTransitionWithTimeout(ctx, projectID, workspaceName, connectionName, client, defaultCreateUpdateTimeout)
-}
-
-// WaitStateTransitionWithTimeout waits for a stream connection to reach a READY or FAILED state with a custom timeout.
-func WaitStateTransitionWithTimeout(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi, timeout time.Duration) (*admin.StreamsConnection, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending:        []string{StatePending},
-		Target:         []string{StateReady, StateFailed},
-		Refresh:        streamConnectionRefreshFunc(ctx, projectID, workspaceName, connectionName, client),
-		Timeout:        timeout,
-		Delay:          0,
-		NotFoundChecks: notFoundChecks,
+		Pending: pendingStates,
+		Target:  targetStates,
+		Refresh: refreshFunc(ctx, projectID, workspaceName, connectionName, client),
+		Timeout: timeout,
 	}
 
 	result, err := stateConf.WaitForStateContext(ctx)
@@ -128,8 +71,9 @@ func WaitStateTransitionWithTimeout(ctx context.Context, projectID, workspaceNam
 	return nil, errors.New("did not obtain valid result when waiting for stream connection state transition")
 }
 
-// streamConnectionRefreshFunc returns a function that polls the stream connection state.
-func streamConnectionRefreshFunc(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi) retry.StateRefreshFunc {
+// refreshFunc returns a function that polls the stream connection state.
+// Returns StateDeleted when resource is not found (404).
+func refreshFunc(ctx context.Context, projectID, workspaceName, connectionName string, client admin.StreamsApi) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		model, resp, err := client.GetStreamConnection(ctx, projectID, workspaceName, connectionName).Execute()
 		if err != nil && model == nil && resp == nil {
@@ -137,17 +81,11 @@ func streamConnectionRefreshFunc(ctx context.Context, projectID, workspaceName, 
 		}
 		if err != nil {
 			if validate.StatusNotFound(resp) {
-				// Return nil to trigger NotFoundChecks for eventual consistency after creation
-				// After notFoundChecks consecutive 404s (~1.4s), it will fail fast
-				return nil, StatePending, nil
+				return &admin.StreamsConnection{}, StateDeleted, nil
 			}
 			return nil, "", err
 		}
 		state := model.GetState()
-		if state == "" {
-			// If state is not present in the response, assume the connection is ready
-			return model, StateReady, nil
-		}
 		return model, state, nil
 	}
 }

--- a/internal/service/streamconnection/state_transition_test.go
+++ b/internal/service/streamconnection/state_transition_test.go
@@ -18,7 +18,7 @@ func TestStreamConnectionDeletion(t *testing.T) {
 	var (
 		m                   = mockadmin.NewStreamsApi(t)
 		projectID           = "projectID"
-		instanceName        = "instanceName"
+		workspaceName       = "workspaceName"
 		connectionName      = "connectionName"
 		errDeleteInProgress = admin.ApiError{
 			ErrorCode: "STREAM_KAFKA_CONNECTION_IS_DEPLOYING",
@@ -32,48 +32,24 @@ func TestStreamConnectionDeletion(t *testing.T) {
 	notFoundErr.SetError("not found")
 
 	// Delete retries until success
-	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Times(3)
+	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Times(3)
 	m.EXPECT().DeleteStreamConnectionExecute(mock.Anything).Once().Return(nil, &genericErr)
 	m.EXPECT().DeleteStreamConnectionExecute(mock.Anything).Once().Return(nil, &genericErr)
 	m.EXPECT().DeleteStreamConnectionExecute(mock.Anything).Once().Return(nil, nil)
 
 	// After delete succeeds, wait for resource to be deleted (404 response)
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
+	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
 	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(nil, &http.Response{StatusCode: http.StatusNotFound}, &notFoundErr)
 
-	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, instanceName, connectionName, time.Minute)
+	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, workspaceName, connectionName, time.Minute)
 	assert.NoError(t, err)
 }
 
-func TestStreamConnectionDeletion404(t *testing.T) {
-	var (
-		m              = mockadmin.NewStreamsApi(t)
-		projectID      = "projectID"
-		instanceName   = "instanceName"
-		connectionName = "connectionName"
-		notFoundErr    = admin.GenericOpenAPIError{}
-	)
-	notFoundErr.SetError("not found")
-
-	// Delete returns 404 immediately (resource doesn't exist)
-	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Once()
-	m.EXPECT().DeleteStreamConnectionExecute(mock.Anything).Once().Return(&http.Response{StatusCode: http.StatusNotFound}, nil)
-
-	// Wait for delete still checks, gets 404 confirming resource is gone
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
-	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(nil, &http.Response{StatusCode: http.StatusNotFound}, &notFoundErr)
-
-	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, instanceName, connectionName, time.Minute)
-	assert.NoError(t, err)
-}
-
-// TestStreamConnectionDeletionWithDeletingState tests the async delete case where the
-// connection goes through a DELETING state before being fully removed.
 func TestStreamConnectionDeletionWithDeletingState(t *testing.T) {
 	var (
 		m              = mockadmin.NewStreamsApi(t)
 		projectID      = "projectID"
-		instanceName   = "instanceName"
+		workspaceName  = "workspaceName"
 		connectionName = "connectionName"
 		notFoundErr    = admin.GenericOpenAPIError{}
 	)
@@ -86,25 +62,41 @@ func TestStreamConnectionDeletionWithDeletingState(t *testing.T) {
 	}
 
 	// Delete call succeeds immediately
-	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Once()
+	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Once()
 	m.EXPECT().DeleteStreamConnectionExecute(mock.Anything).Once().Return(nil, nil)
 
 	// Wait for delete polls: first returns DELETING, second returns 404
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Times(2)
+	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Times(2)
 	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(deletingConnection, nil, nil)
 	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(nil, &http.Response{StatusCode: http.StatusNotFound}, &notFoundErr)
 
-	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, instanceName, connectionName, time.Minute)
+	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, workspaceName, connectionName, time.Minute)
 	assert.NoError(t, err)
 }
 
-// TestStreamConnectionDeletionFailed tests that deletion returns an error when the connection
-// transitions to FAILED state during deletion.
+func TestStreamConnectionDeletionNonRetryableError(t *testing.T) {
+	var (
+		m              = mockadmin.NewStreamsApi(t)
+		projectID      = "projectID"
+		workspaceName  = "workspaceName"
+		connectionName = "connectionName"
+		genericErr     = admin.GenericOpenAPIError{}
+	)
+	genericErr.SetError("internal server error")
+
+	// Delete returns non-retryable error
+	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Once()
+	m.EXPECT().DeleteStreamConnectionExecute(mock.Anything).Once().Return(&http.Response{StatusCode: http.StatusInternalServerError}, &genericErr)
+
+	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, workspaceName, connectionName, time.Minute)
+	require.Error(t, err)
+}
+
 func TestStreamConnectionDeletionFailed(t *testing.T) {
 	var (
 		m              = mockadmin.NewStreamsApi(t)
 		projectID      = "projectID"
-		instanceName   = "instanceName"
+		workspaceName  = "workspaceName"
 		connectionName = "connectionName"
 	)
 
@@ -115,115 +107,48 @@ func TestStreamConnectionDeletionFailed(t *testing.T) {
 	}
 
 	// Delete call succeeds immediately
-	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Once()
+	m.EXPECT().DeleteStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.DeleteStreamConnectionApiRequest{ApiService: m}).Once()
 	m.EXPECT().DeleteStreamConnectionExecute(mock.Anything).Once().Return(nil, nil)
 
 	// Wait for delete polls: returns FAILED state
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, instanceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
+	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
 	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(failedConnection, nil, nil)
 
-	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, instanceName, connectionName, time.Minute)
+	err := streamconnection.DeleteStreamConnection(t.Context(), m, projectID, workspaceName, connectionName, time.Minute)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "deletion failed")
+	assert.Contains(t, err.Error(), "stream connection deletion failed for connection 'connectionName' in workspace 'workspaceName' (project: projectID)")
 }
 
-func TestWaitStateTransitionSuccess(t *testing.T) {
+func TestWaitStateTransition(t *testing.T) {
 	var (
 		m              = mockadmin.NewStreamsApi(t)
 		projectID      = "projectID"
 		workspaceName  = "workspaceName"
 		connectionName = "connectionName"
 	)
-	expectedConnection := &admin.StreamsConnection{
-		Name:  new(connectionName),
-		Type:  new("Kafka"),
-		State: new("READY"),
-	}
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
-	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(expectedConnection, nil, nil)
 
-	result, err := streamconnection.WaitStateTransitionWithTimeout(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, connectionName, *result.Name)
-}
-
-func TestWaitStateTransitionPendingToReady(t *testing.T) {
-	var (
-		m              = mockadmin.NewStreamsApi(t)
-		projectID      = "projectID"
-		workspaceName  = "workspaceName"
-		connectionName = "connectionName"
-	)
 	pendingConnection := &admin.StreamsConnection{
-		Name:  new(connectionName),
-		Type:  new("Kafka"),
-		State: new("PENDING"),
+		Name:  admin.PtrString(connectionName),
+		Type:  admin.PtrString("Kafka"),
+		State: admin.PtrString("PENDING"),
 	}
 	readyConnection := &admin.StreamsConnection{
-		Name:  new(connectionName),
-		Type:  new("Kafka"),
-		State: new("READY"),
+		Name:  admin.PtrString(connectionName),
+		Type:  admin.PtrString("Kafka"),
+		State: admin.PtrString("READY"),
 	}
-	// First call returns PENDING, second call returns READY
+
 	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Times(2)
 	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(pendingConnection, nil, nil)
 	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(readyConnection, nil, nil)
 
-	result, err := streamconnection.WaitStateTransitionWithTimeout(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second)
+	pendingStates := []string{streamconnection.StatePending}
+	targetStates := []string{streamconnection.StateReady, streamconnection.StateFailed}
+	result, err := streamconnection.WaitStateTransition(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second, pendingStates, targetStates)
 	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, "READY", *result.State)
+	assert.Equal(t, "READY", result.GetState())
 }
 
-func TestWaitStateTransition404ThenReady(t *testing.T) {
-	var (
-		m              = mockadmin.NewStreamsApi(t)
-		projectID      = "projectID"
-		workspaceName  = "workspaceName"
-		connectionName = "connectionName"
-		genericErr     = admin.GenericOpenAPIError{}
-	)
-	genericErr.SetError("not found")
-	readyConnection := &admin.StreamsConnection{
-		Name:  new(connectionName),
-		Type:  new("Kafka"),
-		State: new("READY"),
-	}
-	// First call returns 404 (eventual consistency), second call returns READY
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Times(2)
-	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(nil, &http.Response{StatusCode: http.StatusNotFound}, &genericErr)
-	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(readyConnection, nil, nil)
-
-	// 404 should be treated as PENDING state to handle eventual consistency after creation
-	result, err := streamconnection.WaitStateTransitionWithTimeout(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, "READY", *result.State)
-}
-
-func TestWaitStateTransitionNotFoundExceedsLimit(t *testing.T) {
-	var (
-		m              = mockadmin.NewStreamsApi(t)
-		projectID      = "projectID"
-		workspaceName  = "workspaceName"
-		connectionName = "connectionName"
-		genericErr     = admin.GenericOpenAPIError{}
-	)
-	genericErr.SetError("not found")
-	// Return 404 more times than NotFoundChecks allows (3 checks + 1 to trigger error = 4 calls)
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Times(4)
-	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Return(nil, &http.Response{StatusCode: http.StatusNotFound}, &genericErr).Times(4)
-
-	// After exceeding NotFoundChecks, should return an error
-	result, err := streamconnection.WaitStateTransitionWithTimeout(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "couldn't find resource")
-	assert.Nil(t, result)
-}
-
-// TestWaitStateTransitionFailed verifies that when a connection reaches the FAILED state,
-// the function returns the connection (so Terraform can show the failure details).
 func TestWaitStateTransitionFailed(t *testing.T) {
 	var (
 		m              = mockadmin.NewStreamsApi(t)
@@ -231,62 +156,20 @@ func TestWaitStateTransitionFailed(t *testing.T) {
 		workspaceName  = "workspaceName"
 		connectionName = "connectionName"
 	)
+
 	failedConnection := &admin.StreamsConnection{
-		Name:  new(connectionName),
-		Type:  new("Kafka"),
-		State: new("FAILED"),
+		Name:  admin.PtrString(connectionName),
+		Type:  admin.PtrString("Kafka"),
+		State: admin.PtrString("FAILED"),
 	}
+
 	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
 	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(failedConnection, nil, nil)
 
-	// FAILED is a target state, so it should return successfully with the failed connection
-	result, err := streamconnection.WaitStateTransitionWithTimeout(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second)
+	// WaitStateTransition returns the model without error - caller must check the state
+	pendingStates := []string{streamconnection.StatePending}
+	targetStates := []string{streamconnection.StateReady, streamconnection.StateFailed}
+	result, err := streamconnection.WaitStateTransition(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second, pendingStates, targetStates)
 	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, "FAILED", *result.State)
-}
-
-// TestWaitStateTransitionEmptyStateAssumesReady verifies backward compatibility:
-// when the API response doesn't include a state field, we assume the connection is READY.
-func TestWaitStateTransitionEmptyStateAssumesReady(t *testing.T) {
-	var (
-		m              = mockadmin.NewStreamsApi(t)
-		projectID      = "projectID"
-		workspaceName  = "workspaceName"
-		connectionName = "connectionName"
-	)
-	// Connection without State field (backward compatibility with older API versions)
-	connectionWithoutState := &admin.StreamsConnection{
-		Name: new(connectionName),
-		Type: new("Kafka"),
-		// State is not set
-	}
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
-	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(connectionWithoutState, nil, nil)
-
-	// Empty state should be treated as READY
-	result, err := streamconnection.WaitStateTransitionWithTimeout(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, connectionName, *result.Name)
-}
-
-// TestWaitStateTransitionAPIError verifies that non-404 API errors fail immediately
-// rather than retrying indefinitely.
-func TestWaitStateTransitionAPIError(t *testing.T) {
-	var (
-		m              = mockadmin.NewStreamsApi(t)
-		projectID      = "projectID"
-		workspaceName  = "workspaceName"
-		connectionName = "connectionName"
-		genericErr     = admin.GenericOpenAPIError{}
-	)
-	genericErr.SetError("internal server error")
-	m.EXPECT().GetStreamConnection(mock.Anything, projectID, workspaceName, connectionName).Return(admin.GetStreamConnectionApiRequest{ApiService: m}).Once()
-	m.EXPECT().GetStreamConnectionExecute(mock.Anything).Once().Return(nil, &http.Response{StatusCode: http.StatusInternalServerError}, &genericErr)
-
-	// Non-404 errors should fail immediately
-	result, err := streamconnection.WaitStateTransitionWithTimeout(t.Context(), projectID, workspaceName, connectionName, m, 30*time.Second)
-	require.Error(t, err)
-	assert.Nil(t, result)
+	assert.Equal(t, "FAILED", result.GetState())
 }


### PR DESCRIPTION
## Description

### Summary
Update mongodbatlas_stream_connection to poll after DELETE until the connection is fully removed.

### Background
The DELETE API returns HTTP 202 Accepted immediately, but connections with private networking require asynchronous cleanup of cloud resources. During cleanup, the connection remains in DELETING state and cannot be recreated with the same name.

### Why This Change
Previously, users had no visibility into why connection recreation failed after a successful delete. With DELETING state now explicit, the provider can poll until deletion completes, ensuring subsequent terraform apply runs succeed.

### Not a Breaking Change
Older provider versions will experience the same behavior as before:
- DELETE still returns 202 Accepted
- Attempting to recreate a connection mid-cleanup still returns STREAM_CONNECTION_NAME_ALREADY_EXISTS
- The only difference is newer providers wait for cleanup to complete rather than returning immediately

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
