### PR TITLE
feat: Add send_query_stats_metrics to third_party_integration

### DIFF
--- a/.changelog/4228.txt
+++ b/.changelog/4228.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_third_party_integration: Adds `send_query_stats_metrics` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_third_party_integration: Adds `send_query_stats_metrics` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_third_party_integrations: Adds `send_query_stats_metrics` attribute
+```

--- a/docs/data-sources/third_party_integration.md
+++ b/docs/data-sources/third_party_integration.md
@@ -50,9 +50,10 @@ Additional values based on Type
 * `DATADOG`
   * `api_key` - Your API Key.
   * `region` - Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-getthirdpartyintegration) for more details. Datadog will use "US" by default.
-  * `send_collection_latency_metrics` - Toggle sending collection latency metrics that includes database names and collection name sand latency metrics on reads, writes, commands, and transactions.
+  * `send_collection_latency_metrics` - Toggle sending collection latency metrics that includes database names and collection names and latency metrics on reads, writes, commands, and transactions.
   * `send_database_metrics` - Toggle sending database metrics that includes database names and metrics on the number of collections, storage size, and index size.
-  * `send_user_provided_resource_tags` - Toggle sending user provided group and cluster resource tags with the datadog metrics.
+  * `send_user_provided_resource_tags` - Toggle sending user provided group and cluster resource tags with the Datadog metrics.
+  * `send_query_stats_metrics` - Toggle sending query shape metrics that includes query hash and metrics on latency, execution frequency, documents returned, and timestamps.
 * `OPS_GENIE`
   * `api_key` - Your API Key.
   * `region` - Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-getthirdpartyintegration) for more details. Opsgenie will use US by default.

--- a/docs/data-sources/third_party_integrations.md
+++ b/docs/data-sources/third_party_integrations.md
@@ -66,7 +66,8 @@ Additional values based on Type
   * `region` - Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-getthirdpartyintegration) for more details. Datadog will use "US" by default.
   * `send_collection_latency_metrics` - Toggle sending collection latency metrics that includes database names and collection names and latency metrics on reads, writes, commands, and transactions.
   * `send_database_metrics` - Toggle sending database metrics that includes database names and metrics on the number of collections, storage size, and index size.
-  * `send_user_provided_resource_tags` - Toggle sending user provided group and cluster resource tags with the datadog metrics.
+  * `send_user_provided_resource_tags` - Toggle sending user provided group and cluster resource tags with the Datadog metrics.
+  * `send_query_stats_metrics` - Toggle sending query shape metrics that includes query hash and metrics on latency, execution frequency, documents returned, and timestamps.
 * `OPS_GENIE`
   * `api_key` - Your API Key.
   * `region` -  Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-getthirdpartyintegration) for more details. Opsgenie will use US by default.

--- a/docs/resources/third_party_integration.md
+++ b/docs/resources/third_party_integration.md
@@ -10,7 +10,7 @@ subcategory: "Projects"
 
 -> **NOTE:** Slack integrations now use the OAuth2 verification method and must be initially configured, or updated from a legacy integration, through the Atlas third-party service integrations page. Legacy tokens will soon no longer be supported.[Read more about slack setup](https://docs.atlas.mongodb.com/tutorial/third-party-service-integrations/)
 
-~> **IMPORTANT** Each project can only have one configuration per {INTEGRATION-TYPE}.
+~> **IMPORTANT** Each project can only have one configuration per integration `type`.
 
 ~> **IMPORTANT:** All arguments including the secrets will be stored in the raw state as plain-text. [Read more about sensitive data in state.](https://www.terraform.io/docs/state/sensitive-data.html)
 
@@ -52,7 +52,8 @@ resource "mongodbatlas_third_party_integration" "test_datadog" {
   * `region` (Required) - Two-letter code that indicates which API URL to use. See the `region` request parameter of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createthirdpartyintegration) for more details.
   * `send_collection_latency_metrics` - Toggle sending collection latency metrics that includes database names and collection names and latency metrics on reads, writes, commands, and transactions. Default: `false`.
   * `send_database_metrics` - Toggle sending database metrics that includes database names and metrics on the number of collections, storage size, and index size. Default: `false`.
-  * `send_user_provided_resource_tags` - Toggle sending user provided group and cluster resource tags with the datadog metrics. Default: `false`.
+  * `send_user_provided_resource_tags` - Toggle sending user provided group and cluster resource tags with the Datadog metrics. Default: `false`.
+  * `send_query_stats_metrics` - Toggle sending query shape metrics that includes query hash and metrics on latency, execution frequency, documents returned, and timestamps. Default: `false`.
 * `OPS_GENIE`
   * `api_key` - Your API Key.
   * `region` (Required) - Two-letter code that indicates which API URL to use. See the `region` request parameter of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createthirdpartyintegration) for more details.

--- a/examples/mongodbatlas_third_party_integration/datadog/integration.tf
+++ b/examples/mongodbatlas_third_party_integration/datadog/integration.tf
@@ -7,4 +7,5 @@ resource "mongodbatlas_third_party_integration" "test-datadog" {
   send_collection_latency_metrics  = var.send_collection_latency_metrics
   send_database_metrics            = var.send_database_metrics
   send_user_provided_resource_tags = var.send_user_provided_resource_tags
+  send_query_stats_metrics         = var.send_query_stats_metrics
 }

--- a/examples/mongodbatlas_third_party_integration/datadog/variables.tf
+++ b/examples/mongodbatlas_third_party_integration/datadog/variables.tf
@@ -45,3 +45,9 @@ variable "send_user_provided_resource_tags" {
   default     = false
   type        = bool
 }
+
+variable "send_query_stats_metrics" {
+  description = "Send query shape metrics (only for Datadog integrations)"
+  default     = false
+  type        = bool
+}

--- a/internal/service/thirdpartyintegration/data_source.go
+++ b/internal/service/thirdpartyintegration/data_source.go
@@ -114,6 +114,10 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"send_query_stats_metrics": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/service/thirdpartyintegration/model.go
+++ b/internal/service/thirdpartyintegration/model.go
@@ -75,6 +75,7 @@ func integrationToSchema(d *schema.ResourceData, integration *admin.ThirdPartyIn
 		"send_collection_latency_metrics":  integration.SendCollectionLatencyMetrics,
 		"send_database_metrics":            integration.SendDatabaseMetrics,
 		"send_user_provided_resource_tags": integration.SendUserProvidedResourceTags,
+		"send_query_stats_metrics":         integration.SendQueryStatsMetrics,
 	}
 
 	// removing optional empty values, terraform complains about unexpected values even though they're empty
@@ -164,6 +165,10 @@ func schemaToIntegration(in *schema.ResourceData) (out *admin.ThirdPartyIntegrat
 		out.SendUserProvidedResourceTags = new(sendUserProvidedResourceTags.(bool))
 	}
 
+	if sendQueryStatsMetrics, ok := in.GetOk("send_query_stats_metrics"); ok {
+		out.SendQueryStatsMetrics = new(sendQueryStatsMetrics.(bool))
+	}
+
 	return out
 }
 
@@ -228,5 +233,9 @@ func updateIntegrationFromSchema(d *schema.ResourceData, integration *admin.Thir
 
 	if d.HasChange("send_user_provided_resource_tags") {
 		integration.SendUserProvidedResourceTags = new(d.Get("send_user_provided_resource_tags").(bool))
+	}
+
+	if d.HasChange("send_query_stats_metrics") {
+		integration.SendQueryStatsMetrics = new(d.Get("send_query_stats_metrics").(bool))
 	}
 }

--- a/internal/service/thirdpartyintegration/resource.go
+++ b/internal/service/thirdpartyintegration/resource.go
@@ -146,6 +146,11 @@ func Resource() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"send_query_stats_metrics": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Optional: true,
+			},
 		},
 	}
 }

--- a/internal/service/thirdpartyintegration/resource_test.go
+++ b/internal/service/thirdpartyintegration/resource_test.go
@@ -12,14 +12,29 @@ import (
 )
 
 // dummy keys used for credential values in third party notifications
-const dummy32CharKey = "11111111111111111111111111111111"
-const dummy32CharKeyUpdated = "11111111111111111111111111111112"
-const dummy36CharKey = "11111111-1111-1111-1111-111111111111"
-const dummy36CharKeyUpdated = "11111111-1111-1111-1111-111111111112"
+const (
+	dummy32CharKey        = "11111111111111111111111111111111"
+	dummy32CharKeyUpdated = "11111111111111111111111111111112"
+	dummy36CharKey        = "11111111-1111-1111-1111-111111111111"
+	dummy36CharKeyUpdated = "11111111-1111-1111-1111-111111111112"
 
-const resourceName = "mongodbatlas_third_party_integration.test"
-const dataSourceName = "data." + resourceName
-const dataSourcePluralName = "data.mongodbatlas_third_party_integrations.test"
+	resourceName         = "mongodbatlas_third_party_integration.test"
+	dataSourceName       = "data." + resourceName
+	dataSourcePluralName = "data.mongodbatlas_third_party_integrations.test"
+
+	singularDataStr = `
+		data "mongodbatlas_third_party_integration" "test" {
+			project_id = mongodbatlas_third_party_integration.test.project_id
+			type = mongodbatlas_third_party_integration.test.type
+		}
+	`
+	pluralDataStr = `
+		data "mongodbatlas_third_party_integrations" "test" {
+			project_id = mongodbatlas_third_party_integration.test.project_id
+			depends_on = [mongodbatlas_third_party_integration.test]
+		}
+	`
+)
 
 func TestAccThirdPartyIntegration_basicPagerDuty(t *testing.T) {
 	// basic test also include testing of plural data source which is why it cannot run in parallel
@@ -179,7 +194,7 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configDatadog(projectID, apiKey, "US", false, false, false, false),
+				Config: configDatadog(projectID, apiKey, "US", false, false, false, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
@@ -187,15 +202,18 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 					resource.TestCheckResourceAttr(resourceName, "region", region),
 					resource.TestCheckResourceAttr(resourceName, "send_collection_latency_metrics", "false"),
 					resource.TestCheckResourceAttr(resourceName, "send_database_metrics", "false"),
+					resource.TestCheckResourceAttr(resourceName, "send_user_provided_resource_tags", "false"),
+					resource.TestCheckResourceAttr(resourceName, "send_query_stats_metrics", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "type", intType),
 					resource.TestCheckResourceAttr(dataSourceName, "region", region),
 					resource.TestCheckResourceAttr(dataSourceName, "send_collection_latency_metrics", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "send_database_metrics", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "send_user_provided_resource_tags", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "send_query_stats_metrics", "false"),
 				),
 			},
 			{
-				Config: configDatadog(projectID, apiKey, "US", true, true, false, false),
+				Config: configDatadog(projectID, apiKey, "US", true, true, false, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
@@ -203,15 +221,18 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 					resource.TestCheckResourceAttr(resourceName, "region", region),
 					resource.TestCheckResourceAttr(resourceName, "send_collection_latency_metrics", "true"),
 					resource.TestCheckResourceAttr(resourceName, "send_database_metrics", "false"),
+					resource.TestCheckResourceAttr(resourceName, "send_user_provided_resource_tags", "false"),
+					resource.TestCheckResourceAttr(resourceName, "send_query_stats_metrics", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "type", intType),
 					resource.TestCheckResourceAttr(dataSourceName, "region", region),
 					resource.TestCheckResourceAttr(dataSourceName, "send_collection_latency_metrics", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "send_database_metrics", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "send_user_provided_resource_tags", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "send_query_stats_metrics", "false"),
 				),
 			},
 			{
-				Config: configDatadog(projectID, updatedAPIKey, "US", true, false, true, false),
+				Config: configDatadog(projectID, updatedAPIKey, "US", true, false, true, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
@@ -220,10 +241,11 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 					resource.TestCheckResourceAttr(resourceName, "send_collection_latency_metrics", "false"),
 					resource.TestCheckResourceAttr(resourceName, "send_database_metrics", "true"),
 					resource.TestCheckResourceAttr(resourceName, "send_user_provided_resource_tags", "false"),
+					resource.TestCheckResourceAttr(resourceName, "send_query_stats_metrics", "false"),
 				),
 			},
 			{
-				Config: configDatadog(projectID, updatedAPIKey, "US", true, true, true, true),
+				Config: configDatadog(projectID, updatedAPIKey, "US", true, true, true, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
@@ -231,9 +253,12 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 					resource.TestCheckResourceAttr(resourceName, "region", region),
 					resource.TestCheckResourceAttr(resourceName, "send_collection_latency_metrics", "true"),
 					resource.TestCheckResourceAttr(resourceName, "send_database_metrics", "true"),
+					resource.TestCheckResourceAttr(resourceName, "send_user_provided_resource_tags", "true"),
+					resource.TestCheckResourceAttr(resourceName, "send_query_stats_metrics", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "send_collection_latency_metrics", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "send_database_metrics", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "send_user_provided_resource_tags", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "send_query_stats_metrics", "true"),
 				),
 			},
 			importStep(resourceName),
@@ -406,125 +431,90 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	}
 }
 
-var singularDataStr = `
-data "mongodbatlas_third_party_integration" "test" {
-	project_id = mongodbatlas_third_party_integration.test.project_id
-	type = mongodbatlas_third_party_integration.test.type
-}
-
-`
-
-var pluralDataStr = `
-data "mongodbatlas_third_party_integrations" "test" {
-	project_id = mongodbatlas_third_party_integration.test.project_id
-}`
-
 func configOpsGenie(projectID, apiKey string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_third_party_integration" "test" {
-		project_id = "%[1]s"
-		type = "%[2]s"
-		api_key = "%[3]s"
-		region  = "%[4]s"
-	}`,
-		projectID,
-		"OPS_GENIE",
-		apiKey,
-		"US",
-	) + singularDataStr
+		resource "mongodbatlas_third_party_integration" "test" {
+			project_id = "%[1]s"
+			type = "%[2]s"
+			api_key = "%[3]s"
+			region  = "%[4]s"
+		}
+	`, projectID, "OPS_GENIE", apiKey, "US") + singularDataStr
 }
 
 func configBasicPagerDuty(projectID, serviceKey string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_third_party_integration" "test" {
-		project_id = "%[1]s"
-		type = "%[2]s"
-		service_key = "%[3]s"
-	}
-	`,
-		projectID,
-		"PAGER_DUTY",
-		serviceKey,
-	) + singularDataStr + pluralDataStr
+		resource "mongodbatlas_third_party_integration" "test" {
+			project_id = "%[1]s"
+			type = "%[2]s"
+			service_key = "%[3]s"
+		}
+	`, projectID, "PAGER_DUTY", serviceKey) + singularDataStr + pluralDataStr
 }
 
 func configVictorOps(projectID, apiKey string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_third_party_integration" "test" {
-		project_id = "%[1]s"
-		type = "%[2]s"
-		api_key = "%[3]s"
-		routing_key = "testing"
-	}
-	`,
-		projectID,
-		"VICTOR_OPS",
-		apiKey,
-	) + singularDataStr
+		resource "mongodbatlas_third_party_integration" "test" {
+			project_id = "%[1]s"
+			type = "%[2]s"
+			api_key = "%[3]s"
+			routing_key = "testing"
+		}
+	`, projectID, "VICTOR_OPS", apiKey) + singularDataStr
 }
 
-func configDatadog(projectID, apiKey, region string, useOptionalAttr, sendCollectionLatencyMetrics, sendDatabaseMetrics, sendUserProvidedResourceTags bool) string {
+func configDatadog(projectID, apiKey, region string, useOptionalAttr, sendCollectionLatencyMetrics, sendDatabaseMetrics, sendUserProvidedResourceTags, sendQueryStatsMetrics bool) string {
 	optionalConfigAttrs := ""
 	if useOptionalAttr {
-		optionalConfigAttrs = fmt.Sprintf(
-			`send_collection_latency_metrics = %[1]t
-		send_database_metrics = %[2]t
-		send_user_provided_resource_tags = %[3]t`, sendCollectionLatencyMetrics, sendDatabaseMetrics, sendUserProvidedResourceTags)
+		optionalConfigAttrs = fmt.Sprintf(`
+			send_collection_latency_metrics = %[1]t
+			send_database_metrics = %[2]t
+			send_user_provided_resource_tags = %[3]t
+			send_query_stats_metrics = %[4]t
+		`, sendCollectionLatencyMetrics, sendDatabaseMetrics, sendUserProvidedResourceTags, sendQueryStatsMetrics)
 	}
 	return fmt.Sprintf(`
-	resource "mongodbatlas_third_party_integration" "test" {
-		project_id = "%[1]s"
-		type = "%[2]s"
-		api_key = "%[3]s"
-		region  ="%[4]s"
-		
-		%[5]s
-	}
-	`,
-		projectID,
-		"DATADOG",
-		apiKey,
-		region,
-		optionalConfigAttrs,
-	) + singularDataStr
+		resource "mongodbatlas_third_party_integration" "test" {
+			project_id = "%[1]s"
+			type = "%[2]s"
+			api_key = "%[3]s"
+			region  ="%[4]s"
+			
+			%[5]s
+		}
+	`, projectID, "DATADOG", apiKey, region, optionalConfigAttrs) + singularDataStr
 }
 
 func configPrometheus(projectID, username, password, serviceDiscovery string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_third_party_integration" "test" {
-		project_id = "%[1]s"
-		type = "%[2]s"
-		user_name = "%[3]s"	
-		password  = "%[4]s"
-		service_discovery = "%[5]s" 
-		enabled = true
-	}
-	`,
-		projectID,
-		"PROMETHEUS",
-		username,
-		password,
-		serviceDiscovery,
-	) + singularDataStr
+		resource "mongodbatlas_third_party_integration" "test" {
+			project_id = "%[1]s"
+			type = "%[2]s"
+			user_name = "%[3]s"	
+			password  = "%[4]s"
+			service_discovery = "%[5]s" 
+			enabled = true
+		}
+	`, projectID, "PROMETHEUS", username, password, serviceDiscovery) + singularDataStr
 }
 
 func configMicrosoftTeams(projectID, url string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_third_party_integration" "test" {
-		project_id = "%[1]s"
-		type = "MICROSOFT_TEAMS"
-		microsoft_teams_webhook_url = "%[2]s"	
-	}
+		resource "mongodbatlas_third_party_integration" "test" {
+			project_id = "%[1]s"
+			type = "MICROSOFT_TEAMS"
+			microsoft_teams_webhook_url = "%[2]s"	
+		}
 	`, projectID, url) + singularDataStr
 }
 
 func configWebhook(projectID, url string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_third_party_integration" "test" {
-		project_id = "%[1]s"
-		type = "WEBHOOK"
-		url = "%[2]s"	
-	}
+		resource "mongodbatlas_third_party_integration" "test" {
+			project_id = "%[1]s"
+			type = "WEBHOOK"
+			url = "%[2]s"	
+		}
 	`, projectID, url) + singularDataStr
 }
 


### PR DESCRIPTION
## Description

Add a new attribute `send_query_stats_metrics` to the `third_party_integration` resource and data sources.
This attribute is similar to other Datadog attributes like `send_collection_latency_metrics`, `send_database_metrics` and `send_user_provided_resource_tags`.

Link to any related issue(s): CLOUDP-383913

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
