### PR TITLE
fix: Fixes `max_tier_size` of `mongodbatlas_stream_workspace` being dropped on read causing inconsistent result after apply 

### DIFF
--- a/.changelog/4277.txt
+++ b/.changelog/4277.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_stream_workspace: Fixes `max_tier_size` being dropped on read-back causing inconsistent result after apply
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -417,7 +417,7 @@ jobs:
             - 'internal/service/streaminstance/*.go'
             - 'internal/service/streamprocessor/*.go'
             - 'internal/service/streamprivatelinkendpoint/*.go'
-            - 'internal/service/streamworkspace/*.go' 
+            - 'internal/service/streamworkspace/*.go'
 
 
   advanced_cluster:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -416,7 +416,8 @@ jobs:
             - 'internal/service/streamconnection/*.go'
             - 'internal/service/streaminstance/*.go'
             - 'internal/service/streamprocessor/*.go'
-            - 'internal/service/streamprivatelinkendpoint/*.go' 
+            - 'internal/service/streamprivatelinkendpoint/*.go'
+            - 'internal/service/streamworkspace/*.go' 
 
 
   advanced_cluster:
@@ -1406,6 +1407,7 @@ jobs:
               ./internal/service/streaminstance
               ./internal/service/streamprocessor
               ./internal/service/streamprivatelinkendpoint
+              ./internal/service/streamworkspace
           run: make testacc
 
   slack-notification-stream:

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -74,6 +74,7 @@ func (m *TFModel) FromInstanceModel(instanceModel *streaminstance.TFStreamInstan
 	} else {
 		instanceStreamConfigAttrs := instanceModel.StreamConfig.Attributes()
 		tierValue := instanceStreamConfigAttrs["tier"]
+		maxTierSizeValue := instanceStreamConfigAttrs["max_tier_size"]
 
 		workspaceStreamConfig, _ := types.ObjectValue(
 			map[string]attr.Type{
@@ -81,7 +82,7 @@ func (m *TFModel) FromInstanceModel(instanceModel *streaminstance.TFStreamInstan
 				"tier":          types.StringType,
 			},
 			map[string]attr.Value{
-				"max_tier_size": types.StringNull(),
+				"max_tier_size": maxTierSizeValue,
 				"tier":          tierValue,
 			},
 		)

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -74,7 +74,6 @@ func (m *TFModel) FromInstanceModel(instanceModel *streaminstance.TFStreamInstan
 	} else {
 		instanceStreamConfigAttrs := instanceModel.StreamConfig.Attributes()
 		tierValue := instanceStreamConfigAttrs["tier"]
-		maxTierSizeValue := instanceStreamConfigAttrs["max_tier_size"]
 
 		workspaceStreamConfig, _ := types.ObjectValue(
 			map[string]attr.Type{
@@ -82,7 +81,7 @@ func (m *TFModel) FromInstanceModel(instanceModel *streaminstance.TFStreamInstan
 				"tier":          types.StringType,
 			},
 			map[string]attr.Value{
-				"max_tier_size": maxTierSizeValue,
+				"max_tier_size": types.StringNull(),
 				"tier":          tierValue,
 			},
 		)

--- a/internal/service/streamworkspace/resource_schema.go
+++ b/internal/service/streamworkspace/resource_schema.go
@@ -49,9 +49,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"max_tier_size": schema.StringAttribute{
 						Optional: true,
 						Computed: true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"tier": schema.StringAttribute{
 						Optional: true,

--- a/internal/service/streamworkspace/resource_test.go
+++ b/internal/service/streamworkspace/resource_test.go
@@ -102,35 +102,6 @@ func checkStreamsWorkspaceImportStateIDFunc(resourceName string) resource.Import
 	}
 }
 
-func TestAccStreamWorkspaceRS_maxTierSize(t *testing.T) {
-	var (
-		resourceName  = "mongodbatlas_stream_workspace.test"
-		projectID     = acc.ProjectIDExecution(t)
-		workspaceName = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyStreamInstance,
-		Steps: []resource.TestStep{
-			{
-				Config: streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cloudProvider, "SP10", "SP30"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					streamsWorkspaceAttributeChecks(resourceName, workspaceName, region, cloudProvider),
-					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP10"),
-					resource.TestCheckResourceAttr(resourceName, "stream_config.max_tier_size", "SP30"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: checkStreamsWorkspaceImportStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider string) string {
 	return streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cloudProvider, "SP10", "SP30")
 }

--- a/internal/service/streamworkspace/resource_test.go
+++ b/internal/service/streamworkspace/resource_test.go
@@ -102,7 +102,40 @@ func checkStreamsWorkspaceImportStateIDFunc(resourceName string) resource.Import
 	}
 }
 
+func TestAccStreamWorkspaceRS_maxTierSize(t *testing.T) {
+	var (
+		resourceName  = "mongodbatlas_stream_workspace.test"
+		projectID     = acc.ProjectIDExecution(t)
+		workspaceName = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyStreamInstance,
+		Steps: []resource.TestStep{
+			{
+				Config: streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cloudProvider, "SP10", "SP30"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					streamsWorkspaceAttributeChecks(resourceName, workspaceName, region, cloudProvider),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP10"),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.max_tier_size", "SP30"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: checkStreamsWorkspaceImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider string) string {
+	return streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cloudProvider, "SP10", "SP30")
+}
+
+func streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cloudProvider, tier, maxTierSize string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_stream_workspace" "test" {
 			project_id = %[1]q
@@ -112,9 +145,9 @@ func streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider stri
 				cloud_provider = %[4]q
 			}
 			stream_config = {
-				max_tier_size = "SP30"
-				tier = "SP10"
+				tier = %[5]q
+				max_tier_size = %[6]q
 			}
 		}
-	`, projectID, workspaceName, region, cloudProvider)
+	`, projectID, workspaceName, region, cloudProvider, tier, maxTierSize)
 }

--- a/internal/service/streamworkspace/resource_test.go
+++ b/internal/service/streamworkspace/resource_test.go
@@ -39,29 +39,6 @@ func TestAccStreamWorkspaceRS_basic(t *testing.T) {
 	})
 }
 
-func TestAccStreamWorkspaceRS_withStreamConfig(t *testing.T) {
-	var (
-		resourceName  = "mongodbatlas_stream_workspace.test"
-		projectID     = acc.ProjectIDExecution(t)
-		workspaceName = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyStreamInstance, // Reuse the same destroy check
-		Steps: []resource.TestStep{
-			{
-				Config: streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					streamsWorkspaceAttributeChecks(resourceName, workspaceName, region, cloudProvider),
-					resource.TestCheckResourceAttr(resourceName, "stream_config.max_tier_size", "SP30"),
-					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP10"),
-				),
-			},
-		},
-	})
-}
-
 func streamsWorkspaceAttributeChecks(resourceName, workspaceName, region, cloudProvider string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
 		checkStreamsWorkspaceExists(resourceName),


### PR DESCRIPTION
## Description

`FromInstanceModel()` hardcoded `max_tier_size` to null instead of reading it from the instance model attributes, causing "Provider produced inconsistent result after apply" when `stream_config.max_tier_size` was set. This was not caught earlier because `streamworkspace` tests were not being run in the CI

Fixed by reading `max_tier_size` from the instance model the same way tier already was. Also added `streamworkspace` to the stream CI partition (change-detection filter and ACCTEST_PACKAGES) so these tests run going forward.

Link to any related issue(s): CLOUDP-387913 fixes https://github.com/mongodb/terraform-provider-mongodbatlas/issues/4272

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
