### PR TITLE
fix: Fix `alert_configuration` when adding new notification blocks

### DIFF
--- a/.changelog/4278.txt
+++ b/.changelog/4278.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_alert_configuration: Fixes inconsistent result after apply when adding a new notification without defining `email_enabled` or `sms_enabled`
+```

--- a/.changelog/4278.txt
+++ b/.changelog/4278.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_alert_configuration: Fixes inconsistent result after apply when adding a new notification without defining `email_enabled` or `sms_enabled`
+resource/mongodbatlas_alert_configuration: Fixes error when updating notifications, thresholds, or metric thresholds without specifying all optional attributes
 ```

--- a/internal/service/alertconfiguration/resource.go
+++ b/internal/service/alertconfiguration/resource.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -196,9 +194,6 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"threshold": schema.Float64Attribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Float64{
-								float64planmodifier.UseStateForUnknown(),
-							},
 						},
 						"units": schema.StringAttribute{
 							Optional: true,
@@ -221,9 +216,6 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"threshold": schema.Float64Attribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Float64{
-								float64planmodifier.UseStateForUnknown(),
-							},
 						},
 						"units": schema.StringAttribute{
 							Optional: true,
@@ -273,9 +265,6 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"delay_min": schema.Int64Attribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.UseStateForUnknown(),
-							},
 						},
 						"email_address": schema.StringAttribute{
 							Optional: true,
@@ -283,9 +272,6 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"email_enabled": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Bool{
-								boolplanmodifier.UseStateForUnknown(),
-							},
 						},
 						"interval_min": schema.Int64Attribute{
 							Optional: true,
@@ -314,18 +300,12 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"sms_enabled": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Bool{
-								boolplanmodifier.UseStateForUnknown(),
-							},
 						},
 						"team_id": schema.StringAttribute{
 							Optional: true,
 						},
 						"team_name": schema.StringAttribute{
 							Computed: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
 						},
 						"notifier_id": schema.StringAttribute{
 							Computed: true,

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -1538,8 +1538,6 @@ func configAddNotification(projectID string, twoNotifications bool) string {
 		secondNotification = `
 			notification {
 				type_name     = "EMAIL"
-				interval_min  = 120
-				delay_min     = 0
 				email_address = "ops-team@example.com"
 			}`
 	}
@@ -1551,8 +1549,6 @@ func configAddNotification(projectID string, twoNotifications bool) string {
 
 			notification {
 				type_name     = "EMAIL"
-				interval_min  = 120
-				delay_min     = 0
 				email_address = "test@mongodb.com"
 			}
 

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -290,6 +290,42 @@ func TestAccConfigRSAlertConfiguration_withoutRoles(t *testing.T) {
 	})
 }
 
+func TestAccConfigRSAlertConfiguration_addNotification(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+	)
+	step1Checks := []resource.TestCheckFunc{
+		checkExists(resourceName),
+		resource.TestCheckResourceAttr(resourceName, "notification.0.type_name", "EMAIL"),
+		resource.TestCheckResourceAttr(resourceName, "notification.0.email_address", "test@mongodb.com"),
+		resource.TestCheckResourceAttr(resourceName, "notification.0.email_enabled", "false"),
+		resource.TestCheckResourceAttr(resourceName, "notification.0.sms_enabled", "false"),
+	}
+	step2Checks := step1Checks
+	step2Checks = append(step2Checks,
+		resource.TestCheckResourceAttr(resourceName, "notification.1.type_name", "EMAIL"),
+		resource.TestCheckResourceAttr(resourceName, "notification.1.email_address", "ops-team@example.com"),
+		resource.TestCheckResourceAttr(resourceName, "notification.1.email_enabled", "false"),
+		resource.TestCheckResourceAttr(resourceName, "notification.1.sms_enabled", "false"),
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: configAddNotification(projectID, false),
+				Check:  resource.ComposeAggregateTestCheckFunc(step1Checks...),
+			},
+			{
+				Config: configAddNotification(projectID, true),
+				Check:  resource.ComposeAggregateTestCheckFunc(step2Checks...),
+			},
+		},
+	})
+}
+
 func TestAccConfigRSAlertConfiguration_withoutOptionalAttributes(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
@@ -1496,4 +1532,39 @@ func checkCount(resourceName string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func configAddNotification(projectID string, twoNotifications bool) string {
+	secondNotification := ""
+	if twoNotifications {
+		secondNotification = `
+			notification {
+				type_name     = "EMAIL"
+				interval_min  = 120
+				delay_min     = 0
+				email_address = "ops-team@example.com"
+			}`
+	}
+	return fmt.Sprintf(`
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = %[1]q
+			event_type = "CPS_SNAPSHOT_BEHIND"
+			enabled    = true
+
+			notification {
+				type_name     = "EMAIL"
+				interval_min  = 120
+				delay_min     = 0
+				email_address = "test@mongodb.com"
+			}
+
+			threshold_config {
+				operator  = "GREATER_THAN"
+				threshold = 48
+				units     = "HOURS"
+			}
+
+			%[2]s
+		}
+	`, projectID, secondNotification)
 }

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -291,9 +291,7 @@ func TestAccConfigRSAlertConfiguration_withoutRoles(t *testing.T) {
 }
 
 func TestAccConfigRSAlertConfiguration_addNotification(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-	)
+	projectID := acc.ProjectIDExecution(t)
 	step1Checks := []resource.TestCheckFunc{
 		checkExists(resourceName),
 		resource.TestCheckResourceAttr(resourceName, "notification.0.type_name", "EMAIL"),


### PR DESCRIPTION
## Description

Fix `alert_configuration` when adding new blocks. Although the problem found was with `email_enabled` and `sms_enabled`, also removing from the other nested attributes as it could also produce the same error.

UseStateForUnknown has been removed from:
- metric_threshold_config.threshold
- threshold_config.threshold
- notification.delay_min
- notification.email_enabled
- notification.sms_enabled
- notification.team_name


Link to any related issue(s): CLOUDP-387108

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
