### PR TITLE
chore: Add log integration discriminator validation coverage

### DIFF
--- a/internal/serviceapi/logintegration/resource_schema.go
+++ b/internal/serviceapi/logintegration/resource_schema.go
@@ -8,8 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/customtypes"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/customvalidator"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 )
 
@@ -104,6 +106,36 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"type": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.",
+				Validators: []validator.String{
+					customvalidator.ValidateDiscriminator(customvalidator.DiscriminatorDefinition{
+						Mapping: map[string]customvalidator.VariantDefinition{
+							"AZURE_LOG_EXPORT": {
+								Allowed:  []string{"prefix_path", "role_id", "storage_account_name", "storage_container_name"},
+								Required: []string{"prefix_path", "role_id", "storage_account_name", "storage_container_name"},
+							},
+							"DATADOG_LOG_EXPORT": {
+								Allowed:  []string{"api_key", "region"},
+								Required: []string{"api_key", "region"},
+							},
+							"GCS_LOG_EXPORT": {
+								Allowed:  []string{"bucket_name", "prefix_path", "role_id"},
+								Required: []string{"bucket_name", "prefix_path", "role_id"},
+							},
+							"OTEL_LOG_EXPORT": {
+								Allowed:  []string{"otel_endpoint", "otel_supplied_headers"},
+								Required: []string{"otel_endpoint", "otel_supplied_headers"},
+							},
+							"S3_LOG_EXPORT": {
+								Allowed:  []string{"bucket_name", "iam_role_id", "kms_key", "prefix_path"},
+								Required: []string{"bucket_name", "iam_role_id", "prefix_path"},
+							},
+							"SPLUNK_LOG_EXPORT": {
+								Allowed:  []string{"hec_token", "hec_url"},
+								Required: []string{"hec_token", "hec_url"},
+							},
+						},
+					}),
+				},
 			},
 		},
 	}

--- a/internal/serviceapi/logintegration/schema_test.go
+++ b/internal/serviceapi/logintegration/schema_test.go
@@ -179,6 +179,12 @@ func TestAccLogIntegration_discriminatorValidConfig(t *testing.T) {
 				region  = "US1"
 			`),
 		},
+		{
+			name: "unknown integration type skips discriminator validation",
+			config: config("FUTURE_UNKNOWN_LOG_EXPORT", `
+				api_key = "test-dd-api-key"
+			`),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/serviceapi/logintegration/schema_test.go
+++ b/internal/serviceapi/logintegration/schema_test.go
@@ -1,0 +1,214 @@
+package logintegration_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestAccLogIntegration_discriminatorMissingRequired(t *testing.T) {
+	testCases := []struct {
+		name          string
+		typeName      string
+		extraAttrs    string
+		expectedError string
+	}{
+		{
+			name:          "datadog missing api_key",
+			typeName:      "DATADOG_LOG_EXPORT",
+			extraAttrs:    `region = "US1"`,
+			expectedError: `Attribute "api_key" must be set when type is "DATADOG_LOG_EXPORT"`,
+		},
+		{
+			name:     "splunk missing hec_token",
+			typeName: "SPLUNK_LOG_EXPORT",
+			extraAttrs: `
+				hec_url = "https://splunk.example.com:8088"
+			`,
+			expectedError: `Attribute "hec_token" must be set when type is "SPLUNK_LOG_EXPORT"`,
+		},
+		{
+			name:     "s3 missing bucket_name",
+			typeName: "S3_LOG_EXPORT",
+			extraAttrs: `
+				iam_role_id = "111111111111111111111111"
+				prefix_path = "prefix-path"
+			`,
+			expectedError: `Attribute "bucket_name" must be set when type is "S3_LOG_EXPORT"`,
+		},
+		{
+			name:     "azure missing prefix_path",
+			typeName: "AZURE_LOG_EXPORT",
+			extraAttrs: `
+				role_id                = "111111111111111111111111"
+				storage_account_name   = "storageaccountname"
+				storage_container_name = "storage-container-name"
+			`,
+			expectedError: `Attribute "prefix_path" must be set when type is "AZURE_LOG_EXPORT"`,
+		},
+		{
+			name:     "gcs missing bucket_name",
+			typeName: "GCS_LOG_EXPORT",
+			extraAttrs: `
+				prefix_path = "prefix-path"
+				role_id     = "111111111111111111111111"
+			`,
+			expectedError: `Attribute "bucket_name" must be set when type is "GCS_LOG_EXPORT"`,
+		},
+		{
+			name:     "otel missing otel_endpoint",
+			typeName: "OTEL_LOG_EXPORT",
+			extraAttrs: `
+				otel_supplied_headers = [{
+					name  = "Authorization"
+					value = "Bearer token"
+				}]
+			`,
+			expectedError: `Attribute "otel_endpoint" must be set when type is "OTEL_LOG_EXPORT"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Steps: []resource.TestStep{
+					{
+						Config:      config(tc.typeName, tc.extraAttrs),
+						ExpectError: regexp.MustCompile(tc.expectedError),
+					},
+				},
+			})
+		})
+	}
+}
+
+func TestAccLogIntegration_discriminatorDisallowedAttrs(t *testing.T) {
+	testCases := []struct {
+		name          string
+		typeName      string
+		extraAttrs    string
+		expectedError string
+	}{
+		{
+			name:     "datadog disallows bucket_name",
+			typeName: "DATADOG_LOG_EXPORT",
+			extraAttrs: `
+				api_key     = "test-dd-api-key"
+				region      = "US1"
+				bucket_name = "test-bucket"
+			`,
+			expectedError: `"bucket_name" is not allowed when type is "DATADOG_LOG_EXPORT"`,
+		},
+		{
+			name:     "s3 disallows hec_url",
+			typeName: "S3_LOG_EXPORT",
+			extraAttrs: `
+				bucket_name = "test-bucket"
+				iam_role_id = "111111111111111111111111"
+				prefix_path = "prefix-path"
+				hec_url     = "https://splunk.example.com:8088"
+			`,
+			expectedError: `"hec_url" is not allowed when type is "S3_LOG_EXPORT"`,
+		},
+		{
+			name:     "splunk disallows otel_endpoint",
+			typeName: "SPLUNK_LOG_EXPORT",
+			extraAttrs: `
+				hec_token     = "test-hec-token"
+				hec_url       = "https://splunk.example.com:8088"
+				otel_endpoint = "https://otel.example.com:4317/v1/logs"
+			`,
+			expectedError: `"otel_endpoint" is not allowed when type is "SPLUNK_LOG_EXPORT"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Steps: []resource.TestStep{
+					{
+						Config:      config(tc.typeName, tc.extraAttrs),
+						ExpectError: regexp.MustCompile(tc.expectedError),
+					},
+				},
+			})
+		})
+	}
+}
+
+func TestAccLogIntegration_discriminatorValidConfig(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "valid datadog config",
+			config: config("DATADOG_LOG_EXPORT", `
+				api_key = "test-dd-api-key"
+				region  = "US1"
+			`),
+		},
+		{
+			name: "valid splunk config",
+			config: config("SPLUNK_LOG_EXPORT", `
+				hec_token = "test-hec-token"
+				hec_url   = "https://splunk.example.com:8088"
+			`),
+		},
+		{
+			name: "valid otel config",
+			config: config("OTEL_LOG_EXPORT", `
+				otel_endpoint = "https://otel.example.com:4317/v1/logs"
+				otel_supplied_headers = [{
+					name  = "Authorization"
+					value = "Bearer token"
+				}]
+			`),
+		},
+		{
+			name: "valid datadog config with unknown api_key at plan time",
+			config: configWithPrefix(`
+				resource "terraform_data" "unknown" {}
+			`, "DATADOG_LOG_EXPORT", `
+				api_key = terraform_data.unknown.id
+				region  = "US1"
+			`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Steps: []resource.TestStep{
+					{
+						Config:             tc.config,
+						PlanOnly:           true,
+						ExpectNonEmptyPlan: true,
+					},
+				},
+			})
+		})
+	}
+}
+
+func config(typeName, extraAttrs string) string {
+	return configWithPrefix("", typeName, extraAttrs)
+}
+
+func configWithPrefix(prefix, typeName, extraAttrs string) string {
+	return fmt.Sprintf(`
+		%[1]s
+		resource "mongodbatlas_log_integration" "test" {
+			project_id = "111111111111111111111111"
+			type       = %[2]q
+			log_types  = ["MONGOD"]
+			%[3]s
+		}
+	`, prefix, typeName, extraAttrs)
+}

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -787,6 +787,7 @@ resources:
     version_header: application/vnd.atlas.2023-02-01+json
     # All defined configuration is for trying to reach backwards compatibility with curated resource
     schema:
+      expanded_model: true
       ignores:
         [
           # Hide noisy subresource link blocks (curated resource doesn't expose them)

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -787,7 +787,6 @@ resources:
     version_header: application/vnd.atlas.2023-02-01+json
     # All defined configuration is for trying to reach backwards compatibility with curated resource
     schema:
-      expanded_model: true
       ignores:
         [
           # Hide noisy subresource link blocks (curated resource doesn't expose them)
@@ -1185,9 +1184,6 @@ resources:
             immutable_computed: true
           otel_supplied_headers:
             sensitive: true
-          # no need for discriminator as there is currently only a single type, keep prod code exactly as is
-          type:
-            ignore_validators: [ discriminator ]
     datasources:
       read:
         path: /api/atlas/v2/groups/{groupId}/logIntegrations/{id}

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -89,7 +89,6 @@ schema:
         property_name:
             api_name: type
             tf_schema_name: type
-        skip_validation: true
     attributes:
         - string: {}
           description: API key for authentication.


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-383938

- Adjust config.yml to avoid explicit skip of discriminator validator in `log_integration`
- Adds plan-phase coverage for log integration discriminator behavior within `schema_test.go` similar to how plan-only acceptance tests are handled in [advancedcluster/schema_test.go](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/internal/service/advancedcluster/schema_test.go).

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
