### PR TITLE
chore: Add support for skipping discriminator validator through `config.yml`

### DIFF
--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -25,6 +25,7 @@ func ApplyTransformationsToResource(resourceConfig *config.Resource, resource *R
 		return fmt.Errorf("failed to apply attribute transformations: %w", err)
 	}
 	applyAliasToDiscriminator(resourceConfig.SchemaOptions.Aliases, resource.Schema.Discriminator, &resource.Schema.Attributes)
+	applyIgnoreValidatorsToDiscriminators(resource.Schema.Discriminator, resource.Schema.Attributes, resourceConfig.SchemaOptions)
 	applyAliasToPathParams(&resource.Operations, resourceConfig.SchemaOptions.Aliases)
 	ApplyDeleteOnCreateTimeoutTransformation(resource)
 	ApplyTimeoutTransformation(resource)
@@ -49,6 +50,8 @@ func ApplyTransformationsToDataSources(dsConfig *config.DataSources, ds *DataSou
 
 	applyAliasToDiscriminator(dsConfig.SchemaOptions.Aliases, nil, ds.Schema.SingularDSAttributes)
 	applyAliasToDiscriminator(dsConfig.SchemaOptions.Aliases, nil, ds.Schema.PluralDSAttributes)
+	skipValidationForAllNestedDiscriminators(ds.Schema.SingularDSAttributes)
+	skipValidationForAllNestedDiscriminators(ds.Schema.PluralDSAttributes)
 	applyAliasToPathParams(&ds.Operations, dsConfig.SchemaOptions.Aliases)
 	return nil
 }
@@ -457,6 +460,80 @@ func applyAliasToDiscriminatorAttrNames(names []DiscriminatorAttrName, aliases m
 		applyAliasToDiscriminatorAttrName(&names[i], aliases, parentAPIPath)
 	}
 	sortDiscriminatorAttrNames(names)
+}
+
+func applyIgnoreValidatorsToDiscriminators(rootDisc *Discriminator, attrs Attributes, schemaOptions config.SchemaOptions) {
+	applyIgnoreValidatorsToDiscriminator(rootDisc, schemaOptions, "")
+	applyIgnoreValidatorsToNestedDiscriminators(attrs, schemaOptions, "")
+}
+
+func applyIgnoreValidatorsToDiscriminator(disc *Discriminator, schemaOptions config.SchemaOptions, parentSchemaPath string) {
+	if disc == nil {
+		return
+	}
+	overridePath := attrPathForOverrides(buildPath(parentSchemaPath, disc.PropertyName.TFSchemaName))
+	override, ok := schemaOptions.Overrides[overridePath]
+	if !ok {
+		return
+	}
+	for _, v := range override.IgnoreValidators {
+		if v == "polymorphic" {
+			disc.SkipValidation = true
+		}
+	}
+}
+
+func applyIgnoreValidatorsToNestedDiscriminators(attributes Attributes, schemaOptions config.SchemaOptions, parentSchemaPath string) {
+	for i := range attributes {
+		attr := &attributes[i]
+		schemaPath := buildPath(parentSchemaPath, attr.TFSchemaName)
+
+		switch {
+		case attr.ListNested != nil:
+			applyIgnoreValidatorsToDiscriminator(attr.ListNested.NestedObject.Discriminator, schemaOptions, schemaPath)
+			applyIgnoreValidatorsToNestedDiscriminators(attr.ListNested.NestedObject.Attributes, schemaOptions, schemaPath)
+		case attr.SingleNested != nil:
+			applyIgnoreValidatorsToDiscriminator(attr.SingleNested.NestedObject.Discriminator, schemaOptions, schemaPath)
+			applyIgnoreValidatorsToNestedDiscriminators(attr.SingleNested.NestedObject.Attributes, schemaOptions, schemaPath)
+		case attr.SetNested != nil:
+			applyIgnoreValidatorsToDiscriminator(attr.SetNested.NestedObject.Discriminator, schemaOptions, schemaPath)
+			applyIgnoreValidatorsToNestedDiscriminators(attr.SetNested.NestedObject.Attributes, schemaOptions, schemaPath)
+		case attr.MapNested != nil:
+			applyIgnoreValidatorsToDiscriminator(attr.MapNested.NestedObject.Discriminator, schemaOptions, schemaPath)
+			applyIgnoreValidatorsToNestedDiscriminators(attr.MapNested.NestedObject.Attributes, schemaOptions, schemaPath)
+		}
+	}
+}
+
+// skipValidationForAllNestedDiscriminators unconditionally sets SkipValidation on every
+// discriminator found in the attribute tree. Used for data sources where validators are never emitted.
+func skipValidationForAllNestedDiscriminators(attributes *Attributes) {
+	if attributes == nil {
+		return
+	}
+	for i := range *attributes {
+		attr := &(*attributes)[i]
+		switch {
+		case attr.ListNested != nil:
+			skipDiscriminator(attr.ListNested.NestedObject.Discriminator)
+			skipValidationForAllNestedDiscriminators(&attr.ListNested.NestedObject.Attributes)
+		case attr.SingleNested != nil:
+			skipDiscriminator(attr.SingleNested.NestedObject.Discriminator)
+			skipValidationForAllNestedDiscriminators(&attr.SingleNested.NestedObject.Attributes)
+		case attr.SetNested != nil:
+			skipDiscriminator(attr.SetNested.NestedObject.Discriminator)
+			skipValidationForAllNestedDiscriminators(&attr.SetNested.NestedObject.Attributes)
+		case attr.MapNested != nil:
+			skipDiscriminator(attr.MapNested.NestedObject.Discriminator)
+			skipValidationForAllNestedDiscriminators(&attr.MapNested.NestedObject.Attributes)
+		}
+	}
+}
+
+func skipDiscriminator(disc *Discriminator) {
+	if disc != nil {
+		disc.SkipValidation = true
+	}
 }
 
 // tagsAndLabelsAsMapTypeTransformation transforms attributes that represent collections of key/value pairs (tags and labels) from a nested list of objects into a Map type.

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -477,7 +477,7 @@ func applyIgnoreValidatorsToDiscriminator(disc *Discriminator, schemaOptions con
 		return
 	}
 	for _, v := range override.IgnoreValidators {
-		if v == "polymorphic" {
+		if v == "discriminator" {
 			disc.SkipValidation = true
 		}
 	}

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -773,6 +773,132 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 	}
 }
 
+func TestApplyTransformationsToResource_IgnoreValidatorsTransformation(t *testing.T) {
+	tests := map[string]struct {
+		inputResource   *codespec.Resource
+		inputConfig     *config.Resource
+		expectedDiscrim *codespec.Discriminator
+		expectedNested  *codespec.Discriminator
+		nestedAttrName  string
+	}{
+		"Root discriminator SkipValidation set when override has polymorphic": {
+			inputConfig: &config.Resource{
+				SchemaOptions: config.SchemaOptions{
+					Overrides: map[string]config.Override{
+						"type": {
+							IgnoreValidators: []string{"polymorphic"},
+						},
+					},
+				},
+			},
+			inputResource: &codespec.Resource{
+				Schema: &codespec.Schema{
+					Discriminator: &codespec.Discriminator{
+						PropertyName: codespec.DiscriminatorAttrName{APIName: "type", TFSchemaName: "type"},
+						Mapping: map[string]codespec.DiscriminatorType{
+							"A": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "attrA", TFSchemaName: "attr_a"}}},
+						},
+					},
+					Attributes: codespec.Attributes{
+						{
+							TFSchemaName:             "type",
+							TFModelName:              "Type",
+							APIName:                  "type",
+							ComputedOptionalRequired: codespec.Required,
+							String:                   &codespec.StringAttribute{},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+						},
+					},
+				},
+				Operations: codespec.APIOperations{
+					Create: &codespec.APIOperation{},
+					Read:   &codespec.APIOperation{},
+				},
+			},
+			expectedDiscrim: &codespec.Discriminator{
+				PropertyName:   codespec.DiscriminatorAttrName{APIName: "type", TFSchemaName: "type"},
+				SkipValidation: true,
+				Mapping: map[string]codespec.DiscriminatorType{
+					"A": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "attrA", TFSchemaName: "attr_a"}}},
+				},
+			},
+		},
+		"Nested discriminator SkipValidation set via dot-notation override path": {
+			inputConfig: &config.Resource{
+				SchemaOptions: config.SchemaOptions{
+					Overrides: map[string]config.Override{
+						"nested_obj.type": {
+							IgnoreValidators: []string{"polymorphic"},
+						},
+					},
+				},
+			},
+			inputResource: &codespec.Resource{
+				Schema: &codespec.Schema{
+					Attributes: codespec.Attributes{
+						{
+							TFSchemaName:             "nested_obj",
+							TFModelName:              "NestedObj",
+							APIName:                  "nestedObj",
+							ComputedOptionalRequired: codespec.Computed,
+							SingleNested: &codespec.SingleNestedAttribute{
+								NestedObject: codespec.NestedAttributeObject{
+									Discriminator: &codespec.Discriminator{
+										PropertyName: codespec.DiscriminatorAttrName{APIName: "type", TFSchemaName: "type"},
+										Mapping: map[string]codespec.DiscriminatorType{
+											"X": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "xAttr", TFSchemaName: "x_attr"}}},
+										},
+									},
+									Attributes: codespec.Attributes{
+										{
+											TFSchemaName:             "type",
+											TFModelName:              "Type",
+											APIName:                  "type",
+											ComputedOptionalRequired: codespec.Computed,
+											String:                   &codespec.StringAttribute{},
+											ReqBodyUsage:             codespec.OmitAlways,
+										},
+									},
+								},
+							},
+							ReqBodyUsage: codespec.OmitAlways,
+						},
+					},
+				},
+				Operations: codespec.APIOperations{
+					Create: &codespec.APIOperation{},
+					Read:   &codespec.APIOperation{},
+				},
+			},
+			nestedAttrName: "nested_obj",
+			expectedNested: &codespec.Discriminator{
+				PropertyName:   codespec.DiscriminatorAttrName{APIName: "type", TFSchemaName: "type"},
+				SkipValidation: true,
+				Mapping: map[string]codespec.DiscriminatorType{
+					"X": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "xAttr", TFSchemaName: "x_attr"}}},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := codespec.ApplyTransformationsToResource(tc.inputConfig, tc.inputResource)
+			require.NoError(t, err)
+			if tc.expectedDiscrim != nil {
+				assert.Equal(t, tc.expectedDiscrim, tc.inputResource.Schema.Discriminator)
+			}
+			if tc.nestedAttrName != "" {
+				for _, attr := range tc.inputResource.Schema.Attributes {
+					if attr.TFSchemaName == tc.nestedAttrName && attr.SingleNested != nil {
+						assert.Equal(t, tc.expectedNested, attr.SingleNested.NestedObject.Discriminator)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestApplyTransformationsToDataSources_AliasTransformation(t *testing.T) {
 	tests := map[string]struct {
 		inputDataSources   *codespec.DataSources

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -781,12 +781,12 @@ func TestApplyTransformationsToResource_IgnoreValidatorsTransformation(t *testin
 		expectedNested  *codespec.Discriminator
 		nestedAttrName  string
 	}{
-		"Root discriminator SkipValidation set when override has polymorphic": {
+		"Root discriminator SkipValidation set when override has discriminator": {
 			inputConfig: &config.Resource{
 				SchemaOptions: config.SchemaOptions{
 					Overrides: map[string]config.Override{
 						"type": {
-							IgnoreValidators: []string{"polymorphic"},
+							IgnoreValidators: []string{"discriminator"},
 						},
 					},
 				},
@@ -828,7 +828,7 @@ func TestApplyTransformationsToResource_IgnoreValidatorsTransformation(t *testin
 				SchemaOptions: config.SchemaOptions{
 					Overrides: map[string]config.Override{
 						"nested_obj.type": {
-							IgnoreValidators: []string{"polymorphic"},
+							IgnoreValidators: []string{"discriminator"},
 						},
 					},
 				},

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -108,8 +108,9 @@ type DiscriminatorAttrName struct {
 }
 
 type Discriminator struct {
-	Mapping      map[string]DiscriminatorType `yaml:"mapping"`
-	PropertyName DiscriminatorAttrName        `yaml:"property_name"`
+	Mapping        map[string]DiscriminatorType `yaml:"mapping"`
+	PropertyName   DiscriminatorAttrName        `yaml:"property_name"`
+	SkipValidation bool                         `yaml:"skip_validation,omitempty"`
 }
 
 type DiscriminatorType struct {

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -675,7 +675,7 @@ resources:
           request_body_usage: "send_null_as_null_on_update" # on update if an empty array is sent the index definition is rejected with error Invalid definition: "typeSets" cannot be empty.
         # discriminator in this schema is not helpful as polymorphism is within a nested property `definition`, violating ipa/125
         type:
-          ignore_validators: [polymorphic]
+          ignore_validators: [discriminator]
 
   # Update doesn't work because API defines incorrectly region and cloud_provider at root level in PATCH instead of inside data_process_region as in the other endpoints.
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.
@@ -717,9 +717,9 @@ resources:
       overrides:
         # discriminator is nested in an attribute that fully computed, follow up in CLOUDP-383599 so this filtering is done automatically
         connections.type:
-          ignore_validators: [polymorphic]
+          ignore_validators: [discriminator]
         connections.schema_registry_authentication.type:
-          ignore_validators: [polymorphic]
+          ignore_validators: [discriminator]
 
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.
   # Custom methods :startWith and :stop are not called so state attribute is not supported as Optional like in the curated resource, only as Computed.
@@ -1184,7 +1184,7 @@ resources:
             immutable_computed: true
           # no need for discriminator as there is currently only a single type, keep prod code exactly as it
           type:
-            ignore_validators: [polymorphic]
+            ignore_validators: [discriminator]
     datasources:
       read:
         path: /api/atlas/v2/groups/{groupId}/logIntegrations/{id}

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -715,7 +715,7 @@ resources:
       aliases:
         tenantName: name # path param name does not match the API request property
       overrides:
-        # discriminator is nested in an attribute that fully computed, follow up in CLOUDP-383599 so this filtering is done automatically
+        # discriminator is nested in an attribute that is fully computed, follow up in CLOUDP-383599 so this filtering is done automatically
         connections.type:
           ignore_validators: [discriminator]
         connections.schema_registry_authentication.type:

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -718,7 +718,7 @@ resources:
         # discriminator is nested in an attribute that fully computed, follow up in CLOUDP-383599 so this filtering is done automatically
         connections.type:
           ignore_validators: [polymorphic]
-        connections.authentication.type:
+        connections.schema_registry_authentication.type:
           ignore_validators: [polymorphic]
 
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -673,6 +673,9 @@ resources:
       overrides:
         definition.type_sets:
           request_body_usage: "send_null_as_null_on_update" # on update if an empty array is sent the index definition is rejected with error Invalid definition: "typeSets" cannot be empty.
+        # discriminator in this schema is not helpful as polymorphism is within a nested property `definition`, violating ipa/125
+        type:
+          ignore_validators: [polymorphic]
 
   # Update doesn't work because API defines incorrectly region and cloud_provider at root level in PATCH instead of inside data_process_region as in the other endpoints.
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.
@@ -711,6 +714,12 @@ resources:
         ]
       aliases:
         tenantName: name # path param name does not match the API request property
+      overrides:
+        # discriminator is nested in an attribute that fully computed, follow up in CLOUDP-383599 so this filtering is done automatically
+        connections.type:
+          ignore_validators: [polymorphic]
+        connections.authentication.type:
+          ignore_validators: [polymorphic]
 
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.
   # Custom methods :startWith and :stop are not called so state attribute is not supported as Optional like in the curated resource, only as Computed.
@@ -1173,6 +1182,9 @@ resources:
             description: *project_id_description
           integration_id:
             immutable_computed: true
+          # no need for discriminator as there is currently only a single type, keep prod code exactly as it
+          type:
+            ignore_validators: [polymorphic]
     datasources:
       read:
         path: /api/atlas/v2/groups/{groupId}/logIntegrations/{id}

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -1182,7 +1182,7 @@ resources:
             description: *project_id_description
           integration_id:
             immutable_computed: true
-          # no need for discriminator as there is currently only a single type, keep prod code exactly as it
+          # no need for discriminator as there is currently only a single type, keep prod code exactly as is
           type:
             ignore_validators: [discriminator]
     datasources:

--- a/tools/codegen/config/config_model.go
+++ b/tools/codegen/config/config_model.go
@@ -61,6 +61,7 @@ type Override struct {
 	Description        string         `yaml:"description"`
 	PlanModifiers      []PlanModifier `yaml:"plan_modifiers"`
 	Validators         []Validator    `yaml:"validators"`
+	IgnoreValidators   []string       `yaml:"ignore_validators"`
 }
 
 type PlanModifier struct {

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -17,6 +17,7 @@ schema:
         property_name:
             api_name: type
             tf_schema_name: type
+        skip_validation: true
     attributes:
         - string: {}
           description: Human-readable label that identifies the S3 bucket name for storing log files.
@@ -273,6 +274,7 @@ data_sources:
                         property_name:
                             api_name: type
                             tf_schema_name: type
+                        skip_validation: true
                     attributes:
                         - string: {}
                           description: Human-readable label that identifies the S3 bucket name for storing log files.

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -13,6 +13,7 @@ schema:
         property_name:
             api_name: type
             tf_schema_name: type
+        skip_validation: true
     attributes:
         - string: {}
           description: Name of the cluster that contains the collection on which to create an Atlas Search index.

--- a/tools/codegen/models/stream_instance_api.yaml
+++ b/tools/codegen/models/stream_instance_api.yaml
@@ -486,6 +486,7 @@ schema:
                                 property_name:
                                     api_name: type
                                     tf_schema_name: type
+                                skip_validation: true
                             attributes:
                                 - string: {}
                                   description: Password or Private Key for authentication.

--- a/tools/codegen/models/stream_instance_api.yaml
+++ b/tools/codegen/models/stream_instance_api.yaml
@@ -67,6 +67,7 @@ schema:
                     property_name:
                         api_name: type
                         tf_schema_name: type
+                    skip_validation: true
                 attributes:
                     - single_nested:
                         nested_object:


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-381489

- Adds support for suppressing discriminator validators on a per-attribute basis through the ignore_validators config option in `config.yml`.
- Logic is added to ensure data sources do not include discriminator validation as they are computed only attributes.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
