### PR TITLE
chore: Federated settings identity provider role sort crash

### DIFF
--- a/.changelog/4233.txt
+++ b/.changelog/4233.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
-resource/mongodbatlas_federated_settings_identity_provider: Fixes crash when role assignments have no role defined
+data-source/mongodbatlas_federated_settings_identity_provider: Fixes crash when role assignments have no role defined
+```
+
+```release-note:bug
+data-source/mongodbatlas_federated_settings_identity_providers: Fixes crash when role assignments have no role defined
 ```

--- a/.changelog/4233.txt
+++ b/.changelog/4233.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_federated_settings_identity_provider: Fixes crash when role assignments have no role defined
+```


### PR DESCRIPTION
## Description

Adds changelog entry for a bug fix where sorting role assignments in `mongodbatlas_federated_settings_identity_provider` could crash when a role assignment had no role defined. Only the data sources are affected, not the resource.

The actual code fix is in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4224. This PR only adds the changelog entry.

Link to any related issue(s): CLOUDP-383524

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
