### PR TITLE
chore: Adding `environment.json` file and script for resigning commits

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-    "install": "make tools && make link-git-hooks"
+    "install": "make tools link-git-hooks"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+    "install": "make tools && make link-git-hooks"
+}

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ tflint: fmtcheck ## Linter for Terraform files in examples/ dir (avoid `internal
 tf-validate: fmtcheck ## Validate Terraform files
 	scripts/tf-validate.sh
 
+.PHONY: resign-commits
+resign-commits: ## Rebase commits ahead of master and re-sign them with GPG. Usage: make resign-commits [base=master]
+	./scripts/resign-commits.sh $(or $(base),master)
+
 .PHONY: link-git-hooks
 link-git-hooks: ## Install Git hooks
 	@echo "==> Installing all git hooks..."

--- a/scripts/resign-commits.sh
+++ b/scripts/resign-commits.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Rebase commits on the current branch (that are ahead of master) and re-sign them with GPG.
 # Usage: ./scripts/resign-commits.sh [base-branch]

--- a/scripts/resign-commits.sh
+++ b/scripts/resign-commits.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# Rebase commits on the current branch (that are ahead of master) and re-sign them with GPG.
+# Usage: ./scripts/resign-commits.sh [base-branch]
+# Default base: master
+
+BASE_BRANCH="${1:-master}"
+
+echo "==> Checking for uncommitted changes..."
+if ! git diff-index --quiet HEAD --; then
+  echo "Error: You have uncommitted changes. Please commit or stash them first."
+  exit 1
+fi
+
+echo "==> Checking if base branch '$BASE_BRANCH' exists..."
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  echo "Error: Base branch '$BASE_BRANCH' not found."
+  exit 1
+fi
+
+echo "==> Rebasing onto $BASE_BRANCH and re-signing commits..."
+git rebase --exec 'git commit --amend --no-edit -S' "$BASE_BRANCH"
+
+echo "==> Done. All commits have been re-signed."

--- a/scripts/resign-commits.sh
+++ b/scripts/resign-commits.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 BASE_BRANCH="${1:-master}"
 
 echo "==> Checking for uncommitted changes..."
-if ! git diff-index --quiet HEAD --; then
+if [ -n "$(git status --porcelain)" ]; then
   echo "Error: You have uncommitted changes. Please commit or stash them first."
   exit 1
 fi


### PR DESCRIPTION
## Description

Small improvement for handling and improving sage-bot generated PRs:

- `enviroment.json`: Ensure new instance properly installs tools and applies linting. Initial test PR had incorrect formating (https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4181), with new file `execution.json` did a rerun of the same prompt and generated PR applied linting correctly without any followups (https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4192).
- `make resign-commits`: Command to run locally once PR has been generated so that all generated commits are signed.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
