### PR TITLE
chore(provider): Uses env base URL and Realm base URL when unset in provider

### DIFF
--- a/docs/guides/provider-configuration.md
+++ b/docs/guides/provider-configuration.md
@@ -143,8 +143,8 @@ provider "mongodbatlas" {
 * `access_token` - (Optional) SA Access Token (env: `MONGODB_ATLAS_ACCESS_TOKEN`). Instead of using Client ID and Client Secret, you can generate and use an SA token directly. See [Generate Service Account Token](https://www.mongodb.com/docs/atlas/api/service-accounts/generate-oauth2-token/#std-label-generate-oauth2-token-atlas) for details. Note: tokens have expiration times.
 * `public_key` - (Optional) PAK Public Key (env: `MONGODB_ATLAS_PUBLIC_API_KEY`).
 * `private_key` - (Optional) PAK Private Key (env: `MONGODB_ATLAS_PRIVATE_API_KEY`).
-* `base_url` - (Optional) MongoDB Atlas Base URL (env: `MONGODB_ATLAS_BASE_URL`). For advanced use cases, you can configure custom API endpoints.
-* `realm_base_url` - (Optional) MongoDB Realm Base URL (env: `MONGODB_REALM_BASE_URL`).
+* `base_url` - (Optional) MongoDB Atlas Base URL (env: `MONGODB_ATLAS_BASE_URL`, `MCLI_OPS_MANAGER_URL`). For advanced use cases, you can configure custom API endpoints. When not set in the provider block, the provider uses the value from the environment for all API operations. This allows using a single env var (e.g. `MONGODB_ATLAS_BASE_URL=https://cloud-dev.mongodb.com`) with provider blocks that only set credentials.
+* `realm_base_url` - (Optional) MongoDB Realm Base URL (env: `MONGODB_REALM_BASE_URL`). When not set in the provider block, the value from the environment is used for all Realm API operations.
 * `is_mongodbgov_cloud` - (Optional) Set to `true` to use MongoDB Atlas for Government, a dedicated deployment option for government agencies and contractors requiring FedRAMP compliance. When enabled, the provider uses government-specific API endpoints. Ensure credentials are created in the government environment. See [Atlas for Government Considerations](https://www.mongodb.com/docs/atlas/government/api/#atlas-for-government-considerations) for feature limitations and requirements.
   ```terraform
   provider "mongodbatlas" {

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -476,6 +476,50 @@ func TestGetCredentials(t *testing.T) {
 			want:         &config.Credentials{},
 			wantErr:      false,
 		},
+		"Provider credentials with keys but no base_url get BaseURL from env": {
+			providerVars: &config.Vars{
+				PublicKey:  "provider-public",
+				PrivateKey: "provider-private",
+			},
+			envVars: &config.Vars{
+				BaseURL:      "https://cloud-dev.mongodb.com",
+				RealmBaseURL: "https://realm-dev.example.com",
+			},
+			want: &config.Credentials{
+				PublicKey:    "provider-public",
+				PrivateKey:   "provider-private",
+				BaseURL:      "https://cloud-dev.mongodb.com",
+				RealmBaseURL: "https://realm-dev.example.com",
+			},
+			wantErr: false,
+		},
+		"Provider base_url is not overwritten by env": {
+			providerVars: &config.Vars{
+				PublicKey: "provider-public",
+				BaseURL:   "https://provider.example.com",
+			},
+			envVars: &config.Vars{
+				BaseURL: "https://env.example.com",
+			},
+			want: &config.Credentials{
+				PublicKey: "provider-public",
+				BaseURL:   "https://provider.example.com",
+			},
+			wantErr: false,
+		},
+		"AWS credentials get BaseURL from env when empty": {
+			providerVars: &config.Vars{
+				AWSAssumeRoleARN: "arn",
+			},
+			envVars: &config.Vars{
+				BaseURL: "https://cloud-dev.mongodb.com",
+			},
+			want: &config.Credentials{
+				AccessToken: "aws-token",
+				BaseURL:     "https://cloud-dev.mongodb.com",
+			},
+			wantErr: false,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
## Description


When `base_url` (or `realm_base_url`) is not set in the provider block or in the chosen credentials (e.g. from AWS Secrets Manager), the provider now fills it from the environment so that `MONGODB_ATLAS_BASE_URL` and `MONGODB_REALM_BASE_URL` apply to all API operations. This allows using a single env var (e.g. in CI or for dev/private endpoints) with provider blocks or aliases that only set credentials.

Provider- or AWS-set `base_url` and `realm_base_url` are never overwritten by env. `MCLI_OPS_MANAGER_URL` remains a fallback env var for `base_url` for compatibility.

Link to any related issue(s): CLOUDP-384262

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

## Design choice: where to merge base URL from env

**Chosen:** In `GetCredentials`, after `CoalesceCredentials` returns, call `mergeBaseURLFromEnv(c, envVars)` so empty `BaseURL`/`RealmBaseURL` are filled from env.

**Alternative:** Change `CoalesceCredentials` to merge unset variables (e.g. after picking the winning credential set, back-fill empty BaseURL/RealmBaseURL from another set such as env).

**Pros of current approach:** Coalesce stays single-purpose (pick first credential set by auth); “env backs fill when config base_url empty” stays an explicit provider rule in one place; no signature or semantic change to `CoalesceCredentials`; easy to extend (e.g. more env-backed fields) without touching coalesce.

**Cons of alternative:** Coalesce would need to know “which arg is env” and which fields to merge, mixing generic coalesce with provider-specific fallback; per-field coalesce (variant where every field is “first non-empty”) would change semantics and could mix auth from one source with URLs from another.