### PR TITLE
feat: Supports `retain_backups_for_disabling` in `mongodbatlas_advanced_cluster` resource and data source

### DIFF
--- a/.changelog/4253.txt
+++ b/.changelog/4253.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_advanced_cluster: Adds `retain_backups_for_disabling` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_advanced_cluster: Adds `retain_backups_for_disabling` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_advanced_clusters: Adds `retain_backups_for_disabling` attribute
+```

--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -181,6 +181,7 @@ In addition to all arguments above, the following attributes are exported:
 * `mongo_db_major_version` - Version of the cluster to deploy.
 * `pinned_fcv` - The pinned Feature Compatibility Version (FCV) with its associated expiration date. See [below](#pinned_fcv).
 * `pit_enabled` - Flag that indicates if the cluster uses Continuous Cloud Backup.
+* `retain_backups_for_disabling` - Flag that indicates whether to retain backups when disabling backups for the cluster.
 * `replication_specs` - List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations. See [below](#replication_specs).
 * `root_cert_type` - Certificate Authority that MongoDB Atlas clusters use. 
 * `termination_protection_enabled` - Flag that indicates whether termination protection is enabled on the cluster. If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -216,6 +216,7 @@ In addition to all arguments above, the following attributes are exported:
 * `mongo_db_major_version` - Version of the cluster to deploy.
 * `pinned_fcv` - The pinned Feature Compatibility Version (FCV) with its associated expiration date. See [below](#pinned_fcv).
 * `pit_enabled` - Flag that indicates if the cluster uses Continuous Cloud Backup.
+* `retain_backups_for_disabling` - Flag that indicates whether to retain backups when disabling backups for the cluster.
 * `replication_specs` - List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations. See [below](#replication_specs)
 * `root_cert_type` - Certificate Authority that MongoDB Atlas clusters use.
 * `termination_protection_enabled` - Flag that indicates whether termination protection is enabled on the cluster. If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -540,6 +540,8 @@ Refer to the following for full privatelink endpoint connection string examples:
 
   -> **NOTE:** If you have a [Backup Compliance Policy](backup_compliance_policy.md) enabled for the project, you can't disable Cloud Backup without assistance from [MongoDB Support](https://www.mongodb.com/docs/atlas/support/#request-support).
 
+- `retain_backups_for_disabling` - (Optional) Set to true to retain backups when disabling backups for the cluster. Defaults to `false`.
+
 - `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. This parameter applies to the Delete operation and only affects M10 and above clusters. To delete an Atlas cluster that has an associated [`mongodbatlas_cloud_backup_schedule`](cloud_backup_schedule.md) resource and an enabled [Backup Compliance Policy](backup_compliance_policy.md), see [Delete a Cluster with a Backup Compliance Policy](../guides/delete-cluster-with-backup-compliance-policy.md).
 
   -> **NOTE** Prior version of provider had parameter as `bi_connector` state will migrate it to new value you only need to update parameter in your terraform file

--- a/internal/service/advancedcluster/model_ClusterDescription20240805.go
+++ b/internal/service/advancedcluster/model_ClusterDescription20240805.go
@@ -47,6 +47,7 @@ func newTFModel(ctx context.Context, input *admin.ClusterDescription20240805, di
 		RedactClientLogData:              types.BoolValue(conversion.SafeValue(input.RedactClientLogData)),
 		ReplicaSetScalingStrategy:        types.StringValue(conversion.SafeValue(input.ReplicaSetScalingStrategy)),
 		ReplicationSpecs:                 replicationSpecs,
+		RetainBackupsForDisabling:        types.BoolValue(conversion.SafeValue(input.RetainBackups)),
 		RootCertType:                     types.StringValue(conversion.SafeValue(input.RootCertType)),
 		StateName:                        types.StringValue(conversion.SafeValue(input.StateName)),
 		Tags:                             tags,

--- a/internal/service/advancedcluster/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedcluster/model_to_ClusterDescription20240805.go
@@ -42,6 +42,7 @@ func newAtlasReq(ctx context.Context, input *TFModel, diags *diag.Diagnostics) *
 		RedactClientLogData:              conversion.NilForUnknown(input.RedactClientLogData, input.RedactClientLogData.ValueBoolPointer()),
 		ReplicaSetScalingStrategy:        conversion.NilForUnknown(input.ReplicaSetScalingStrategy, input.ReplicaSetScalingStrategy.ValueStringPointer()),
 		ReplicationSpecs:                 newReplicationSpec(ctx, input.ReplicationSpecs, diags),
+		RetainBackups:                    conversion.NilForUnknown(input.RetainBackupsForDisabling, input.RetainBackupsForDisabling.ValueBoolPointer()),
 		RootCertType:                     conversion.NilForUnknown(input.RootCertType, input.RootCertType.ValueStringPointer()),
 		Tags:                             newResourceTag(ctx, diags, input.Tags),
 		TerminationProtectionEnabled:     conversion.NilForUnknown(input.TerminationProtectionEnabled, input.TerminationProtectionEnabled.ValueBoolPointer()),

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -1480,6 +1480,7 @@ func configAWSProvider(t *testing.T, configInfo ReplicaSetAWSConfig, isTPF bool)
 			name         = %[2]q
 			cluster_type = %[3]q
 			retain_backups_enabled = "true"
+			retain_backups_for_disabling = "true"
 			disk_size_gb = %[4]d
 
 			replication_specs {
@@ -1507,6 +1508,7 @@ func configAWSProvider(t *testing.T, configInfo ReplicaSetAWSConfig, isTPF bool)
 			name         = %[2]q
 			cluster_type = %[3]q
 			retain_backups_enabled = "true"
+			retain_backups_for_disabling = "true"
 		
 
 		  replication_specs = [{
@@ -1533,6 +1535,9 @@ func configAWSProvider(t *testing.T, configInfo ReplicaSetAWSConfig, isTPF bool)
 func checkReplicaSetAWSProvider(isTPF, useDataSource bool, projectID, name string, diskSizeGB, nodeCountElectable int, checkDiskSizeGBInnerLevel, checkExternalID bool) resource.TestCheckFunc {
 	additionalChecks := []resource.TestCheckFunc{
 		acc.TestCheckResourceAttrMigTPF(isTPF, resourceName, "retain_backups_enabled", "true"),
+		acc.TestCheckResourceAttrMigTPF(isTPF, resourceName, "retain_backups_for_disabling", "true"),
+		acc.TestCheckResourceAttrMigTPF(isTPF, dataSourceName, "retain_backups_for_disabling", "true"),
+		acc.TestCheckResourceAttrMigTPF(isTPF, dataSourcePluralName, "results.0.retain_backups_for_disabling", "true"),
 	}
 	additionalChecks = append(additionalChecks,
 		acc.TestCheckResourceAttrWithMigTPF(isTPF, resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),

--- a/internal/service/advancedcluster/schema.go
+++ b/internal/service/advancedcluster/schema.go
@@ -309,6 +309,11 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				MarkdownDescription: "Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify **mongoDBMajorVersion**.",
 			},
+			"retain_backups_for_disabling": schema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Flag that indicates whether to retain backup snapshots when disabling backups.",
+			},
 			"retain_backups_enabled": schema.BoolAttribute{
 				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.",
@@ -698,6 +703,7 @@ type TFModel struct {
 	PinnedFCV                                     types.Object   `tfsdk:"pinned_fcv"`
 	TerminationProtectionEnabled                  types.Bool     `tfsdk:"termination_protection_enabled"`
 	Paused                                        types.Bool     `tfsdk:"paused"`
+	RetainBackupsForDisabling                     types.Bool     `tfsdk:"retain_backups_for_disabling"`
 	RetainBackupsEnabled                          types.Bool     `tfsdk:"retain_backups_enabled"`
 	BackupEnabled                                 types.Bool     `tfsdk:"backup_enabled"`
 	GlobalClusterSelfManagedSharding              types.Bool     `tfsdk:"global_cluster_self_managed_sharding"`
@@ -736,6 +742,7 @@ type TFModelDS struct {
 	BackupEnabled                                 types.Bool   `tfsdk:"backup_enabled"`
 	Paused                                        types.Bool   `tfsdk:"paused"`
 	TerminationProtectionEnabled                  types.Bool   `tfsdk:"termination_protection_enabled"`
+	RetainBackupsForDisabling                     types.Bool   `tfsdk:"retain_backups_for_disabling"`
 	PitEnabled                                    types.Bool   `tfsdk:"pit_enabled"`
 	UseAwsTimeBasedSnapshotCopyForFastInitialSync types.Bool   `tfsdk:"use_aws_time_based_snapshot_copy_for_fast_initial_sync"`
 	UseEffectiveFields                            types.Bool   `tfsdk:"use_effective_fields"`

--- a/internal/service/advancedcluster/schema_test.go
+++ b/internal/service/advancedcluster/schema_test.go
@@ -85,6 +85,11 @@ func TestAdvancedCluster_PlanModifierValid(t *testing.T) {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
+			{
+				Config:             configBasic(projectID, clusterName, "retain_backups_for_disabling = true"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description

Adds `retain_backups_for_disabling` in `mongodbatlas_advanced_cluster` resource and data source to allow users to select whether to retain current backups when disabling cloud backups.

Link to any related issue(s): CLOUDP-365445

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
