### PR TITLE
chore: Add polymorphic description prefixes for schema attributes

### DIFF
--- a/docs/data-sources/log_integration.md
+++ b/docs/data-sources/log_integration.md
@@ -40,7 +40,7 @@ output "log_integration_type" {
 - `hec_url` (String) Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.
 - `iam_role_id` (String) Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `kms_key` (String) Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
-- `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+- `log_types` (Set of String) Array of log types exported by this integration.
 - `otel_endpoint` (String) Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.
 - `otel_supplied_headers` (Attributes List, Sensitive) Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
 - `prefix_path` (String) Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.

--- a/docs/data-sources/log_integration.md
+++ b/docs/data-sources/log_integration.md
@@ -34,20 +34,20 @@ output "log_integration_type" {
 
 ### Read-Only
 
-- `api_key` (String, Sensitive) API key for authentication.
-- `bucket_name` (String) Name of the bucket to store log files.
-- `hec_token` (String, Sensitive) HTTP Event Collector (HEC) token for authentication.
-- `hec_url` (String) HTTP Event Collector (HEC) endpoint URL.
-- `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
-- `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+- `api_key` (String, Sensitive) Applies to type: DATADOG_LOG_EXPORT. API key for authentication.
+- `bucket_name` (String) Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.
+- `hec_token` (String, Sensitive) Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.
+- `hec_url` (String) Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.
+- `iam_role_id` (String) Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
+- `kms_key` (String) Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
 - `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
-- `otel_endpoint` (String) OpenTelemetry collector endpoint URL.
-- `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
-- `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
-- `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
-- `role_id` (String) Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
-- `storage_account_name` (String) Storage account name where logs will be stored.
-- `storage_container_name` (String) Storage container name for log files.
+- `otel_endpoint` (String) Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.
+- `otel_supplied_headers` (Attributes List, Sensitive) Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
+- `prefix_path` (String) Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `region` (String) Applies to type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
+- `role_id` (String) Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
+- `storage_account_name` (String) Applies to type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.
+- `storage_container_name` (String) Applies to type: AZURE_LOG_EXPORT. Storage container name for log files.
 - `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
 
 <a id="nestedatt--otel_supplied_headers"></a>

--- a/docs/data-sources/log_integrations.md
+++ b/docs/data-sources/log_integrations.md
@@ -51,7 +51,7 @@ Read-Only:
 - `iam_role_id` (String) Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `integration_id` (String) Unique 24-character hexadecimal digit string that identifies the log integration configuration.
 - `kms_key` (String) Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
-- `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+- `log_types` (Set of String) Array of log types exported by this integration.
 - `otel_endpoint` (String) Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.
 - `otel_supplied_headers` (Attributes List, Sensitive) Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--results--otel_supplied_headers))
 - `prefix_path` (String) Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.

--- a/docs/data-sources/log_integrations.md
+++ b/docs/data-sources/log_integrations.md
@@ -44,21 +44,21 @@ output "log_integration_ids" {
 
 Read-Only:
 
-- `api_key` (String, Sensitive) API key for authentication.
-- `bucket_name` (String) Name of the bucket to store log files.
-- `hec_token` (String, Sensitive) HTTP Event Collector (HEC) token for authentication.
-- `hec_url` (String) HTTP Event Collector (HEC) endpoint URL.
-- `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
+- `api_key` (String, Sensitive) Applies to type: DATADOG_LOG_EXPORT. API key for authentication.
+- `bucket_name` (String) Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.
+- `hec_token` (String, Sensitive) Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.
+- `hec_url` (String) Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.
+- `iam_role_id` (String) Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `integration_id` (String) Unique 24-character hexadecimal digit string that identifies the log integration configuration.
-- `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+- `kms_key` (String) Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
 - `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
-- `otel_endpoint` (String) OpenTelemetry collector endpoint URL.
-- `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--results--otel_supplied_headers))
-- `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
-- `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
-- `role_id` (String) Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
-- `storage_account_name` (String) Storage account name where logs will be stored.
-- `storage_container_name` (String) Storage container name for log files.
+- `otel_endpoint` (String) Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.
+- `otel_supplied_headers` (Attributes List, Sensitive) Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--results--otel_supplied_headers))
+- `prefix_path` (String) Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `region` (String) Applies to type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
+- `role_id` (String) Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
+- `storage_account_name` (String) Applies to type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.
+- `storage_container_name` (String) Applies to type: AZURE_LOG_EXPORT. Storage container name for log files.
 - `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
 
 <a id="nestedatt--results--otel_supplied_headers"></a>

--- a/docs/resources/log_integration.md
+++ b/docs/resources/log_integration.md
@@ -143,7 +143,7 @@ resource "mongodbatlas_log_integration" "example" {
 
 ### Required
 
-- `log_types` (Set of String) Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+- `log_types` (Set of String) Array of log types exported by this integration.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project.
 - `type` (String) Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.
 
@@ -154,7 +154,7 @@ resource "mongodbatlas_log_integration" "example" {
 - `hec_token` (String, Sensitive) Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.
 - `hec_url` (String) Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.
 - `iam_role_id` (String) Required for type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
-- `kms_key` (String) Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+- `kms_key` (String) Optional for type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
 - `otel_endpoint` (String) Required for type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.
 - `otel_supplied_headers` (Attributes List, Sensitive) Required for type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
 - `prefix_path` (String) Required for type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.

--- a/docs/resources/log_integration.md
+++ b/docs/resources/log_integration.md
@@ -149,19 +149,19 @@ resource "mongodbatlas_log_integration" "example" {
 
 ### Optional
 
-- `api_key` (String, Sensitive) API key for authentication.
-- `bucket_name` (String) Name of the bucket to store log files.
-- `hec_token` (String, Sensitive) HTTP Event Collector (HEC) token for authentication.
-- `hec_url` (String) HTTP Event Collector (HEC) endpoint URL.
-- `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
-- `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
-- `otel_endpoint` (String) OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.
-- `otel_supplied_headers` (Attributes List, Sensitive) HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
-- `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
-- `region` (String) Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
-- `role_id` (String) Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
-- `storage_account_name` (String) Storage account name where logs will be stored.
-- `storage_container_name` (String) Storage container name for log files.
+- `api_key` (String, Sensitive) Required for type: DATADOG_LOG_EXPORT. API key for authentication.
+- `bucket_name` (String) Required for type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.
+- `hec_token` (String, Sensitive) Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.
+- `hec_url` (String) Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.
+- `iam_role_id` (String) Required for type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
+- `kms_key` (String) Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+- `otel_endpoint` (String) Required for type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.
+- `otel_supplied_headers` (Attributes List, Sensitive) Required for type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB. (see [below for nested schema](#nestedatt--otel_supplied_headers))
+- `prefix_path` (String) Required for type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `region` (String) Required for type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.
+- `role_id` (String) Required for type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
+- `storage_account_name` (String) Required for type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.
+- `storage_container_name` (String) Required for type: AZURE_LOG_EXPORT. Storage container name for log files.
 
 ### Read-Only
 

--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -197,7 +197,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"analytics_auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -238,7 +238,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -265,7 +265,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -306,11 +306,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"backing_provider_name": schema.StringAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+										MarkdownDescription: "Optional for provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
 									},
 									"effective_analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsEffectiveAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -337,7 +337,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_electable_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsEffectiveElectableSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -364,7 +364,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsEffectiveReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -448,7 +448,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -594,7 +594,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"analytics_auto_scaling": schema.SingleNestedAttribute{
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -636,7 +636,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -668,7 +668,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -716,11 +716,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"backing_provider_name": schema.StringAttribute{
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+										MarkdownDescription: "Optional for provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
 									},
 									"effective_analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -747,7 +747,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_electable_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveElectableSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -774,7 +774,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -863,7 +863,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{

--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -197,7 +197,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"analytics_auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -238,7 +238,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -265,7 +265,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -306,11 +306,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"backing_provider_name": schema.StringAttribute{
 										Computed:            true,
-										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+										MarkdownDescription: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
 									},
 									"effective_analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsEffectiveAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -337,7 +337,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_electable_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsEffectiveElectableSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -364,7 +364,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsEffectiveReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -448,7 +448,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFEffectiveReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -594,7 +594,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"analytics_auto_scaling": schema.SingleNestedAttribute{
 										Optional:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -636,7 +636,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -668,7 +668,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -716,11 +716,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"backing_provider_name": schema.StringAttribute{
 										Optional:            true,
-										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+										MarkdownDescription: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
 									},
 									"effective_analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -747,7 +747,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_electable_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveElectableSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -774,7 +774,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"effective_read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -863,7 +863,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "The current hardware specifications for read only nodes in the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{

--- a/internal/serviceapi/clusteroldapi/resource_schema.go
+++ b/internal/serviceapi/clusteroldapi/resource_schema.go
@@ -284,7 +284,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"analytics_auto_scaling": schema.SingleNestedAttribute{
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -326,7 +326,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -354,7 +354,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -402,7 +402,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"backing_provider_name": schema.StringAttribute{
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+										MarkdownDescription: "Optional for provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
 									},
 									"electable_specs": schema.SingleNestedAttribute{
 										Optional:            true,
@@ -463,7 +463,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
+										MarkdownDescription: "Optional for provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{

--- a/internal/serviceapi/clusteroldapi/resource_schema.go
+++ b/internal/serviceapi/clusteroldapi/resource_schema.go
@@ -284,7 +284,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"analytics_auto_scaling": schema.SingleNestedAttribute{
 										Optional:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -326,7 +326,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"analytics_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{
@@ -354,7 +354,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"auto_scaling": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"compute": schema.SingleNestedAttribute{
@@ -402,7 +402,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"backing_provider_name": schema.StringAttribute{
 										Optional:            true,
-										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+										MarkdownDescription: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
 									},
 									"electable_specs": schema.SingleNestedAttribute{
 										Optional:            true,
@@ -463,7 +463,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,
 										Optional:            true,
-										MarkdownDescription: "Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
+										MarkdownDescription: "Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
 										CustomType:          customtypes.NewObjectType[TFReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx),
 										Attributes: map[string]schema.Attribute{
 											"disk_iops": schema.Int64Attribute{

--- a/internal/serviceapi/logintegration/data_source_schema.go
+++ b/internal/serviceapi/logintegration/data_source_schema.go
@@ -16,25 +16,25 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 		Attributes: map[string]dsschema.Attribute{
 			"api_key": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "API key for authentication.",
+				MarkdownDescription: "Applies to type: DATADOG_LOG_EXPORT. API key for authentication.",
 				Sensitive:           true,
 			},
 			"bucket_name": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Name of the bucket to store log files.",
+				MarkdownDescription: "Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.",
 			},
 			"hec_token": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "HTTP Event Collector (HEC) token for authentication.",
+				MarkdownDescription: "Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.",
 				Sensitive:           true,
 			},
 			"hec_url": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "HTTP Event Collector (HEC) endpoint URL.",
+				MarkdownDescription: "Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.",
 			},
 			"iam_role_id": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.",
+				MarkdownDescription: "Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.",
 			},
 			"integration_id": dsschema.StringAttribute{
 				Required:            true,
@@ -42,7 +42,7 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"kms_key": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
+				MarkdownDescription: "Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
 			},
 			"log_types": dsschema.SetAttribute{
 				Computed:            true,
@@ -52,11 +52,11 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"otel_endpoint": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "OpenTelemetry collector endpoint URL.",
+				MarkdownDescription: "Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.",
 			},
 			"otel_supplied_headers": dsschema.ListNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: "HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.",
+				MarkdownDescription: "Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.",
 				Sensitive:           true,
 				CustomType:          customtypes.NewNestedListType[TFDSOtelSuppliedHeadersModel](ctx),
 				NestedObject: dsschema.NestedAttributeObject{
@@ -75,7 +75,7 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"prefix_path": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.",
+				MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.",
 			},
 			"project_id": dsschema.StringAttribute{
 				Required:            true,
@@ -83,19 +83,19 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"region": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.",
+				MarkdownDescription: "Applies to type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.",
 			},
 			"role_id": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
+				MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
 			},
 			"storage_account_name": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Storage account name where logs will be stored.",
+				MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.",
 			},
 			"storage_container_name": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Storage container name for log files.",
+				MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT. Storage container name for log files.",
 			},
 			"type": dsschema.StringAttribute{
 				Computed:            true,

--- a/internal/serviceapi/logintegration/data_source_schema.go
+++ b/internal/serviceapi/logintegration/data_source_schema.go
@@ -46,7 +46,7 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"log_types": dsschema.SetAttribute{
 				Computed:            true,
-				MarkdownDescription: "Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.",
+				MarkdownDescription: "Array of log types exported by this integration.",
 				CustomType:          customtypes.NewSetType[types.String](ctx),
 				ElementType:         types.StringType,
 			},

--- a/internal/serviceapi/logintegration/plural_data_source_schema.go
+++ b/internal/serviceapi/logintegration/plural_data_source_schema.go
@@ -30,25 +30,25 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 					Attributes: map[string]dsschema.Attribute{
 						"api_key": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "API key for authentication.",
+							MarkdownDescription: "Applies to type: DATADOG_LOG_EXPORT. API key for authentication.",
 							Sensitive:           true,
 						},
 						"bucket_name": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Name of the bucket to store log files.",
+							MarkdownDescription: "Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.",
 						},
 						"hec_token": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "HTTP Event Collector (HEC) token for authentication.",
+							MarkdownDescription: "Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.",
 							Sensitive:           true,
 						},
 						"hec_url": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "HTTP Event Collector (HEC) endpoint URL.",
+							MarkdownDescription: "Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.",
 						},
 						"iam_role_id": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.",
+							MarkdownDescription: "Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.",
 						},
 						"integration_id": dsschema.StringAttribute{
 							Computed:            true,
@@ -56,7 +56,7 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"kms_key": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
+							MarkdownDescription: "Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
 						},
 						"log_types": dsschema.SetAttribute{
 							Computed:            true,
@@ -66,11 +66,11 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"otel_endpoint": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "OpenTelemetry collector endpoint URL.",
+							MarkdownDescription: "Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.",
 						},
 						"otel_supplied_headers": dsschema.ListNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.",
+							MarkdownDescription: "Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.",
 							Sensitive:           true,
 							CustomType:          customtypes.NewNestedListType[TFPluralDSResultsOtelSuppliedHeadersModel](ctx),
 							NestedObject: dsschema.NestedAttributeObject{
@@ -89,23 +89,23 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"prefix_path": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.",
+							MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.",
 						},
 						"region": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.",
+							MarkdownDescription: "Applies to type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.",
 						},
 						"role_id": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
+							MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
 						},
 						"storage_account_name": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Storage account name where logs will be stored.",
+							MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.",
 						},
 						"storage_container_name": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Storage container name for log files.",
+							MarkdownDescription: "Applies to type: AZURE_LOG_EXPORT. Storage container name for log files.",
 						},
 						"type": dsschema.StringAttribute{
 							Computed:            true,

--- a/internal/serviceapi/logintegration/plural_data_source_schema.go
+++ b/internal/serviceapi/logintegration/plural_data_source_schema.go
@@ -60,7 +60,7 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"log_types": dsschema.SetAttribute{
 							Computed:            true,
-							MarkdownDescription: "Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.",
+							MarkdownDescription: "Array of log types exported by this integration.",
 							CustomType:          customtypes.NewSetType[types.String](ctx),
 							ElementType:         types.StringType,
 						},

--- a/internal/serviceapi/logintegration/resource_schema.go
+++ b/internal/serviceapi/logintegration/resource_schema.go
@@ -52,11 +52,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"kms_key": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
+				MarkdownDescription: "Optional for type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
 			},
 			"log_types": schema.SetAttribute{
 				Required:            true,
-				MarkdownDescription: "Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.",
+				MarkdownDescription: "Array of log types exported by this integration.",
 				CustomType:          customtypes.NewSetType[types.String](ctx),
 				ElementType:         types.StringType,
 			},

--- a/internal/serviceapi/logintegration/resource_schema.go
+++ b/internal/serviceapi/logintegration/resource_schema.go
@@ -20,12 +20,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"api_key": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "API key for authentication.",
+				MarkdownDescription: "Required for type: DATADOG_LOG_EXPORT. API key for authentication.",
 				Sensitive:           true,
 			},
 			"bucket_name": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Name of the bucket to store log files.",
+				MarkdownDescription: "Required for type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.",
 			},
 			"project_id": schema.StringAttribute{
 				Required:            true,
@@ -34,16 +34,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"hec_token": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "HTTP Event Collector (HEC) token for authentication.",
+				MarkdownDescription: "Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.",
 				Sensitive:           true,
 			},
 			"hec_url": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "HTTP Event Collector (HEC) endpoint URL.",
+				MarkdownDescription: "Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.",
 			},
 			"iam_role_id": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.",
+				MarkdownDescription: "Required for type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.",
 			},
 			"integration_id": schema.StringAttribute{
 				Computed:            true,
@@ -52,7 +52,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"kms_key": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
+				MarkdownDescription: "Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.",
 			},
 			"log_types": schema.SetAttribute{
 				Required:            true,
@@ -62,11 +62,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"otel_endpoint": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.",
+				MarkdownDescription: "Required for type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.",
 			},
 			"otel_supplied_headers": schema.ListNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.",
+				MarkdownDescription: "Required for type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.",
 				Sensitive:           true,
 				CustomType:          customtypes.NewNestedListType[TFOtelSuppliedHeadersModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
@@ -85,23 +85,23 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"prefix_path": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.",
+				MarkdownDescription: "Required for type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.",
 			},
 			"region": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.",
+				MarkdownDescription: "Required for type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.",
 			},
 			"role_id": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
+				MarkdownDescription: "Required for type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.",
 			},
 			"storage_account_name": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Storage account name where logs will be stored.",
+				MarkdownDescription: "Required for type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.",
 			},
 			"storage_container_name": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Storage container name for log files.",
+				MarkdownDescription: "Required for type: AZURE_LOG_EXPORT. Storage container name for log files.",
 			},
 			"type": schema.StringAttribute{
 				Required:            true,

--- a/internal/serviceapi/searchindexapi/resource_schema.go
+++ b/internal/serviceapi/searchindexapi/resource_schema.go
@@ -468,11 +468,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"synonym_mapping_status": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Status that describes this index's synonym mappings. This status appears only if the index has synonyms defined.",
+				MarkdownDescription: "Applies to type: search. Status that describes this index's synonym mappings. This status appears only if the index has synonyms defined.",
 			},
 			"synonym_mapping_status_detail": schema.ListAttribute{
 				Computed:            true,
-				MarkdownDescription: "A list of documents describing the status of the index's synonym mappings on each search host. Only appears if the index has synonyms defined.",
+				MarkdownDescription: "Applies to type: search. A list of documents describing the status of the index's synonym mappings on each search host. Only appears if the index has synonyms defined.",
 				CustomType:          customtypes.NewListType[jsontypes.Normalized](ctx),
 				ElementType:         jsontypes.NormalizedType{},
 			},

--- a/internal/serviceapi/searchindexapi/resource_schema.go
+++ b/internal/serviceapi/searchindexapi/resource_schema.go
@@ -468,11 +468,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"synonym_mapping_status": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Applies to type: search. Status that describes this index's synonym mappings. This status appears only if the index has synonyms defined.",
+				MarkdownDescription: "Optional for type: search. Status that describes this index's synonym mappings. This status appears only if the index has synonyms defined.",
 			},
 			"synonym_mapping_status_detail": schema.ListAttribute{
 				Computed:            true,
-				MarkdownDescription: "Applies to type: search. A list of documents describing the status of the index's synonym mappings on each search host. Only appears if the index has synonyms defined.",
+				MarkdownDescription: "Optional for type: search. A list of documents describing the status of the index's synonym mappings on each search host. Only appears if the index has synonyms defined.",
 				CustomType:          customtypes.NewListType[jsontypes.Normalized](ctx),
 				ElementType:         jsontypes.NormalizedType{},
 			},

--- a/internal/serviceapi/streamconnectionapi/resource_schema.go
+++ b/internal/serviceapi/streamconnectionapi/resource_schema.go
@@ -20,7 +20,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"authentication": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
+				MarkdownDescription: "Optional for type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
 				CustomType:          customtypes.NewObjectType[TFAuthenticationModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"client_id": schema.StringAttribute{
@@ -78,7 +78,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"aws": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.",
+				MarkdownDescription: "Optional for type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.",
 				CustomType:          customtypes.NewObjectType[TFAwsModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"role_arn": schema.StringAttribute{
@@ -93,25 +93,25 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"bootstrap_servers": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Kafka. Comma separated list of server addresses.",
+				MarkdownDescription: "Optional for type: Kafka. Comma separated list of server addresses.",
 			},
 			"cluster_project_id": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
+				MarkdownDescription: "Optional for type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
 			},
 			"cluster_name": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Cluster. Name of the cluster configured for this connection.",
+				MarkdownDescription: "Optional for type: Cluster. Name of the cluster configured for this connection.",
 			},
 			"config": schema.MapAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
+				MarkdownDescription: "Optional for type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
 				CustomType:          customtypes.NewMapType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
 			"db_role_to_execute": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
+				MarkdownDescription: "Optional for type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
 				CustomType:          customtypes.NewObjectType[TFDbRoleToExecuteModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"role": schema.StringAttribute{
@@ -131,7 +131,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"headers": schema.MapAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.",
+				MarkdownDescription: "Optional for type: Https. A map of key-value pairs that will be passed as headers for the request.",
 				CustomType:          customtypes.NewMapType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
@@ -141,7 +141,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"networking": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.",
+				MarkdownDescription: "Optional for type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.",
 				CustomType:          customtypes.NewObjectType[TFNetworkingModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"access": schema.SingleNestedAttribute{
@@ -216,7 +216,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"security": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
+				MarkdownDescription: "Optional for type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
 				CustomType:          customtypes.NewObjectType[TFSecurityModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"broker_public_certificate": schema.StringAttribute{
@@ -273,7 +273,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"url": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Applies to type: Https. The URL to be used for the request.",
+				MarkdownDescription: "Optional for type: Https. The URL to be used for the request.",
 			},
 			"delete_on_create_timeout": schema.BoolAttribute{
 				Computed:            true,

--- a/internal/serviceapi/streamconnectionapi/resource_schema.go
+++ b/internal/serviceapi/streamconnectionapi/resource_schema.go
@@ -20,7 +20,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"authentication": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
+				MarkdownDescription: "Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
 				CustomType:          customtypes.NewObjectType[TFAuthenticationModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"client_id": schema.StringAttribute{
@@ -78,7 +78,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"aws": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "AWS configurations for AWS-based connection types.",
+				MarkdownDescription: "Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.",
 				CustomType:          customtypes.NewObjectType[TFAwsModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"role_arn": schema.StringAttribute{
@@ -93,25 +93,25 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"bootstrap_servers": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Comma separated list of server addresses.",
+				MarkdownDescription: "Applies to type: Kafka. Comma separated list of server addresses.",
 			},
 			"cluster_project_id": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
+				MarkdownDescription: "Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
 			},
 			"cluster_name": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Name of the cluster configured for this connection.",
+				MarkdownDescription: "Applies to type: Cluster. Name of the cluster configured for this connection.",
 			},
 			"config": schema.MapAttribute{
 				Optional:            true,
-				MarkdownDescription: "A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
+				MarkdownDescription: "Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
 				CustomType:          customtypes.NewMapType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
 			"db_role_to_execute": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
+				MarkdownDescription: "Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
 				CustomType:          customtypes.NewObjectType[TFDbRoleToExecuteModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"role": schema.StringAttribute{
@@ -131,7 +131,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"headers": schema.MapAttribute{
 				Optional:            true,
-				MarkdownDescription: "A map of key-value pairs that will be passed as headers for the request.",
+				MarkdownDescription: "Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.",
 				CustomType:          customtypes.NewMapType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
@@ -141,7 +141,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"networking": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Networking configuration for Streams connections.",
+				MarkdownDescription: "Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.",
 				CustomType:          customtypes.NewObjectType[TFNetworkingModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"access": schema.SingleNestedAttribute{
@@ -171,7 +171,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"schema_registry_provider": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "The Schema Registry provider.",
+				MarkdownDescription: "Required for type: SchemaRegistry. The Schema Registry provider.",
 			},
 			"region": schema.StringAttribute{
 				Computed:            true,
@@ -179,12 +179,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"schema_registry_authentication": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Authentication configuration for Schema Registry.",
+				MarkdownDescription: "Required for type: SchemaRegistry. Authentication configuration for Schema Registry.",
 				CustomType:          customtypes.NewObjectType[TFSchemaRegistryAuthenticationModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"password": schema.StringAttribute{
 						Optional:            true,
-						MarkdownDescription: "Password or Private Key for authentication.",
+						MarkdownDescription: "Required for type: USER_INFO. Password or Private Key for authentication.",
 						Sensitive:           true,
 					},
 					"type": schema.StringAttribute{
@@ -204,19 +204,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 					"username": schema.StringAttribute{
 						Optional:            true,
-						MarkdownDescription: "Username or Public Key for authentication.",
+						MarkdownDescription: "Required for type: USER_INFO. Username or Public Key for authentication.",
 					},
 				},
 			},
 			"schema_registry_urls": schema.ListAttribute{
 				Optional:            true,
-				MarkdownDescription: "List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.",
+				MarkdownDescription: "Required for type: SchemaRegistry. List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.",
 				CustomType:          customtypes.NewListType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
 			"security": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
+				MarkdownDescription: "Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
 				CustomType:          customtypes.NewObjectType[TFSecurityModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"broker_public_certificate": schema.StringAttribute{
@@ -273,7 +273,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"url": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "The URL to be used for the request.",
+				MarkdownDescription: "Applies to type: Https. The URL to be used for the request.",
 			},
 			"delete_on_create_timeout": schema.BoolAttribute{
 				Computed:            true,

--- a/internal/serviceapi/streaminstanceapi/resource_schema.go
+++ b/internal/serviceapi/streaminstanceapi/resource_schema.go
@@ -23,7 +23,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"authentication": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
+							MarkdownDescription: "Optional for type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsAuthenticationModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"client_id": schema.StringAttribute{
@@ -80,7 +80,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"aws": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.",
+							MarkdownDescription: "Optional for type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsAwsModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"role_arn": schema.StringAttribute{
@@ -95,25 +95,25 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"bootstrap_servers": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Kafka. Comma separated list of server addresses.",
+							MarkdownDescription: "Optional for type: Kafka. Comma separated list of server addresses.",
 						},
 						"cluster_group_id": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
+							MarkdownDescription: "Optional for type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
 						},
 						"cluster_name": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Cluster. Name of the cluster configured for this connection.",
+							MarkdownDescription: "Optional for type: Cluster. Name of the cluster configured for this connection.",
 						},
 						"config": schema.MapAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
+							MarkdownDescription: "Optional for type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
 							CustomType:          customtypes.NewMapType[types.String](ctx),
 							ElementType:         types.StringType,
 						},
 						"db_role_to_execute": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
+							MarkdownDescription: "Optional for type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsDbRoleToExecuteModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"role": schema.StringAttribute{
@@ -128,7 +128,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"headers": schema.MapAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.",
+							MarkdownDescription: "Optional for type: Https. A map of key-value pairs that will be passed as headers for the request.",
 							CustomType:          customtypes.NewMapType[types.String](ctx),
 							ElementType:         types.StringType,
 						},
@@ -138,7 +138,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"networking": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.",
+							MarkdownDescription: "Optional for type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsNetworkingModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"access": schema.SingleNestedAttribute{
@@ -201,7 +201,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"security": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
+							MarkdownDescription: "Optional for type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsSecurityModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"broker_public_certificate": schema.StringAttribute{
@@ -224,7 +224,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"url": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Applies to type: Https. The URL to be used for the request.",
+							MarkdownDescription: "Optional for type: Https. The URL to be used for the request.",
 						},
 					},
 				},

--- a/internal/serviceapi/streaminstanceapi/resource_schema.go
+++ b/internal/serviceapi/streaminstanceapi/resource_schema.go
@@ -23,7 +23,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"authentication": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
+							MarkdownDescription: "Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsAuthenticationModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"client_id": schema.StringAttribute{
@@ -80,7 +80,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"aws": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "AWS configurations for AWS-based connection types.",
+							MarkdownDescription: "Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsAwsModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"role_arn": schema.StringAttribute{
@@ -95,25 +95,25 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"bootstrap_servers": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Comma separated list of server addresses.",
+							MarkdownDescription: "Applies to type: Kafka. Comma separated list of server addresses.",
 						},
 						"cluster_group_id": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
+							MarkdownDescription: "Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.",
 						},
 						"cluster_name": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Name of the cluster configured for this connection.",
+							MarkdownDescription: "Applies to type: Cluster. Name of the cluster configured for this connection.",
 						},
 						"config": schema.MapAttribute{
 							Computed:            true,
-							MarkdownDescription: "A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
+							MarkdownDescription: "Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
 							CustomType:          customtypes.NewMapType[types.String](ctx),
 							ElementType:         types.StringType,
 						},
 						"db_role_to_execute": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
+							MarkdownDescription: "Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsDbRoleToExecuteModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"role": schema.StringAttribute{
@@ -128,7 +128,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"headers": schema.MapAttribute{
 							Computed:            true,
-							MarkdownDescription: "A map of key-value pairs that will be passed as headers for the request.",
+							MarkdownDescription: "Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.",
 							CustomType:          customtypes.NewMapType[types.String](ctx),
 							ElementType:         types.StringType,
 						},
@@ -138,7 +138,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"networking": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Networking configuration for Streams connections.",
+							MarkdownDescription: "Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsNetworkingModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"access": schema.SingleNestedAttribute{
@@ -168,7 +168,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"provider": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The Schema Registry provider.",
+							MarkdownDescription: "Required for type: SchemaRegistry. The Schema Registry provider.",
 						},
 						"region": schema.StringAttribute{
 							Computed:            true,
@@ -176,12 +176,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"schema_registry_authentication": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Authentication configuration for Schema Registry.",
+							MarkdownDescription: "Required for type: SchemaRegistry. Authentication configuration for Schema Registry.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsSchemaRegistryAuthenticationModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"password": schema.StringAttribute{
 									Computed:            true,
-									MarkdownDescription: "Password or Private Key for authentication.",
+									MarkdownDescription: "Required for type: USER_INFO. Password or Private Key for authentication.",
 								},
 								"type": schema.StringAttribute{
 									Computed:            true,
@@ -189,19 +189,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"username": schema.StringAttribute{
 									Computed:            true,
-									MarkdownDescription: "Username or Public Key for authentication.",
+									MarkdownDescription: "Required for type: USER_INFO. Username or Public Key for authentication.",
 								},
 							},
 						},
 						"schema_registry_urls": schema.SetAttribute{
 							Computed:            true,
-							MarkdownDescription: "List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.",
+							MarkdownDescription: "Required for type: SchemaRegistry. List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.",
 							CustomType:          customtypes.NewSetType[types.String](ctx),
 							ElementType:         types.StringType,
 						},
 						"security": schema.SingleNestedAttribute{
 							Computed:            true,
-							MarkdownDescription: "Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
+							MarkdownDescription: "Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
 							CustomType:          customtypes.NewObjectType[TFConnectionsSecurityModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"broker_public_certificate": schema.StringAttribute{
@@ -224,7 +224,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"url": schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The URL to be used for the request.",
+							MarkdownDescription: "Applies to type: Https. The URL to be used for the request.",
 						},
 					},
 				},

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -29,6 +29,7 @@ func ApplyTransformationsToResource(resourceConfig *config.Resource, resource *R
 	applyAliasToPathParams(&resource.Operations, resourceConfig.SchemaOptions.Aliases)
 	ApplyDeleteOnCreateTimeoutTransformation(resource)
 	ApplyTimeoutTransformation(resource)
+	EnhanceDescriptionsWithDiscriminator(resource.Schema.Attributes, resource.Schema.Discriminator, true)
 	return nil
 }
 
@@ -60,6 +61,7 @@ func applyDSSchemaTransformations(schemaOptions config.SchemaOptions, schema *Sc
 	applyAliasToDiscriminator(schemaOptions.Aliases, schema.Discriminator, &schema.Attributes)
 	skipDiscriminator(schema.Discriminator)
 	skipValidationForAllNestedDiscriminators(&schema.Attributes)
+	EnhanceDescriptionsWithDiscriminator(schema.Attributes, schema.Discriminator, false)
 	return nil
 }
 
@@ -154,22 +156,8 @@ func applyAttributeTransformationsList(schemaOptions config.SchemaOptions, attri
 			}
 		}
 
-		// apply transformations to nested attributes recursively with the same transformation list
-		switch {
-		case attr.ListNested != nil:
-			if err := applyAttributeTransformationsList(schemaOptions, &attr.ListNested.NestedObject.Attributes, &paths, transformationList); err != nil {
-				return err
-			}
-		case attr.SingleNested != nil:
-			if err := applyAttributeTransformationsList(schemaOptions, &attr.SingleNested.NestedObject.Attributes, &paths, transformationList); err != nil {
-				return err
-			}
-		case attr.SetNested != nil:
-			if err := applyAttributeTransformationsList(schemaOptions, &attr.SetNested.NestedObject.Attributes, &paths, transformationList); err != nil {
-				return err
-			}
-		case attr.MapNested != nil:
-			if err := applyAttributeTransformationsList(schemaOptions, &attr.MapNested.NestedObject.Attributes, &paths, transformationList); err != nil {
+		if nested := attr.NestedObject(); nested != nil {
+			if err := applyAttributeTransformationsList(schemaOptions, &nested.Attributes, &paths, transformationList); err != nil {
 				return err
 			}
 		}
@@ -418,19 +406,9 @@ func applyAliasesToNestedDiscriminators(attributes Attributes, aliases map[strin
 		attr := &attributes[i]
 		apiPath := buildPath(parentAPIPath, attr.APIName)
 
-		switch {
-		case attr.ListNested != nil:
-			applyAliasesToDiscriminator(attr.ListNested.NestedObject.Discriminator, aliases, apiPath)
-			applyAliasesToNestedDiscriminators(attr.ListNested.NestedObject.Attributes, aliases, apiPath)
-		case attr.SingleNested != nil:
-			applyAliasesToDiscriminator(attr.SingleNested.NestedObject.Discriminator, aliases, apiPath)
-			applyAliasesToNestedDiscriminators(attr.SingleNested.NestedObject.Attributes, aliases, apiPath)
-		case attr.SetNested != nil:
-			applyAliasesToDiscriminator(attr.SetNested.NestedObject.Discriminator, aliases, apiPath)
-			applyAliasesToNestedDiscriminators(attr.SetNested.NestedObject.Attributes, aliases, apiPath)
-		case attr.MapNested != nil:
-			applyAliasesToDiscriminator(attr.MapNested.NestedObject.Discriminator, aliases, apiPath)
-			applyAliasesToNestedDiscriminators(attr.MapNested.NestedObject.Attributes, aliases, apiPath)
+		if nested := attr.NestedObject(); nested != nil {
+			applyAliasesToDiscriminator(nested.Discriminator, aliases, apiPath)
+			applyAliasesToNestedDiscriminators(nested.Attributes, aliases, apiPath)
 		}
 	}
 }
@@ -495,19 +473,9 @@ func applyIgnoreValidatorsToNestedDiscriminators(attributes Attributes, schemaOp
 		attr := &attributes[i]
 		schemaPath := buildPath(parentSchemaPath, attr.TFSchemaName)
 
-		switch {
-		case attr.ListNested != nil:
-			applyIgnoreValidatorsToDiscriminator(attr.ListNested.NestedObject.Discriminator, schemaOptions, schemaPath)
-			applyIgnoreValidatorsToNestedDiscriminators(attr.ListNested.NestedObject.Attributes, schemaOptions, schemaPath)
-		case attr.SingleNested != nil:
-			applyIgnoreValidatorsToDiscriminator(attr.SingleNested.NestedObject.Discriminator, schemaOptions, schemaPath)
-			applyIgnoreValidatorsToNestedDiscriminators(attr.SingleNested.NestedObject.Attributes, schemaOptions, schemaPath)
-		case attr.SetNested != nil:
-			applyIgnoreValidatorsToDiscriminator(attr.SetNested.NestedObject.Discriminator, schemaOptions, schemaPath)
-			applyIgnoreValidatorsToNestedDiscriminators(attr.SetNested.NestedObject.Attributes, schemaOptions, schemaPath)
-		case attr.MapNested != nil:
-			applyIgnoreValidatorsToDiscriminator(attr.MapNested.NestedObject.Discriminator, schemaOptions, schemaPath)
-			applyIgnoreValidatorsToNestedDiscriminators(attr.MapNested.NestedObject.Attributes, schemaOptions, schemaPath)
+		if nested := attr.NestedObject(); nested != nil {
+			applyIgnoreValidatorsToDiscriminator(nested.Discriminator, schemaOptions, schemaPath)
+			applyIgnoreValidatorsToNestedDiscriminators(nested.Attributes, schemaOptions, schemaPath)
 		}
 	}
 }
@@ -520,19 +488,9 @@ func skipValidationForAllNestedDiscriminators(attributes *Attributes) {
 	}
 	for i := range *attributes {
 		attr := &(*attributes)[i]
-		switch {
-		case attr.ListNested != nil:
-			skipDiscriminator(attr.ListNested.NestedObject.Discriminator)
-			skipValidationForAllNestedDiscriminators(&attr.ListNested.NestedObject.Attributes)
-		case attr.SingleNested != nil:
-			skipDiscriminator(attr.SingleNested.NestedObject.Discriminator)
-			skipValidationForAllNestedDiscriminators(&attr.SingleNested.NestedObject.Attributes)
-		case attr.SetNested != nil:
-			skipDiscriminator(attr.SetNested.NestedObject.Discriminator)
-			skipValidationForAllNestedDiscriminators(&attr.SetNested.NestedObject.Attributes)
-		case attr.MapNested != nil:
-			skipDiscriminator(attr.MapNested.NestedObject.Discriminator)
-			skipValidationForAllNestedDiscriminators(&attr.MapNested.NestedObject.Attributes)
+		if nested := attr.NestedObject(); nested != nil {
+			skipDiscriminator(nested.Discriminator)
+			skipValidationForAllNestedDiscriminators(&nested.Attributes)
 		}
 	}
 }

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -29,7 +29,7 @@ func ApplyTransformationsToResource(resourceConfig *config.Resource, resource *R
 	applyAliasToPathParams(&resource.Operations, resourceConfig.SchemaOptions.Aliases)
 	ApplyDeleteOnCreateTimeoutTransformation(resource)
 	ApplyTimeoutTransformation(resource)
-	EnhanceDescriptionsWithDiscriminator(resource.Schema.Attributes, resource.Schema.Discriminator, true)
+	EnhanceDescriptionsWithDiscriminator(resource.Schema.Attributes, resource.Schema.Discriminator, false)
 	return nil
 }
 
@@ -61,7 +61,7 @@ func applyDSSchemaTransformations(schemaOptions config.SchemaOptions, schema *Sc
 	applyAliasToDiscriminator(schemaOptions.Aliases, schema.Discriminator, &schema.Attributes)
 	skipDiscriminator(schema.Discriminator)
 	skipValidationForAllNestedDiscriminators(&schema.Attributes)
-	EnhanceDescriptionsWithDiscriminator(schema.Attributes, schema.Discriminator, false)
+	EnhanceDescriptionsWithDiscriminator(schema.Attributes, schema.Discriminator, true)
 	return nil
 }
 

--- a/tools/codegen/codespec/description.go
+++ b/tools/codegen/codespec/description.go
@@ -7,23 +7,24 @@ import (
 )
 
 const (
-	DescriptionPrefixRequired = "Required for"
-	DescriptionPrefixApplies  = "Applies to"
+	DescriptionPrefixRequired   = "Required for"
+	DescriptionPrefixOptional   = "Optional for"
+	DescriptionPrefixApplicable = "Applies to"
 )
 
 // EnhanceDescriptionsWithDiscriminator prepends polymorphic type context to attribute descriptions.
 // These prefixes serve two purposes: the doc post-processor parses them to generate per-type
 // subsections in the published documentation, and they surface discriminator constraints in
 // schema-aware tools (IDE autocompletion, LSP hovers) that display attribute descriptions.
-// useRequiredPrefix=true (resources) distinguishes "Required" vs "Applicable";
-// useRequiredPrefix=false (data sources) always uses "Applicable" since all attributes are read-only.
-func EnhanceDescriptionsWithDiscriminator(attrs Attributes, disc *Discriminator, useRequiredPrefix bool) {
-	enhanceCurrentLevel(attrs, disc, useRequiredPrefix)
+// isDataSource=false (resources) distinguishes "Required for" vs "Optional for";
+// isDataSource=true (data sources) always uses "Applies to" since all attributes are read-only.
+func EnhanceDescriptionsWithDiscriminator(attrs Attributes, disc *Discriminator, isDataSource bool) {
+	enhanceCurrentLevel(attrs, disc, isDataSource)
 
 	for i := range attrs {
 		attr := &attrs[i]
 		if nested := attr.NestedObject(); nested != nil {
-			EnhanceDescriptionsWithDiscriminator(nested.Attributes, nested.Discriminator, useRequiredPrefix)
+			EnhanceDescriptionsWithDiscriminator(nested.Attributes, nested.Discriminator, isDataSource)
 		}
 	}
 }
@@ -33,7 +34,7 @@ type attrTypeInfo struct {
 	optionalTypes []string
 }
 
-func enhanceCurrentLevel(attrs Attributes, disc *Discriminator, useRequiredPrefix bool) {
+func enhanceCurrentLevel(attrs Attributes, disc *Discriminator, isDataSource bool) {
 	if disc == nil {
 		return
 	}
@@ -55,7 +56,7 @@ func enhanceCurrentLevel(attrs Attributes, disc *Discriminator, useRequiredPrefi
 			continue
 		}
 
-		if prefix := buildPrefix(info, discriminatorPropName, useRequiredPrefix); prefix != "" {
+		if prefix := buildPrefix(info, discriminatorPropName, isDataSource); prefix != "" {
 			enhanced := prefix + " " + *attr.Description
 			attr.Description = &enhanced
 		}
@@ -93,11 +94,11 @@ func buildReverseIndex(disc *Discriminator) map[string]*attrTypeInfo {
 	return index
 }
 
-func buildPrefix(info *attrTypeInfo, discriminatorName string, useRequiredPrefix bool) string {
-	if !useRequiredPrefix {
+func buildPrefix(info *attrTypeInfo, discriminatorName string, isDataSource bool) string {
+	if isDataSource {
 		allTypes := append(slices.Clone(info.requiredTypes), info.optionalTypes...)
 		slices.Sort(allTypes)
-		return fmt.Sprintf("%s %s: %s.", DescriptionPrefixApplies, discriminatorName, strings.Join(allTypes, ", "))
+		return fmt.Sprintf("%s %s: %s.", DescriptionPrefixApplicable, discriminatorName, strings.Join(allTypes, ", "))
 	}
 
 	var parts []string
@@ -105,7 +106,7 @@ func buildPrefix(info *attrTypeInfo, discriminatorName string, useRequiredPrefix
 		parts = append(parts, fmt.Sprintf("%s %s: %s.", DescriptionPrefixRequired, discriminatorName, strings.Join(info.requiredTypes, ", ")))
 	}
 	if len(info.optionalTypes) > 0 {
-		parts = append(parts, fmt.Sprintf("%s %s: %s.", DescriptionPrefixApplies, discriminatorName, strings.Join(info.optionalTypes, ", ")))
+		parts = append(parts, fmt.Sprintf("%s %s: %s.", DescriptionPrefixOptional, discriminatorName, strings.Join(info.optionalTypes, ", ")))
 	}
 	return strings.Join(parts, " ")
 }

--- a/tools/codegen/codespec/description.go
+++ b/tools/codegen/codespec/description.go
@@ -1,0 +1,112 @@
+package codespec
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+const (
+	DescriptionPrefixRequired = "Required for"
+	DescriptionPrefixApplies  = "Applies to"
+)
+
+// EnhanceDescriptionsWithDiscriminator prepends polymorphic type context to attribute descriptions.
+// These prefixes serve two purposes: the doc post-processor parses them to generate per-type
+// subsections in the published documentation, and they surface discriminator constraints in
+// schema-aware tools (IDE autocompletion, LSP hovers) that display attribute descriptions.
+// useRequiredPrefix=true (resources) distinguishes "Required" vs "Applicable";
+// useRequiredPrefix=false (data sources) always uses "Applicable" since all attributes are read-only.
+func EnhanceDescriptionsWithDiscriminator(attrs Attributes, disc *Discriminator, useRequiredPrefix bool) {
+	enhanceCurrentLevel(attrs, disc, useRequiredPrefix)
+
+	for i := range attrs {
+		attr := &attrs[i]
+		if nested := attr.NestedObject(); nested != nil {
+			EnhanceDescriptionsWithDiscriminator(nested.Attributes, nested.Discriminator, useRequiredPrefix)
+		}
+	}
+}
+
+type attrTypeInfo struct {
+	requiredTypes []string
+	optionalTypes []string
+}
+
+func enhanceCurrentLevel(attrs Attributes, disc *Discriminator, useRequiredPrefix bool) {
+	if disc == nil {
+		return
+	}
+
+	reverseIndex := buildReverseIndex(disc)
+
+	discriminatorPropName := disc.PropertyName.TFSchemaName
+	for i := range attrs {
+		attr := &attrs[i]
+		if attr.TFSchemaName == discriminatorPropName {
+			continue
+		}
+		if attr.Description == nil {
+			continue
+		}
+
+		info, found := reverseIndex[attr.TFSchemaName]
+		if !found {
+			continue
+		}
+
+		prefix := buildPrefix(info, discriminatorPropName, useRequiredPrefix)
+		if prefix != "" {
+			enhanced := prefix + " " + *attr.Description
+			attr.Description = &enhanced
+		}
+	}
+}
+
+func buildReverseIndex(disc *Discriminator) map[string]*attrTypeInfo {
+	index := make(map[string]*attrTypeInfo)
+
+	for typeName, variant := range disc.Mapping {
+		requiredSet := make(map[string]bool, len(variant.Required))
+		for _, r := range variant.Required {
+			requiredSet[r.TFSchemaName] = true
+		}
+
+		for _, a := range variant.Allowed {
+			info, ok := index[a.TFSchemaName]
+			if !ok {
+				info = &attrTypeInfo{}
+				index[a.TFSchemaName] = info
+			}
+			if requiredSet[a.TFSchemaName] {
+				info.requiredTypes = append(info.requiredTypes, typeName)
+			} else {
+				info.optionalTypes = append(info.optionalTypes, typeName)
+			}
+		}
+	}
+
+	for _, info := range index {
+		slices.Sort(info.requiredTypes)
+		slices.Sort(info.optionalTypes)
+	}
+
+	return index
+}
+
+func buildPrefix(info *attrTypeInfo, discriminatorName string, useRequiredPrefix bool) string {
+	if !useRequiredPrefix {
+		allTypes := append(slices.Clone(info.requiredTypes), info.optionalTypes...)
+		slices.Sort(allTypes)
+		return fmt.Sprintf("%s %s: %s.", DescriptionPrefixApplies, discriminatorName, strings.Join(allTypes, ", "))
+	}
+
+	var parts []string
+	if len(info.requiredTypes) > 0 {
+		parts = append(parts, fmt.Sprintf("%s %s: %s.", DescriptionPrefixRequired, discriminatorName, strings.Join(info.requiredTypes, ", ")))
+	}
+	if len(info.optionalTypes) > 0 {
+		parts = append(parts, fmt.Sprintf("%s %s: %s.", DescriptionPrefixApplies, discriminatorName, strings.Join(info.optionalTypes, ", ")))
+	}
+	return strings.Join(parts, " ")
+}

--- a/tools/codegen/codespec/description.go
+++ b/tools/codegen/codespec/description.go
@@ -55,8 +55,7 @@ func enhanceCurrentLevel(attrs Attributes, disc *Discriminator, useRequiredPrefi
 			continue
 		}
 
-		prefix := buildPrefix(info, discriminatorPropName, useRequiredPrefix)
-		if prefix != "" {
+		if prefix := buildPrefix(info, discriminatorPropName, useRequiredPrefix); prefix != "" {
 			enhanced := prefix + " " + *attr.Description
 			attr.Description = &enhanced
 		}

--- a/tools/codegen/codespec/description_test.go
+++ b/tools/codegen/codespec/description_test.go
@@ -1,0 +1,105 @@
+package codespec_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/codespec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnhanceDescriptions_Resource(t *testing.T) {
+	attrs := codespec.Attributes{
+		{TFSchemaName: "discriminator_prop", Description: conversion.StringPtr("The type.")},
+		{TFSchemaName: "base_attr", Description: conversion.StringPtr("Base attr description.")},
+		{TFSchemaName: "required_in_all_types", Description: conversion.StringPtr("Required in all types description.")},
+		{TFSchemaName: "mixed_required_and_optional", Description: conversion.StringPtr("Mixed required and optional description.")},
+		{TFSchemaName: "required_single_type", Description: conversion.StringPtr("Required single type description.")},
+		{TFSchemaName: "nil_description", Description: nil},
+	}
+	disc := &codespec.Discriminator{
+		PropertyName: codespec.DiscriminatorAttrName{APIName: "discriminatorProp", TFSchemaName: "discriminator_prop"},
+		Mapping: map[string]codespec.DiscriminatorType{
+			"ALPHA": {
+				Allowed:  []codespec.DiscriminatorAttrName{{APIName: "requiredInAllTypes", TFSchemaName: "required_in_all_types"}, {APIName: "mixedRequiredAndOptional", TFSchemaName: "mixed_required_and_optional"}},
+				Required: []codespec.DiscriminatorAttrName{{APIName: "requiredInAllTypes", TFSchemaName: "required_in_all_types"}},
+			},
+			"BETA": {
+				Allowed:  []codespec.DiscriminatorAttrName{{APIName: "requiredInAllTypes", TFSchemaName: "required_in_all_types"}, {APIName: "mixedRequiredAndOptional", TFSchemaName: "mixed_required_and_optional"}},
+				Required: []codespec.DiscriminatorAttrName{{APIName: "requiredInAllTypes", TFSchemaName: "required_in_all_types"}, {APIName: "mixedRequiredAndOptional", TFSchemaName: "mixed_required_and_optional"}},
+			},
+			"GAMMA": {
+				Allowed:  []codespec.DiscriminatorAttrName{{APIName: "requiredSingleType", TFSchemaName: "required_single_type"}},
+				Required: []codespec.DiscriminatorAttrName{{APIName: "requiredSingleType", TFSchemaName: "required_single_type"}},
+			},
+		},
+	}
+
+	codespec.EnhanceDescriptionsWithDiscriminator(attrs, disc, true)
+
+	assert.Equal(t, "The type.", *attrs[0].Description, "discriminator property itself is skipped")
+	assert.Equal(t, "Base attr description.", *attrs[1].Description, "base/common attribute is untouched")
+	assert.Equal(t, "Required for discriminator_prop: ALPHA, BETA. Required in all types description.", *attrs[2].Description)
+	assert.Equal(t, "Required for discriminator_prop: BETA. Applies to discriminator_prop: ALPHA. Mixed required and optional description.", *attrs[3].Description)
+	assert.Equal(t, "Required for discriminator_prop: GAMMA. Required single type description.", *attrs[4].Description)
+	assert.Nil(t, attrs[5].Description, "nil description stays nil")
+}
+
+func TestEnhanceDescriptions_DataSource(t *testing.T) {
+	attrs := codespec.Attributes{
+		{TFSchemaName: "type", Description: conversion.StringPtr("The type.")},
+		{TFSchemaName: "bucket_name", Description: conversion.StringPtr("Name of the bucket.")},
+	}
+	disc := &codespec.Discriminator{
+		PropertyName: codespec.NewDiscriminatorAttrName("type"),
+		Mapping: map[string]codespec.DiscriminatorType{
+			"GCS_LOG_EXPORT": {
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("bucketName")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("bucketName")},
+			},
+			"S3_LOG_EXPORT": {
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("bucketName")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("bucketName")},
+			},
+		},
+	}
+
+	codespec.EnhanceDescriptionsWithDiscriminator(attrs, disc, false)
+
+	assert.Equal(t, "Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket.", *attrs[1].Description, "data sources always use 'Applies to'")
+}
+
+func TestEnhanceDescriptions_NestedDiscriminator(t *testing.T) {
+	nestedDisc := &codespec.Discriminator{
+		PropertyName: codespec.NewDiscriminatorAttrName("authType"),
+		Mapping: map[string]codespec.DiscriminatorType{
+			"OAUTH": {
+				Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("clientId")},
+				Required: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("clientId")},
+			},
+		},
+	}
+
+	attrs := codespec.Attributes{
+		{
+			TFSchemaName: "authentication",
+			Description:  conversion.StringPtr("Auth config."),
+			SingleNested: &codespec.SingleNestedAttribute{
+				NestedObject: codespec.NestedAttributeObject{
+					Discriminator: nestedDisc,
+					Attributes: codespec.Attributes{
+						{TFSchemaName: "auth_type", Description: conversion.StringPtr("The auth type.")},
+						{TFSchemaName: "client_id", Description: conversion.StringPtr("OAuth client ID.")},
+					},
+				},
+			},
+		},
+	}
+
+	codespec.EnhanceDescriptionsWithDiscriminator(attrs, nil, true)
+
+	assert.Equal(t, "Auth config.", *attrs[0].Description, "parent not modified when root disc is nil")
+	nestedAttrs := attrs[0].SingleNested.NestedObject.Attributes
+	assert.Equal(t, "The auth type.", *nestedAttrs[0].Description, "nested discriminator property is skipped")
+	assert.Equal(t, "Required for auth_type: OAUTH. OAuth client ID.", *nestedAttrs[1].Description)
+}

--- a/tools/codegen/codespec/description_test.go
+++ b/tools/codegen/codespec/description_test.go
@@ -35,12 +35,12 @@ func TestEnhanceDescriptions_Resource(t *testing.T) {
 		},
 	}
 
-	codespec.EnhanceDescriptionsWithDiscriminator(attrs, disc, true)
+	codespec.EnhanceDescriptionsWithDiscriminator(attrs, disc, false)
 
 	assert.Equal(t, "The type.", *attrs[0].Description, "discriminator property itself is skipped")
 	assert.Equal(t, "Base attr description.", *attrs[1].Description, "base/common attribute is untouched")
 	assert.Equal(t, "Required for discriminator_prop: ALPHA, BETA. Required in all types description.", *attrs[2].Description)
-	assert.Equal(t, "Required for discriminator_prop: BETA. Applies to discriminator_prop: ALPHA. Mixed required and optional description.", *attrs[3].Description)
+	assert.Equal(t, "Required for discriminator_prop: BETA. Optional for discriminator_prop: ALPHA. Mixed required and optional description.", *attrs[3].Description)
 	assert.Equal(t, "Required for discriminator_prop: GAMMA. Required single type description.", *attrs[4].Description)
 	assert.Nil(t, attrs[5].Description, "nil description stays nil")
 }
@@ -64,7 +64,7 @@ func TestEnhanceDescriptions_DataSource(t *testing.T) {
 		},
 	}
 
-	codespec.EnhanceDescriptionsWithDiscriminator(attrs, disc, false)
+	codespec.EnhanceDescriptionsWithDiscriminator(attrs, disc, true)
 
 	assert.Equal(t, "Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket.", *attrs[1].Description, "data sources always use 'Applies to'")
 }
@@ -96,7 +96,7 @@ func TestEnhanceDescriptions_NestedDiscriminator(t *testing.T) {
 		},
 	}
 
-	codespec.EnhanceDescriptionsWithDiscriminator(attrs, nil, true)
+	codespec.EnhanceDescriptionsWithDiscriminator(attrs, nil, false)
 
 	assert.Equal(t, "Auth config.", *attrs[0].Description, "parent not modified when root disc is nil")
 	nestedAttrs := attrs[0].SingleNested.NestedObject.Attributes

--- a/tools/codegen/codespec/merge_attributes.go
+++ b/tools/codegen/codespec/merge_attributes.go
@@ -184,17 +184,8 @@ func updateNestedComputabilityAndReqBodyUsage(attrs *Attributes, parentIsCompute
 		attrIsComputed := attr.ComputedOptionalRequired == Computed
 		attrIsOmittedInReqBody := attr.ReqBodyUsage == OmitAlways
 
-		if attr.ListNested != nil {
-			updateNestedComputabilityAndReqBodyUsage(&attr.ListNested.NestedObject.Attributes, attrIsComputed, attrIsOmittedInReqBody)
-		}
-		if attr.SingleNested != nil {
-			updateNestedComputabilityAndReqBodyUsage(&attr.SingleNested.NestedObject.Attributes, attrIsComputed, attrIsOmittedInReqBody)
-		}
-		if attr.SetNested != nil {
-			updateNestedComputabilityAndReqBodyUsage(&attr.SetNested.NestedObject.Attributes, attrIsComputed, attrIsOmittedInReqBody)
-		}
-		if attr.MapNested != nil {
-			updateNestedComputabilityAndReqBodyUsage(&attr.MapNested.NestedObject.Attributes, attrIsComputed, attrIsOmittedInReqBody)
+		if nested := attr.NestedObject(); nested != nil {
+			updateNestedComputabilityAndReqBodyUsage(&nested.Attributes, attrIsComputed, attrIsOmittedInReqBody)
 		}
 	}
 }
@@ -268,35 +259,10 @@ func setAttributeComputedRecursive(attr *Attribute) {
 	attr.ComputedOptionalRequired = Computed
 	attr.ReqBodyUsage = OmitAlways
 
-	// Process nested attributes in ListNested
-	if attr.ListNested != nil {
-		for i := range attr.ListNested.NestedObject.Attributes {
-			setAttributeComputedRecursive(&attr.ListNested.NestedObject.Attributes[i])
+	if nested := attr.NestedObject(); nested != nil {
+		for i := range nested.Attributes {
+			setAttributeComputedRecursive(&nested.Attributes[i])
 		}
-		sortAttributes(attr.ListNested.NestedObject.Attributes)
-	}
-
-	// Process nested attributes in SingleNested
-	if attr.SingleNested != nil {
-		for i := range attr.SingleNested.NestedObject.Attributes {
-			setAttributeComputedRecursive(&attr.SingleNested.NestedObject.Attributes[i])
-		}
-		sortAttributes(attr.SingleNested.NestedObject.Attributes)
-	}
-
-	// Process nested attributes in SetNested
-	if attr.SetNested != nil {
-		for i := range attr.SetNested.NestedObject.Attributes {
-			setAttributeComputedRecursive(&attr.SetNested.NestedObject.Attributes[i])
-		}
-		sortAttributes(attr.SetNested.NestedObject.Attributes)
-	}
-
-	// Process nested attributes in MapNested
-	if attr.MapNested != nil {
-		for i := range attr.MapNested.NestedObject.Attributes {
-			setAttributeComputedRecursive(&attr.MapNested.NestedObject.Attributes[i])
-		}
-		sortAttributes(attr.MapNested.NestedObject.Attributes)
+		sortAttributes(nested.Attributes)
 	}
 }

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -148,6 +148,21 @@ type Attribute struct {
 	ImmutableComputed           bool                     `yaml:"immutable_computed,omitempty"`    // When true, adds UseStateForUnknown plan modifier for computed attributes.
 }
 
+func (a *Attribute) NestedObject() *NestedAttributeObject {
+	switch {
+	case a.ListNested != nil:
+		return &a.ListNested.NestedObject
+	case a.SetNested != nil:
+		return &a.SetNested.NestedObject
+	case a.SingleNested != nil:
+		return &a.SingleNested.NestedObject
+	case a.MapNested != nil:
+		return &a.MapNested.NestedObject
+	default:
+		return nil
+	}
+}
+
 type ComputedOptionalRequired string
 
 const (

--- a/tools/codegen/gofilegen/schema/typed_model.go
+++ b/tools/codegen/gofilegen/schema/typed_model.go
@@ -44,19 +44,7 @@ func generateTypedModels(attributes codespec.Attributes, name string, isDataSour
 }
 
 func getNestedModel(attribute *codespec.Attribute, ancestorsName string, isDataSource bool, dsPrefix string) *CodeStatement {
-	var nested *codespec.NestedAttributeObject
-	if attribute.ListNested != nil {
-		nested = &attribute.ListNested.NestedObject
-	}
-	if attribute.SingleNested != nil {
-		nested = &attribute.SingleNested.NestedObject
-	}
-	if attribute.MapNested != nil {
-		nested = &attribute.MapNested.NestedObject
-	}
-	if attribute.SetNested != nil {
-		nested = &attribute.SetNested.NestedObject
-	}
+	nested := attribute.NestedObject()
 	if nested == nil {
 		return nil
 	}

--- a/tools/codegen/models/cluster_api.yaml
+++ b/tools/codegen/models/cluster_api.yaml
@@ -575,7 +575,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsAnalyticsAutoScaling
@@ -657,7 +657,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsAnalyticsSpecs
@@ -770,7 +770,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsAutoScaling
@@ -786,7 +786,7 @@ schema:
                                   present_in_any_response: true
                                   request_only_required_on_create: false
                                 - string: {}
-                                  description: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
+                                  description: "Optional for provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
                                   computed_optional_required: computed
                                   tf_schema_name: backing_provider_name
                                   tf_model_name: BackingProviderName
@@ -863,7 +863,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsEffectiveAnalyticsSpecs
@@ -945,7 +945,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsEffectiveElectableSpecs
@@ -1027,7 +1027,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsEffectiveReadOnlySpecs
@@ -1227,7 +1227,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsReadOnlySpecs
@@ -1722,7 +1722,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsAutoScaling
@@ -1804,7 +1804,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsSpecs
@@ -1917,7 +1917,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAutoScaling
@@ -1933,7 +1933,7 @@ schema:
                                   present_in_any_response: true
                                   request_only_required_on_create: false
                                 - string: {}
-                                  description: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
+                                  description: "Optional for provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
                                   computed_optional_required: optional
                                   tf_schema_name: backing_provider_name
                                   tf_model_name: BackingProviderName
@@ -2010,7 +2010,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsEffectiveAnalyticsSpecs
@@ -2092,7 +2092,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsEffectiveElectableSpecs
@@ -2174,7 +2174,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsEffectiveReadOnlySpecs
@@ -2374,7 +2374,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsReadOnlySpecs

--- a/tools/codegen/models/cluster_api.yaml
+++ b/tools/codegen/models/cluster_api.yaml
@@ -575,7 +575,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Options that determine how this cluster handles resource scaling.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsAnalyticsAutoScaling
@@ -657,7 +657,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsAnalyticsSpecs
@@ -770,7 +770,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Options that determine how this cluster handles resource scaling.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsAutoScaling
@@ -786,7 +786,7 @@ schema:
                                   present_in_any_response: true
                                   request_only_required_on_create: false
                                 - string: {}
-                                  description: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
+                                  description: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
                                   computed_optional_required: computed
                                   tf_schema_name: backing_provider_name
                                   tf_model_name: BackingProviderName
@@ -863,7 +863,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsEffectiveAnalyticsSpecs
@@ -945,7 +945,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsEffectiveElectableSpecs
@@ -1027,7 +1027,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsEffectiveReadOnlySpecs
@@ -1227,7 +1227,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: EffectiveReplicationSpecsRegionConfigsReadOnlySpecs
@@ -1722,7 +1722,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Options that determine how this cluster handles resource scaling.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsAutoScaling
@@ -1804,7 +1804,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsSpecs
@@ -1917,7 +1917,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Options that determine how this cluster handles resource scaling.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAutoScaling
@@ -1933,7 +1933,7 @@ schema:
                                   present_in_any_response: true
                                   request_only_required_on_create: false
                                 - string: {}
-                                  description: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
+                                  description: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
                                   computed_optional_required: optional
                                   tf_schema_name: backing_provider_name
                                   tf_model_name: BackingProviderName
@@ -2010,7 +2010,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsEffectiveAnalyticsSpecs
@@ -2092,7 +2092,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsEffectiveElectableSpecs
@@ -2174,7 +2174,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsEffectiveReadOnlySpecs
@@ -2374,7 +2374,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: The current hardware specifications for read only nodes in the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. The current hardware specifications for read only nodes in the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsReadOnlySpecs

--- a/tools/codegen/models/cluster_old_api.yaml
+++ b/tools/codegen/models/cluster_old_api.yaml
@@ -799,7 +799,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Options that determine how this cluster handles resource scaling.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsAutoScaling
@@ -870,7 +870,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don''t specify this parameter, no read-only nodes are deployed to the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsSpecs
@@ -983,7 +983,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Options that determine how this cluster handles resource scaling.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAutoScaling
@@ -999,7 +999,7 @@ schema:
                                   present_in_any_response: true
                                   request_only_required_on_create: false
                                 - string: {}
-                                  description: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
+                                  description: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
                                   computed_optional_required: optional
                                   tf_schema_name: backing_provider_name
                                   tf_model_name: BackingProviderName
@@ -1172,7 +1172,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.
+                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don''t specify this parameter, no read-only nodes are deployed to the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsReadOnlySpecs

--- a/tools/codegen/models/cluster_old_api.yaml
+++ b/tools/codegen/models/cluster_old_api.yaml
@@ -799,7 +799,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsAutoScaling
@@ -870,7 +870,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don''t specify this parameter, no read-only nodes are deployed to the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don''t specify this parameter, no read-only nodes are deployed to the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAnalyticsSpecs
@@ -983,7 +983,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Options that determine how this cluster handles resource scaling.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsAutoScaling
@@ -999,7 +999,7 @@ schema:
                                   present_in_any_response: true
                                   request_only_required_on_create: false
                                 - string: {}
-                                  description: "Applies to provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
+                                  description: "Optional for provider_name: TENANT. Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward."
                                   computed_optional_required: optional
                                   tf_schema_name: backing_provider_name
                                   tf_model_name: BackingProviderName
@@ -1172,7 +1172,7 @@ schema:
                                               create_only: false
                                               present_in_any_response: true
                                               request_only_required_on_create: false
-                                  description: 'Applies to provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don''t specify this parameter, no read-only nodes are deployed to the region.'
+                                  description: 'Optional for provider_name: AWS, AZURE, GCP. Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don''t specify this parameter, no read-only nodes are deployed to the region.'
                                   custom_type:
                                     package: customtypes
                                     name: ReplicationSpecsRegionConfigsReadOnlySpecs

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -169,7 +169,7 @@ schema:
           request_only_required_on_create: false
           immutable_computed: true
         - string: {}
-          description: 'Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.'
+          description: 'Optional for type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.'
           computed_optional_required: optional
           tf_schema_name: kms_key
           tf_model_name: KmsKey
@@ -181,7 +181,7 @@ schema:
           request_only_required_on_create: false
         - set:
             element_type: 4
-          description: Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+          description: Array of log types exported by this integration.
           custom_type:
             package: customtypes
             model: customtypes.SetValue[types.String]
@@ -499,7 +499,7 @@ data_sources:
               request_only_required_on_create: false
             - set:
                 element_type: 4
-              description: Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+              description: Array of log types exported by this integration.
               custom_type:
                 package: customtypes
                 model: customtypes.SetValue[types.String]
@@ -838,7 +838,7 @@ data_sources:
                           request_only_required_on_create: false
                         - set:
                             element_type: 4
-                          description: Array of log types exported by this integration. The specific log types available and maximum number of items depend on the integration type. See the integration-specific schema for details.
+                          description: Array of log types exported by this integration.
                           custom_type:
                             package: customtypes
                             model: customtypes.SetValue[types.String]

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -91,7 +91,7 @@ schema:
             tf_schema_name: type
     attributes:
         - string: {}
-          description: API key for authentication.
+          description: 'Required for type: DATADOG_LOG_EXPORT. API key for authentication.'
           computed_optional_required: optional
           tf_schema_name: api_key
           tf_model_name: ApiKey
@@ -102,7 +102,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Name of the bucket to store log files.
+          description: 'Required for type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.'
           computed_optional_required: optional
           tf_schema_name: bucket_name
           tf_model_name: BucketName
@@ -124,7 +124,7 @@ schema:
           present_in_any_response: false
           request_only_required_on_create: false
         - string: {}
-          description: HTTP Event Collector (HEC) token for authentication.
+          description: 'Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.'
           computed_optional_required: optional
           tf_schema_name: hec_token
           tf_model_name: HecToken
@@ -135,7 +135,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: HTTP Event Collector (HEC) endpoint URL.
+          description: 'Required for type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.'
           computed_optional_required: optional
           tf_schema_name: hec_url
           tf_model_name: HecUrl
@@ -146,7 +146,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
+          description: 'Required for type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.'
           computed_optional_required: optional
           tf_schema_name: iam_role_id
           tf_model_name: IamRoleId
@@ -169,7 +169,7 @@ schema:
           request_only_required_on_create: false
           immutable_computed: true
         - string: {}
-          description: AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+          description: 'Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.'
           computed_optional_required: optional
           tf_schema_name: kms_key
           tf_model_name: KmsKey
@@ -196,7 +196,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.
+          description: 'Required for type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL. Must be HTTPS and not exceed 2048 characters.'
           computed_optional_required: optional
           tf_schema_name: otel_endpoint
           tf_model_name: OtelEndpoint
@@ -231,7 +231,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.
+          description: 'Required for type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.'
           custom_type:
             package: customtypes
             name: OtelSuppliedHeaders
@@ -247,7 +247,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+          description: 'Required for type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.'
           computed_optional_required: optional
           tf_schema_name: prefix_path
           tf_model_name: PrefixPath
@@ -258,7 +258,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: 'Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
+          description: 'Required for type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
           computed_optional_required: optional
           tf_schema_name: region
           tf_model_name: Region
@@ -269,7 +269,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
+          description: 'Required for type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.'
           computed_optional_required: optional
           tf_schema_name: role_id
           tf_model_name: RoleId
@@ -280,7 +280,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Storage account name where logs will be stored.
+          description: 'Required for type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.'
           computed_optional_required: optional
           tf_schema_name: storage_account_name
           tf_model_name: StorageAccountName
@@ -291,7 +291,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Storage container name for log files.
+          description: 'Required for type: AZURE_LOG_EXPORT. Storage container name for log files.'
           computed_optional_required: optional
           tf_schema_name: storage_container_name
           tf_model_name: StorageContainerName
@@ -421,7 +421,7 @@ data_sources:
             skip_validation: true
         attributes:
             - string: {}
-              description: API key for authentication.
+              description: 'Applies to type: DATADOG_LOG_EXPORT. API key for authentication.'
               computed_optional_required: computed
               tf_schema_name: api_key
               tf_model_name: ApiKey
@@ -432,7 +432,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Name of the bucket to store log files.
+              description: 'Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.'
               computed_optional_required: computed
               tf_schema_name: bucket_name
               tf_model_name: BucketName
@@ -443,7 +443,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: HTTP Event Collector (HEC) token for authentication.
+              description: 'Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.'
               computed_optional_required: computed
               tf_schema_name: hec_token
               tf_model_name: HecToken
@@ -454,7 +454,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: HTTP Event Collector (HEC) endpoint URL.
+              description: 'Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.'
               computed_optional_required: computed
               tf_schema_name: hec_url
               tf_model_name: HecUrl
@@ -465,7 +465,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
+              description: 'Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.'
               computed_optional_required: computed
               tf_schema_name: iam_role_id
               tf_model_name: IamRoleId
@@ -487,7 +487,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+              description: 'Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.'
               computed_optional_required: computed
               tf_schema_name: kms_key
               tf_model_name: KmsKey
@@ -514,7 +514,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: OpenTelemetry collector endpoint URL.
+              description: 'Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.'
               computed_optional_required: computed
               tf_schema_name: otel_endpoint
               tf_model_name: OtelEndpoint
@@ -549,7 +549,7 @@ data_sources:
                           create_only: false
                           present_in_any_response: false
                           request_only_required_on_create: false
-              description: HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.
+              description: 'Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.'
               custom_type:
                 package: customtypes
                 name: OtelSuppliedHeaders
@@ -565,7 +565,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+              description: 'Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.'
               computed_optional_required: computed
               tf_schema_name: prefix_path
               tf_model_name: PrefixPath
@@ -587,7 +587,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: 'Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
+              description: 'Applies to type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
               computed_optional_required: computed
               tf_schema_name: region
               tf_model_name: Region
@@ -598,7 +598,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
+              description: 'Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.'
               computed_optional_required: computed
               tf_schema_name: role_id
               tf_model_name: RoleId
@@ -609,7 +609,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Storage account name where logs will be stored.
+              description: 'Applies to type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.'
               computed_optional_required: computed
               tf_schema_name: storage_account_name
               tf_model_name: StorageAccountName
@@ -620,7 +620,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Storage container name for log files.
+              description: 'Applies to type: AZURE_LOG_EXPORT. Storage container name for log files.'
               computed_optional_required: computed
               tf_schema_name: storage_container_name
               tf_model_name: StorageContainerName
@@ -760,7 +760,7 @@ data_sources:
                         skip_validation: true
                     attributes:
                         - string: {}
-                          description: API key for authentication.
+                          description: 'Applies to type: DATADOG_LOG_EXPORT. API key for authentication.'
                           computed_optional_required: computed
                           tf_schema_name: api_key
                           tf_model_name: ApiKey
@@ -771,7 +771,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Name of the bucket to store log files.
+                          description: 'Applies to type: GCS_LOG_EXPORT, S3_LOG_EXPORT. Name of the bucket to store log files.'
                           computed_optional_required: computed
                           tf_schema_name: bucket_name
                           tf_model_name: BucketName
@@ -782,7 +782,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: HTTP Event Collector (HEC) token for authentication.
+                          description: 'Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) token for authentication.'
                           computed_optional_required: computed
                           tf_schema_name: hec_token
                           tf_model_name: HecToken
@@ -793,7 +793,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: HTTP Event Collector (HEC) endpoint URL.
+                          description: 'Applies to type: SPLUNK_LOG_EXPORT. HTTP Event Collector (HEC) endpoint URL.'
                           computed_optional_required: computed
                           tf_schema_name: hec_url
                           tf_model_name: HecUrl
@@ -804,7 +804,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
+                          description: 'Applies to type: S3_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.'
                           computed_optional_required: computed
                           tf_schema_name: iam_role_id
                           tf_model_name: IamRoleId
@@ -826,7 +826,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+                          description: 'Applies to type: S3_LOG_EXPORT. AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.'
                           computed_optional_required: computed
                           tf_schema_name: kms_key
                           tf_model_name: KmsKey
@@ -853,7 +853,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: OpenTelemetry collector endpoint URL.
+                          description: 'Applies to type: OTEL_LOG_EXPORT. OpenTelemetry collector endpoint URL.'
                           computed_optional_required: computed
                           tf_schema_name: otel_endpoint
                           tf_model_name: OtelEndpoint
@@ -888,7 +888,7 @@ data_sources:
                                       create_only: false
                                       present_in_any_response: false
                                       request_only_required_on_create: false
-                          description: HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.
+                          description: 'Applies to type: OTEL_LOG_EXPORT. HTTP headers for authentication and configuration. Maximum 10 headers, total size limit 2KB.'
                           custom_type:
                             package: customtypes
                             name: ResultsOtelSuppliedHeaders
@@ -904,7 +904,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+                          description: 'Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT, S3_LOG_EXPORT. Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.'
                           computed_optional_required: computed
                           tf_schema_name: prefix_path
                           tf_model_name: PrefixPath
@@ -915,7 +915,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: 'Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
+                          description: 'Applies to type: DATADOG_LOG_EXPORT. Datadog site/region for log ingestion. Valid values: US1, US3, US5, EU, AP1, AP2, US1_FED.'
                           computed_optional_required: computed
                           tf_schema_name: region
                           tf_model_name: Region
@@ -926,7 +926,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.
+                          description: 'Applies to type: AZURE_LOG_EXPORT, GCS_LOG_EXPORT. Unique 24-character hexadecimal string that identifies the Atlas Cloud Provider Access role.'
                           computed_optional_required: computed
                           tf_schema_name: role_id
                           tf_model_name: RoleId
@@ -937,7 +937,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Storage account name where logs will be stored.
+                          description: 'Applies to type: AZURE_LOG_EXPORT. Storage account name where logs will be stored.'
                           computed_optional_required: computed
                           tf_schema_name: storage_account_name
                           tf_model_name: StorageAccountName
@@ -948,7 +948,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Storage container name for log files.
+                          description: 'Applies to type: AZURE_LOG_EXPORT. Storage container name for log files.'
                           computed_optional_required: computed
                           tf_schema_name: storage_container_name
                           tf_model_name: StorageContainerName

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -1251,7 +1251,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Status that describes this index's synonym mappings. This status appears only if the index has synonyms defined.
+          description: 'Applies to type: search. Status that describes this index''s synonym mappings. This status appears only if the index has synonyms defined.'
           computed_optional_required: computed
           tf_schema_name: synonym_mapping_status
           tf_model_name: SynonymMappingStatus
@@ -1263,7 +1263,7 @@ schema:
           request_only_required_on_create: false
         - list:
             element_type: 5
-          description: A list of documents describing the status of the index's synonym mappings on each search host. Only appears if the index has synonyms defined.
+          description: 'Applies to type: search. A list of documents describing the status of the index''s synonym mappings on each search host. Only appears if the index has synonyms defined.'
           custom_type:
             package: customtypes
             model: customtypes.ListValue[jsontypes.Normalized]

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -1251,7 +1251,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: 'Applies to type: search. Status that describes this index''s synonym mappings. This status appears only if the index has synonyms defined.'
+          description: 'Optional for type: search. Status that describes this index''s synonym mappings. This status appears only if the index has synonyms defined.'
           computed_optional_required: computed
           tf_schema_name: synonym_mapping_status
           tf_model_name: SynonymMappingStatus
@@ -1263,7 +1263,7 @@ schema:
           request_only_required_on_create: false
         - list:
             element_type: 5
-          description: 'Applies to type: search. A list of documents describing the status of the index''s synonym mappings on each search host. Only appears if the index has synonyms defined.'
+          description: 'Optional for type: search. A list of documents describing the status of the index''s synonym mappings on each search host. Only appears if the index has synonyms defined.'
           custom_type:
             package: customtypes
             model: customtypes.ListValue[jsontypes.Normalized]

--- a/tools/codegen/models/stream_connection_api.yaml
+++ b/tools/codegen/models/stream_connection_api.yaml
@@ -200,7 +200,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.
+          description: 'Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.'
           custom_type:
             package: customtypes
             name: Authentication
@@ -240,7 +240,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: AWS configurations for AWS-based connection types.
+          description: 'Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.'
           custom_type:
             package: customtypes
             name: Aws
@@ -256,7 +256,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Comma separated list of server addresses.
+          description: 'Applies to type: Kafka. Comma separated list of server addresses.'
           computed_optional_required: optional
           tf_schema_name: bootstrap_servers
           tf_model_name: BootstrapServers
@@ -267,7 +267,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.
+          description: 'Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.'
           computed_optional_required: optional
           tf_schema_name: cluster_project_id
           tf_model_name: ClusterProjectId
@@ -278,7 +278,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: Name of the cluster configured for this connection.
+          description: 'Applies to type: Cluster. Name of the cluster configured for this connection.'
           computed_optional_required: optional
           tf_schema_name: cluster_name
           tf_model_name: ClusterName
@@ -290,7 +290,7 @@ schema:
           request_only_required_on_create: false
         - map:
             element_type: 4
-          description: A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.
+          description: 'Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have ''.'' characters.'
           custom_type:
             package: customtypes
             model: customtypes.MapValue[types.String]
@@ -329,7 +329,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: The name of a Built in or Custom DB Role to connect to an Atlas Cluster.
+          description: 'Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.'
           custom_type:
             package: customtypes
             name: DbRoleToExecute
@@ -357,7 +357,7 @@ schema:
           request_only_required_on_create: false
         - map:
             element_type: 4
-          description: A map of key-value pairs that will be passed as headers for the request.
+          description: 'Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.'
           custom_type:
             package: customtypes
             model: customtypes.MapValue[types.String]
@@ -447,7 +447,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: Networking configuration for Streams connections.
+          description: 'Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.'
           custom_type:
             package: customtypes
             name: Networking
@@ -463,7 +463,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: The Schema Registry provider.
+          description: 'Required for type: SchemaRegistry. The Schema Registry provider.'
           computed_optional_required: optional
           tf_schema_name: schema_registry_provider
           tf_model_name: SchemaRegistryProvider
@@ -506,7 +506,7 @@ schema:
                         tf_schema_name: type
                 attributes:
                     - string: {}
-                      description: Password or Private Key for authentication.
+                      description: 'Required for type: USER_INFO. Password or Private Key for authentication.'
                       computed_optional_required: optional
                       tf_schema_name: password
                       tf_model_name: Password
@@ -528,7 +528,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: Username or Public Key for authentication.
+                      description: 'Required for type: USER_INFO. Username or Public Key for authentication.'
                       computed_optional_required: optional
                       tf_schema_name: username
                       tf_model_name: Username
@@ -538,7 +538,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: Authentication configuration for Schema Registry.
+          description: 'Required for type: SchemaRegistry. Authentication configuration for Schema Registry.'
           custom_type:
             package: customtypes
             name: SchemaRegistryAuthentication
@@ -555,7 +555,7 @@ schema:
           request_only_required_on_create: false
         - list:
             element_type: 4
-          description: List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.
+          description: 'Required for type: SchemaRegistry. List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.'
           custom_type:
             package: customtypes
             model: customtypes.ListValue[types.String]
@@ -594,7 +594,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.
+          description: 'Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.'
           custom_type:
             package: customtypes
             name: Security
@@ -643,7 +643,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: The URL to be used for the request.
+          description: 'Applies to type: Https. The URL to be used for the request.'
           computed_optional_required: optional
           tf_schema_name: url
           tf_model_name: Url

--- a/tools/codegen/models/stream_connection_api.yaml
+++ b/tools/codegen/models/stream_connection_api.yaml
@@ -200,7 +200,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: 'Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.'
+          description: 'Optional for type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.'
           custom_type:
             package: customtypes
             name: Authentication
@@ -240,7 +240,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: 'Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.'
+          description: 'Optional for type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.'
           custom_type:
             package: customtypes
             name: Aws
@@ -256,7 +256,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: 'Applies to type: Kafka. Comma separated list of server addresses.'
+          description: 'Optional for type: Kafka. Comma separated list of server addresses.'
           computed_optional_required: optional
           tf_schema_name: bootstrap_servers
           tf_model_name: BootstrapServers
@@ -267,7 +267,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: 'Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.'
+          description: 'Optional for type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.'
           computed_optional_required: optional
           tf_schema_name: cluster_project_id
           tf_model_name: ClusterProjectId
@@ -278,7 +278,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: 'Applies to type: Cluster. Name of the cluster configured for this connection.'
+          description: 'Optional for type: Cluster. Name of the cluster configured for this connection.'
           computed_optional_required: optional
           tf_schema_name: cluster_name
           tf_model_name: ClusterName
@@ -290,7 +290,7 @@ schema:
           request_only_required_on_create: false
         - map:
             element_type: 4
-          description: 'Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have ''.'' characters.'
+          description: 'Optional for type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have ''.'' characters.'
           custom_type:
             package: customtypes
             model: customtypes.MapValue[types.String]
@@ -329,7 +329,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: 'Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.'
+          description: 'Optional for type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.'
           custom_type:
             package: customtypes
             name: DbRoleToExecute
@@ -357,7 +357,7 @@ schema:
           request_only_required_on_create: false
         - map:
             element_type: 4
-          description: 'Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.'
+          description: 'Optional for type: Https. A map of key-value pairs that will be passed as headers for the request.'
           custom_type:
             package: customtypes
             model: customtypes.MapValue[types.String]
@@ -447,7 +447,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: 'Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.'
+          description: 'Optional for type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.'
           custom_type:
             package: customtypes
             name: Networking
@@ -594,7 +594,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: 'Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.'
+          description: 'Optional for type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.'
           custom_type:
             package: customtypes
             name: Security
@@ -643,7 +643,7 @@ schema:
           present_in_any_response: true
           request_only_required_on_create: false
         - string: {}
-          description: 'Applies to type: Https. The URL to be used for the request.'
+          description: 'Optional for type: Https. The URL to be used for the request.'
           computed_optional_required: optional
           tf_schema_name: url
           tf_model_name: Url

--- a/tools/codegen/models/stream_instance_api.yaml
+++ b/tools/codegen/models/stream_instance_api.yaml
@@ -204,7 +204,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.
+                      description: 'Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsAuthentication
@@ -244,7 +244,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: AWS configurations for AWS-based connection types.
+                      description: 'Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsAws
@@ -260,7 +260,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: Comma separated list of server addresses.
+                      description: 'Applies to type: Kafka. Comma separated list of server addresses.'
                       computed_optional_required: computed
                       tf_schema_name: bootstrap_servers
                       tf_model_name: BootstrapServers
@@ -271,7 +271,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.
+                      description: 'Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.'
                       computed_optional_required: computed
                       tf_schema_name: cluster_group_id
                       tf_model_name: ClusterGroupId
@@ -282,7 +282,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: Name of the cluster configured for this connection.
+                      description: 'Applies to type: Cluster. Name of the cluster configured for this connection.'
                       computed_optional_required: computed
                       tf_schema_name: cluster_name
                       tf_model_name: ClusterName
@@ -294,7 +294,7 @@ schema:
                       request_only_required_on_create: false
                     - map:
                         element_type: 4
-                      description: A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.
+                      description: 'Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have ''.'' characters.'
                       custom_type:
                         package: customtypes
                         model: customtypes.MapValue[types.String]
@@ -333,7 +333,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: The name of a Built in or Custom DB Role to connect to an Atlas Cluster.
+                      description: 'Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsDbRoleToExecute
@@ -350,7 +350,7 @@ schema:
                       request_only_required_on_create: false
                     - map:
                         element_type: 4
-                      description: A map of key-value pairs that will be passed as headers for the request.
+                      description: 'Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.'
                       custom_type:
                         package: customtypes
                         model: customtypes.MapValue[types.String]
@@ -440,7 +440,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: Networking configuration for Streams connections.
+                      description: 'Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsNetworking
@@ -456,7 +456,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: The Schema Registry provider.
+                      description: 'Required for type: SchemaRegistry. The Schema Registry provider.'
                       computed_optional_required: computed
                       tf_schema_name: provider
                       tf_model_name: Provider
@@ -500,7 +500,7 @@ schema:
                                 skip_validation: true
                             attributes:
                                 - string: {}
-                                  description: Password or Private Key for authentication.
+                                  description: 'Required for type: USER_INFO. Password or Private Key for authentication.'
                                   computed_optional_required: computed
                                   tf_schema_name: password
                                   tf_model_name: Password
@@ -522,7 +522,7 @@ schema:
                                   present_in_any_response: true
                                   request_only_required_on_create: false
                                 - string: {}
-                                  description: Username or Public Key for authentication.
+                                  description: 'Required for type: USER_INFO. Username or Public Key for authentication.'
                                   computed_optional_required: computed
                                   tf_schema_name: username
                                   tf_model_name: Username
@@ -532,7 +532,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: Authentication configuration for Schema Registry.
+                      description: 'Required for type: SchemaRegistry. Authentication configuration for Schema Registry.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsSchemaRegistryAuthentication
@@ -549,7 +549,7 @@ schema:
                       request_only_required_on_create: false
                     - set:
                         element_type: 4
-                      description: List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.
+                      description: 'Required for type: SchemaRegistry. List of Schema Registry endpoint URLs used by this connection. Each URL must use the http or https scheme and specify a valid host and optional port.'
                       custom_type:
                         package: customtypes
                         model: customtypes.SetValue[types.String]
@@ -588,7 +588,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.
+                      description: 'Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsSecurity
@@ -626,7 +626,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: The URL to be used for the request.
+                      description: 'Applies to type: Https. The URL to be used for the request.'
                       computed_optional_required: computed
                       tf_schema_name: url
                       tf_model_name: Url

--- a/tools/codegen/models/stream_instance_api.yaml
+++ b/tools/codegen/models/stream_instance_api.yaml
@@ -204,7 +204,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: 'Applies to type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.'
+                      description: 'Optional for type: Kafka. User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsAuthentication
@@ -244,7 +244,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: 'Applies to type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.'
+                      description: 'Optional for type: AWSKinesisDataStreams, AWSLambda, S3. AWS configurations for AWS-based connection types.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsAws
@@ -260,7 +260,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: 'Applies to type: Kafka. Comma separated list of server addresses.'
+                      description: 'Optional for type: Kafka. Comma separated list of server addresses.'
                       computed_optional_required: computed
                       tf_schema_name: bootstrap_servers
                       tf_model_name: BootstrapServers
@@ -271,7 +271,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: 'Applies to type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.'
+                      description: 'Optional for type: Cluster. Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.'
                       computed_optional_required: computed
                       tf_schema_name: cluster_group_id
                       tf_model_name: ClusterGroupId
@@ -282,7 +282,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: 'Applies to type: Cluster. Name of the cluster configured for this connection.'
+                      description: 'Optional for type: Cluster. Name of the cluster configured for this connection.'
                       computed_optional_required: computed
                       tf_schema_name: cluster_name
                       tf_model_name: ClusterName
@@ -294,7 +294,7 @@ schema:
                       request_only_required_on_create: false
                     - map:
                         element_type: 4
-                      description: 'Applies to type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have ''.'' characters.'
+                      description: 'Optional for type: Kafka. A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have ''.'' characters.'
                       custom_type:
                         package: customtypes
                         model: customtypes.MapValue[types.String]
@@ -333,7 +333,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: 'Applies to type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.'
+                      description: 'Optional for type: Cluster. The name of a Built in or Custom DB Role to connect to an Atlas Cluster.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsDbRoleToExecute
@@ -350,7 +350,7 @@ schema:
                       request_only_required_on_create: false
                     - map:
                         element_type: 4
-                      description: 'Applies to type: Https. A map of key-value pairs that will be passed as headers for the request.'
+                      description: 'Optional for type: Https. A map of key-value pairs that will be passed as headers for the request.'
                       custom_type:
                         package: customtypes
                         model: customtypes.MapValue[types.String]
@@ -440,7 +440,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: 'Applies to type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.'
+                      description: 'Optional for type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsNetworking
@@ -588,7 +588,7 @@ schema:
                                   create_only: false
                                   present_in_any_response: true
                                   request_only_required_on_create: false
-                      description: 'Applies to type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.'
+                      description: 'Optional for type: Kafka. Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.'
                       custom_type:
                         package: customtypes
                         name: ConnectionsSecurity
@@ -626,7 +626,7 @@ schema:
                       present_in_any_response: true
                       request_only_required_on_create: false
                     - string: {}
-                      description: 'Applies to type: Https. The URL to be used for the request.'
+                      description: 'Optional for type: Https. The URL to be used for the request.'
                       computed_optional_required: computed
                       tf_schema_name: url
                       tf_model_name: Url


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-386371

Polymorphic resources (e.g. `log_integration`) have attributes whose relevance depends on a discriminator value (like `type`). Until now, docs and schema-aware tools (IDE autocompletion, LSP hovers) had no structured way to communicate which attributes belong to which variant.

This PR adds description enhancement during code generation: attribute descriptions are prefixed with structured labels like `Required for type: DATADOG.`, `Optional for type: AWS.` or `Applies to type: S3, GCS.` (data sources). This embeds discriminator context directly into the schema, so any tool that reads Terraform schema descriptions (IDEs, `terraform providers schema`) surfaces this information to users without extra effort.

The description prefixes use a concise format optimized for IDE tooltip readability. Resource and data source doc changes reflect the updated descriptions; proper per-type doc organization is handled in a [follow-up PR](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4262)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.