### PR TITLE
chore: Pass PAT via repo-token input in stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,12 +10,11 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.APIX_BOT_PAT }}
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         id: stale
         with:
+          repo-token: ${{ secrets.APIX_BOT_PAT }}
           stale-issue-message: 'This issue has gone 7 days without any activity and meets the project’s definition of "stale". This will be auto-closed if there is no new activity over the next 7 days. If the issue is still relevant and active, you can simply comment with a "bump" to keep it open, or add the label "not_stale". Thanks for keeping our repository healthy!'
           stale-pr-message: 'This PR has gone 7 days without any activity and meets the project’s definition of "stale". This will be auto-closed if there is no new activity over the next 7 days. If the issue is still relevant and active, you can simply comment with a "bump" to keep it open, or add the label "not_stale". Thanks for keeping our repository healthy!'
           stale-issue-label: 'stale'


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-384276

When the stale bot closes a GitHub issue, the corresponding Jira ticket is not updated (closed) by the `issues.yml` workflow. This happens because `actions/stale` authenticates using its `repo-token` input parameter, which defaults to `${{ github.token }}` — the auto-generated workflow token. Setting `APIX_BOT_PAT` as the `GITHUB_TOKEN` environment variable (current implementation) at the job level has no effect on the action's authentication.

Per GitHub's documentation, [events triggered by `GITHUB_TOKEN` will not create new workflow runs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs). This means when the stale action closes an issue using the default token, the `issues: closed` event is suppressed and the `issues.yml` workflow never fires.

The fix passes the PAT explicitly via the [`repo-token` input](https://github.com/actions/stale?tab=readme-ov-file#repo-token) so the stale action authenticates with it. Events generated by a PAT are not subject to the suppression rule, so closing an issue will now correctly trigger the Jira sync workflow. The now-redundant `GITHUB_TOKEN` env var override is also removed.

Fix was not tested, we will have to keep an eye on future stale issues to 100% know fix is in place.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

References:
- [GitHub docs: When GITHUB_TOKEN triggers workflow runs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs)
- [actions/stale docs: repo-token](https://github.com/actions/stale?tab=readme-ov-file#repo-token)