### PR TITLE
chore: Allows dependabot to update indirect go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+    allow:
+      - dependency-type: "all"
     commit-message:
       prefix: "chore"
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
- Adds `allow: - dependency-type: "all"` to the gomod dependabot config
- By default dependabot only updates direct go dependencies; this enables updates for indirect (transitive) dependencies to fix security warnings

## References
- Same change as https://github.com/terraform-mongodbatlas-modules/terraform-mongodbatlas-cluster/pull/107
