### PR TITLE
test: Add TestAccAdvancedCluster_useAwsTimeBasedSnapshotCopy_nonAWSError

### DIFF
--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -3009,6 +3009,24 @@ func TestAccAdvancedCluster_useAwsTimeBasedSnapshotCopy(t *testing.T) {
 	})
 }
 
+func TestAccAdvancedCluster_useAwsTimeBasedSnapshotCopy_nonAWSError(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 0)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config:      configUseAwsTimeBasedSnapshotCopy(projectID, clusterName, true, "GCP", "US_EAST_4"),
+				ExpectError: regexp.MustCompile("AWS_TIME_BASED_SNAPSHOT_COPY_REQUIRES_AWS_NODES"),
+			},
+		},
+	})
+}
+
 func configUseAwsTimeBasedSnapshotCopy(projectID, name string, value bool, providerName, regionName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {


### PR DESCRIPTION
## Description

Add `TestAccAdvancedCluster_useAwsTimeBasedSnapshotCopy_nonAWSError` to verify `use_aws_time_based_snapshot_copy_for_fast_initial_sync` can only be used in clusters with some AWS nodes.

Link to any related issue(s): CLOUDP-382141

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
