### PR TITLE
fix: Correctly use documented defaults for streams resource creates, updates and deletes

### DIFF
--- a/.changelog/4239.txt
+++ b/.changelog/4239.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/mongodbatlas_stream_connection: Fixes default timeout for create, update, and delete operations to use 20 minutes instead of the generic 3-hour fallback
+```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Updates default delete timeout from 10 minutes to 20 minutes to be consistent with create and update operations
+```

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -322,7 +322,7 @@ resource "mongodbatlas_stream_connection" "example" {
 
 * `create` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after creation. Defaults to `20m` (20 minutes).
 * `update` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after an update. Defaults to `20m` (20 minutes).
-* `delete` - (Optional) The maximum time to wait for the stream connection to be fully deleted. Defaults to `10m` (10 minutes).
+* `delete` - (Optional) The maximum time to wait for the stream connection to be fully deleted. Defaults to `20m` (20 minutes).
 
 ## Import
 

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -3,6 +3,7 @@ package streamconnection
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -17,8 +18,8 @@ import (
 )
 
 const (
-	defaultCreateUpdateTimeoutDoc = "20m"
-	defaultDeleteTimeoutDoc       = "10m"
+	DefaultConnectionTimeout    = 20 * time.Minute
+	defaultConnectionTimeoutDoc = "20m"
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -211,9 +212,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Create:            true,
 				Update:            true,
 				Delete:            true,
-				CreateDescription: constant.TimeoutDescriptionCreateReadUpdate(defaultCreateUpdateTimeoutDoc),
-				UpdateDescription: constant.TimeoutDescriptionCreateReadUpdate(defaultCreateUpdateTimeoutDoc),
-				DeleteDescription: constant.TimeoutDescriptionDelete(defaultDeleteTimeoutDoc),
+				CreateDescription: constant.TimeoutDescriptionCreateReadUpdate(defaultConnectionTimeoutDoc),
+				UpdateDescription: constant.TimeoutDescriptionCreateReadUpdate(defaultConnectionTimeoutDoc),
+				DeleteDescription: constant.TimeoutDescriptionDelete(defaultConnectionTimeoutDoc),
 			}),
 		},
 	}

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -202,16 +202,15 @@ func (r *streamConnectionRS) Create(ctx context.Context, req resource.CreateRequ
 
 	connectionName := conversion.SafeValue(apiResp.Name)
 
-	// Wait for the connection to reach a ready state before returning
-	// This ensures the connection is fully provisioned and available for use with stream processors
 	createTimeout, diags := streamConnectionPlan.Timeouts.Create(ctx, DefaultConnectionTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// StateNotFound is a pending state for create - handles eventual consistency where
-	// the resource may briefly return 404 after creation before becoming visible.
-	apiResp, err = WaitStateTransition(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, createTimeout, []string{StatePending, StateNotFound}, []string{StateReady, StateFailed})
+
+	// Wait for the connection to reach a ready state before returning
+	// This ensures the connection is fully provisioned and available for use with stream processors
+	apiResp, err = WaitStateTransition(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, createTimeout, []string{StatePending}, []string{StateReady, StateFailed})
 	if err != nil {
 		resp.Diagnostics.AddError("error waiting for stream connection to be ready", err.Error())
 		return
@@ -289,13 +288,13 @@ func (r *streamConnectionRS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// Wait for the connection to reach a ready state before returning
-	// This ensures the connection is fully provisioned and available for use with stream processors
 	updateTimeout, diags := streamConnectionPlan.Timeouts.Update(ctx, DefaultConnectionTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Wait for the connection to reach a ready state before returning
+	// This ensures the connection is fully provisioned and available for use with stream processors
 	apiResp, err := WaitStateTransition(ctx, projectID, workspaceOrInstanceName, connectionName, connV2.StreamsApi, updateTimeout, []string{StatePending}, []string{StateReady, StateFailed})
 	if err != nil {
 		resp.Diagnostics.AddError("error waiting for stream connection to be ready", err.Error())

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/cleanup"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -205,7 +204,8 @@ func (r *streamConnectionRS) Create(ctx context.Context, req resource.CreateRequ
 
 	// Wait for the connection to reach a ready state before returning
 	// This ensures the connection is fully provisioned and available for use with stream processors
-	createTimeout := cleanup.ResolveTimeout(ctx, &streamConnectionPlan.Timeouts, cleanup.OperationCreate, &resp.Diagnostics)
+	createTimeout, diags := streamConnectionPlan.Timeouts.Create(ctx, DefaultConnectionTimeout)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -291,7 +291,8 @@ func (r *streamConnectionRS) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Wait for the connection to reach a ready state before returning
 	// This ensures the connection is fully provisioned and available for use with stream processors
-	updateTimeout := cleanup.ResolveTimeout(ctx, &streamConnectionPlan.Timeouts, cleanup.OperationUpdate, &resp.Diagnostics)
+	updateTimeout, diags := streamConnectionPlan.Timeouts.Update(ctx, DefaultConnectionTimeout)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -327,7 +328,8 @@ func (r *streamConnectionRS) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 	connectionName := streamConnectionState.ConnectionName.ValueString()
 
-	deleteTimeout := cleanup.ResolveTimeout(ctx, &streamConnectionState.Timeouts, cleanup.OperationDelete, &resp.Diagnostics)
+	deleteTimeout, diags := streamConnectionState.Timeouts.Delete(ctx, DefaultConnectionTimeout)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
## Description

Currently the streams connection CREATEs, UPDATEs and DELETES are using the system default 3 hour timeouts instead of the documented 20 minute timeouts. We should correctly propagate those documented defaults. 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
