### PR TITLE
fix: Excludes `windows/arm` from GoReleaser build matrix after Go 1.26 upgrade

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 archives:


### PR DESCRIPTION
## Description

Go 1.26 [removed the `windows/arm` (32-bit ARM) port](https://github.com/golang/go/issues/71671) and mentioned in the [Gp 1.26 release notes](https://go.dev/doc/go1.26#windows), causing the release workflow to fail with:

```
build failed: exit status 2: go: unsupported GOOS/GOARCH pair windows/arm
```

This PR adds `windows/arm` to the `ignore` list in `.goreleaser.yml`. The port had been non-functional since Go 1.18 and was officially dropped in Go 1.26. The 64-bit `windows/arm64` port is unaffected.

Link to any related issue(s): - 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
