### PR TITLE
Cloud backup schedule Admin fields

### DIFF
--- a/docs/data-sources/cloud_backup_schedule.md
+++ b/docs/data-sources/cloud_backup_schedule.md
@@ -91,6 +91,7 @@ In addition to all arguments above, the following attributes are exported:
   * true - Enables automatic export of cloud backup snapshots to the Export Bucket.
   * false - Disables automatic export of cloud backup snapshots to the Export Bucket. (default)
 * `use_org_and_group_names_in_export_prefix` - Specify true to use organization and project names instead of organization and project UUIDs in the path for the metadata files that Atlas uploads to your bucket after it finishes exporting the snapshots. To learn more about the metadata files that Atlas uploads, see [Export Cloud Backup Snapshot](https://www.mongodb.com/docs/atlas/backup/cloud-backup/export/#std-label-cloud-provider-snapshot-export).
+* `copy_policy_items_enabled` - Flag that indicates whether copy settings use `copy_policy_items` instead of `frequencies`.
 * `copy_settings` - List that contains a document for each copy setting item in the desired backup policy. See [below](#copy_settings)
 * `export` - Policy for automatically exporting Cloud Backup Snapshots. See [below](#export)
 
@@ -138,11 +139,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### copy_settings
 * `cloud_provider` - Human-readable label that identifies the cloud provider that stores the snapshot copy. i.e. "AWS" "AZURE" "GCP"
-* `frequencies` - List that describes which types of snapshots to copy. i.e. "HOURLY" "DAILY" "WEEKLY" "MONTHLY" "YEARLY" "ON_DEMAND"
+* `frequencies` - List that describes which types of snapshots to copy. Returned when `copy_policy_items_enabled` is false or omitted. i.e. "HOURLY" "DAILY" "WEEKLY" "MONTHLY" "YEARLY" "ON_DEMAND"
+* `copy_policy_items` - List that contains a document for each copy policy item. Returned when `copy_policy_items_enabled` is true. See [below](#copy_policy_items)
+* `last_number_of_snapshots` - Number of most recent snapshots to copy to the target region.
 * `region_name` - Target region to copy snapshots belonging to replicationSpecId to. Please supply the 'Atlas Region' which can be found under https://www.mongodb.com/docs/atlas/reference/cloud-providers/ 'regions' link
 * `zone_id` - Unique 24-hexadecimal digit string that identifies the zone in a cluster. For global clusters, there can be multiple zones to choose from. For sharded clusters and replica set clusters, there is only one zone in the cluster.
 * `should_copy_oplogs` - Flag that indicates whether to copy the oplogs to the target region. You can use the oplogs to perform point-in-time restores.
 
-**Note** The parameter deleteCopiedBackups is not supported in terraform please leverage Atlas Admin API or AtlasCLI instead to manage the lifecycle of backup snaphot copies.
+### copy_policy_items
+* `id` - Unique identifier of the copy policy item.
+* `frequency_type` - Human-readable label that identifies the frequency type associated with the copy policy. Possible values are: `hourly`, `daily`, `weekly`, `monthly`, `yearly`, `ondemand`.
+* `retention_unit` - Unit of time in which MongoDB Cloud measures snapshot copy retention. Possible values are: `days`, `weeks`, `months`, `years`.
+* `retention_value` - Duration in days, weeks, months, or years that MongoDB Cloud retains the snapshot copy.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/schedule/get-all-schedules/).

--- a/docs/resources/cloud_backup_schedule.md
+++ b/docs/resources/cloud_backup_schedule.md
@@ -232,6 +232,12 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
   
   **Note** This parameter does not return updates on return from API, this is a feature of the MongoDB Atlas Admin API itself and not Terraform.  For more details about this resource see [Cloud Backup Schedule](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Cloud-Backups/operation/getBackupSchedule).
 
+* `update_copy_snapshots` - (Optional) Flag that indicates whether to apply the retention changes for updated copy policy items to Snapshot copies that MongoDB Cloud took previously. This is a request-level flag and does not persist in the schedule configuration.
+
+* `delete_copy_snapshots` - (Optional) Flag that indicates whether to delete Snapshot copies that MongoDB Cloud took previously when their associated `copy_policy_items` are removed from a `copy_settings` entry. This option requires `copy_policy_items_enabled` to be true. This is a request-level flag and does not persist in the schedule configuration.
+
+* `copy_policy_items_enabled` - (Optional) Flag that indicates whether copy settings use `copy_policy_items` instead of `frequencies`. When true, you must use `copy_policy_items` in copy_settings. When false or omitted, you must use `frequencies` in copy_settings.
+
 * `policy_item_hourly` - (Optional) Hourly policy item. See [below](#policy_item_hourly)
 * `policy_item_daily` - (Optional) Daily policy item. See [below](#policy_item_daily)
 * `policy_item_weekly` - (Optional) Weekly policy item. See [below](#policy_item_weekly)
@@ -287,10 +293,17 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 
 ### copy_settings
 * `cloud_provider` - (Required) Human-readable label that identifies the cloud provider that stores the snapshot copy. i.e. "AWS" "AZURE" "GCP"
-* `frequencies` - (Required) List that describes which types of snapshots to copy. i.e. "HOURLY" "DAILY" "WEEKLY" "MONTHLY" "ON_DEMAND"
+* `frequencies` - (Optional) List that describes which types of snapshots to copy. i.e. "HOURLY" "DAILY" "WEEKLY" "MONTHLY" "ON_DEMAND". **Note:** Use this field when `copy_policy_items_enabled` is false or omitted. This field is mutually exclusive with `copy_policy_items` and `last_number_of_snapshots`.
+* `copy_policy_items` - (Optional) List that contains a document for each copy policy item. Allowed only when `copy_policy_items_enabled` is true. This field is mutually exclusive with `frequencies` and `last_number_of_snapshots`. See [below](#copy_policy_items)
+* `last_number_of_snapshots` - (Optional) Number of most recent snapshots to copy to the target region (1-500). If specified, Atlas copies this number of the most recent snapshots rather than using a frequency-based or policy-based copy schedule. This field is mutually exclusive with `frequencies` and `copy_policy_items`.
 * `region_name` - (Required) Target region to copy snapshots belonging to replicationSpecId to. Please supply the 'Atlas Region' which can be found under https://www.mongodb.com/docs/atlas/reference/cloud-providers/ 'regions' link
 * `zone_id` - Unique 24-hexadecimal digit string that identifies the zone in a cluster. For global clusters, there can be multiple zones to choose from. For sharded clusters and replica set clusters, there is only one zone in the cluster. To find appropriate value for `zone_id`, do a GET request to Return One Cluster from One Project and consult the replicationSpecs array [Return One Cluster From One Project](#operation/getCluster). Alternately, use `mongodbatlas_advanced_cluster` data source or resource and reference `replication_specs.#.zone_id`.
 * `should_copy_oplogs` - (Required) Flag that indicates whether to copy the oplogs to the target region. You can use the oplogs to perform point-in-time restores.
+
+### copy_policy_items
+* `frequency_type` - (Required) Human-readable label that identifies the frequency type associated with the copy policy. Possible values are: `hourly`, `daily`, `weekly`, `monthly`, `yearly`, `ondemand`.
+* `retention_unit` - (Optional) Unit of time in which MongoDB Cloud measures snapshot copy retention. Required for time-based policy items (not required for `ondemand`). Possible values are: `days`, `weeks`, `months`, `years`.
+* `retention_value` - (Optional) Duration in days, weeks, months, or years that MongoDB Cloud retains the snapshot copy. Required for time-based policy items (not required for `ondemand`).
 
 ## Attributes Reference
 

--- a/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
@@ -28,6 +28,10 @@ func DataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"copy_policy_items_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"copy_settings": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -43,6 +47,34 @@ func DataSource() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+						},
+						"copy_policy_items": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"frequency_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"retention_unit": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"retention_value": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"last_number_of_snapshots": {
+							Type:     schema.TypeInt,
+							Computed: true,
 						},
 						"region_name": {
 							Type:     schema.TypeString,
@@ -270,6 +302,10 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if err := d.Set("copy_settings", copySettings); err != nil {
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "copy_settings", clusterName, err)
+	}
+
+	if err := d.Set("copy_policy_items_enabled", backupSchedule.GetCopyPolicyItemsEnabled()); err != nil {
+		return diag.Errorf(errorSnapshotBackupScheduleSetting, "copy_policy_items_enabled", clusterName, err)
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{

--- a/internal/service/cloudbackupschedule/model_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/model_cloud_backup_schedule.go
@@ -35,13 +35,72 @@ func FlattenExport(roles *admin.DiskBackupSnapshotSchedule20240805) []map[string
 func FlattenCopySettings(copySettingList []admin.DiskBackupCopySetting20240805) []map[string]any {
 	copySettings := make([]map[string]any, 0)
 	for _, v := range copySettingList {
-		copySettings = append(copySettings, map[string]any{
+		setting := map[string]any{
 			"cloud_provider":     v.GetCloudProvider(),
 			"frequencies":        v.GetFrequencies(),
 			"region_name":        v.GetRegionName(),
 			"zone_id":            v.GetZoneId(),
 			"should_copy_oplogs": v.GetShouldCopyOplogs(),
-		})
+		}
+		if copyPolicyItems, ok := v.GetCopyPolicyItemsOk(); ok && copyPolicyItems != nil {
+			setting["copy_policy_items"] = FlattenCopyPolicyItems(*copyPolicyItems)
+		}
+		if lastNumberOfSnapshots, ok := v.GetLastNumberOfSnapshotsOk(); ok && lastNumberOfSnapshots != nil {
+			setting["last_number_of_snapshots"] = *lastNumberOfSnapshots
+		}
+		copySettings = append(copySettings, setting)
 	}
 	return copySettings
+}
+
+func FlattenCopyPolicyItems(items []admin.DiskBackupCopyPolicyItem) []map[string]any {
+	policyItems := make([]map[string]any, 0)
+	for _, item := range items {
+		policyItem := map[string]any{
+			"frequency_type": item.GetFrequencyType(),
+		}
+		if id, ok := item.GetIdOk(); ok && id != nil {
+			policyItem["id"] = *id
+		}
+		if retentionUnit, ok := item.GetRetentionUnitOk(); ok && retentionUnit != nil {
+			policyItem["retention_unit"] = *retentionUnit
+		}
+		if retentionValue, ok := item.GetRetentionValueOk(); ok && retentionValue != nil {
+			policyItem["retention_value"] = *retentionValue
+		}
+		policyItems = append(policyItems, policyItem)
+	}
+	return policyItems
+}
+
+func ExpandCopyPolicyItems(tfList []any) *[]admin.DiskBackupCopyPolicyItem {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	policyItems := make([]admin.DiskBackupCopyPolicyItem, 0, len(tfList))
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		policyItem := admin.DiskBackupCopyPolicyItem{
+			FrequencyType: tfMap["frequency_type"].(string),
+		}
+
+		if retentionUnit, ok := tfMap["retention_unit"]; ok && retentionUnit.(string) != "" {
+			ru := retentionUnit.(string)
+			policyItem.RetentionUnit = &ru
+		}
+
+		if retentionValue, ok := tfMap["retention_value"]; ok && retentionValue.(int) > 0 {
+			rv := retentionValue.(int)
+			policyItem.RetentionValue = &rv
+		}
+
+		policyItems = append(policyItems, policyItem)
+	}
+
+	return &policyItems
 }

--- a/internal/service/cloudbackupschedule/model_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/model_cloud_backup_schedule_test.go
@@ -116,6 +116,58 @@ func TestFlattenCopySettings(t *testing.T) {
 			},
 		},
 		{
+			name: "Copy Settings with CopyPolicyItems",
+			settings: []admin.DiskBackupCopySetting20240805{
+				{
+					CloudProvider:    conversion.StringPtr("AWS"),
+					Frequencies:      &[]string{},
+					RegionName:       conversion.StringPtr("US_WEST_1"),
+					ZoneId:           "12345",
+					ShouldCopyOplogs: new(true),
+					CopyPolicyItems: &[]admin.DiskBackupCopyPolicyItem{
+						{FrequencyType: "daily", RetentionUnit: conversion.StringPtr("days"), RetentionValue: conversion.IntPtr(7)},
+						{FrequencyType: "weekly", RetentionUnit: conversion.StringPtr("weeks"), RetentionValue: conversion.IntPtr(4)},
+					},
+				},
+			},
+			expected: []map[string]any{
+				{
+					"cloud_provider":     "AWS",
+					"frequencies":        []string{},
+					"region_name":        "US_WEST_1",
+					"zone_id":            "12345",
+					"should_copy_oplogs": true,
+					"copy_policy_items": []map[string]any{
+						{"frequency_type": "daily", "retention_unit": "days", "retention_value": 7},
+						{"frequency_type": "weekly", "retention_unit": "weeks", "retention_value": 4},
+					},
+				},
+			},
+		},
+		{
+			name: "Copy Settings with LastNumberOfSnapshots",
+			settings: []admin.DiskBackupCopySetting20240805{
+				{
+					CloudProvider:         conversion.StringPtr("GCP"),
+					Frequencies:           &[]string{},
+					RegionName:            conversion.StringPtr("CENTRAL_US"),
+					ZoneId:                "99999",
+					ShouldCopyOplogs:      new(false),
+					LastNumberOfSnapshots: conversion.IntPtr(100),
+				},
+			},
+			expected: []map[string]any{
+				{
+					"cloud_provider":           "GCP",
+					"frequencies":              []string{},
+					"region_name":              "CENTRAL_US",
+					"zone_id":                  "99999",
+					"should_copy_oplogs":       false,
+					"last_number_of_snapshots": 100,
+				},
+			},
+		},
+		{
 			name:     "Empty Copy Settings List",
 			settings: []admin.DiskBackupCopySetting20240805{},
 			expected: []map[string]any{},
@@ -132,12 +184,55 @@ func TestFlattenCopySettings(t *testing.T) {
 	}
 }
 
+func TestFlattenCopyPolicyItems(t *testing.T) {
+	testCases := []struct {
+		name     string
+		items    []admin.DiskBackupCopyPolicyItem
+		expected []map[string]any
+	}{
+		{
+			name: "Time-based policy items",
+			items: []admin.DiskBackupCopyPolicyItem{
+				{Id: conversion.StringPtr("123"), FrequencyType: "daily", RetentionUnit: conversion.StringPtr("days"), RetentionValue: conversion.IntPtr(7)},
+				{Id: conversion.StringPtr("456"), FrequencyType: "weekly", RetentionUnit: conversion.StringPtr("weeks"), RetentionValue: conversion.IntPtr(4)},
+			},
+			expected: []map[string]any{
+				{"id": "123", "frequency_type": "daily", "retention_unit": "days", "retention_value": 7},
+				{"id": "456", "frequency_type": "weekly", "retention_unit": "weeks", "retention_value": 4},
+			},
+		},
+		{
+			name: "On-demand policy item",
+			items: []admin.DiskBackupCopyPolicyItem{
+				{FrequencyType: "ondemand"},
+			},
+			expected: []map[string]any{
+				{"frequency_type": "ondemand"},
+			},
+		},
+		{
+			name:     "Empty items list",
+			items:    []admin.DiskBackupCopyPolicyItem{},
+			expected: []map[string]any{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cloudbackupschedule.FlattenCopyPolicyItems(tc.items)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Test %s failed: expected %+v, got %+v", tc.name, tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestExpandPolicyItems(t *testing.T) {
 	testCases := []struct {
-		expected      *[]admin.DiskBackupApiPolicyItem
+		items         []any
 		name          string
 		frequencyType string
-		items         []any
+		expected      *[]admin.DiskBackupApiPolicyItem
 	}{
 		{
 			name: "Valid Input",
@@ -158,6 +253,55 @@ func TestExpandPolicyItems(t *testing.T) {
 			result := cloudbackupschedule.ExpandPolicyItems(tc.items, tc.frequencyType)
 			if !reflect.DeepEqual(result, tc.expected) {
 				t.Errorf("Test %s failed: expected %+v, got %+v", tc.name, *tc.expected, *result)
+			}
+		})
+	}
+}
+
+func TestExpandCopyPolicyItems(t *testing.T) {
+	testCases := []struct {
+		items    []any
+		name     string
+		expected *[]admin.DiskBackupCopyPolicyItem
+	}{
+		{
+			name: "Time-based policy items",
+			items: []any{
+				map[string]any{"frequency_type": "daily", "retention_unit": "days", "retention_value": 7},
+				map[string]any{"frequency_type": "weekly", "retention_unit": "weeks", "retention_value": 4},
+			},
+			expected: &[]admin.DiskBackupCopyPolicyItem{
+				{FrequencyType: "daily", RetentionUnit: conversion.StringPtr("days"), RetentionValue: conversion.IntPtr(7)},
+				{FrequencyType: "weekly", RetentionUnit: conversion.StringPtr("weeks"), RetentionValue: conversion.IntPtr(4)},
+			},
+		},
+		{
+			name: "On-demand policy item",
+			items: []any{
+				map[string]any{"frequency_type": "ondemand"},
+			},
+			expected: &[]admin.DiskBackupCopyPolicyItem{
+				{FrequencyType: "ondemand"},
+			},
+		},
+		{
+			name:     "Empty items list",
+			items:    []any{},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cloudbackupschedule.ExpandCopyPolicyItems(tc.items)
+			if tc.expected == nil {
+				if result != nil {
+					t.Errorf("Test %s failed: expected nil, got %+v", tc.name, result)
+				}
+			} else {
+				if !reflect.DeepEqual(result, tc.expected) {
+					t.Errorf("Test %s failed: expected %+v, got %+v", tc.name, *tc.expected, *result)
+				}
 			}
 		})
 	}

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -39,6 +39,7 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},
+		CustomizeDiff: validateCopySettingsMutualExclusivity,
 
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -63,6 +64,21 @@ func Resource() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"copy_policy_items_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"update_copy_snapshots": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"delete_copy_snapshots": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"copy_settings": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -79,6 +95,43 @@ func Resource() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
+							},
+						},
+						"copy_policy_items": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"frequency_type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"retention_unit": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"retention_value": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"last_number_of_snapshots": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: func(val any, key string) (warns []string, errs []error) {
+								v := val.(int)
+								if v < 1 || v > 500 {
+									errs = append(errs, fmt.Errorf("%q value should be between 1 and 500, got: %d", key, v))
+								}
+								return
 							},
 						},
 						"region_name": {
@@ -395,6 +448,10 @@ func setSchemaFields(d *schema.ResourceData, backupSchedule *admin.DiskBackupSna
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "use_org_and_group_names_in_export_prefix", clusterName, err)
 	}
 
+	if err := d.Set("copy_policy_items_enabled", backupSchedule.GetCopyPolicyItemsEnabled()); err != nil {
+		return diag.Errorf(errorSnapshotBackupScheduleSetting, "copy_policy_items_enabled", clusterName, err)
+	}
+
 	if err := d.Set("policy_item_hourly", FlattenPolicyItem(backupSchedule.GetPolicies()[0].GetPolicyItems(), Hourly)); err != nil {
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_hourly", clusterName, err)
 	}
@@ -540,6 +597,20 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 		req.UpdateSnapshots = value
 	}
 
+	if d.HasChange("copy_policy_items_enabled") {
+		req.CopyPolicyItemsEnabled = new(d.Get("copy_policy_items_enabled").(bool))
+	}
+
+	updateCopySnapshots := new(d.Get("update_copy_snapshots").(bool))
+	if *updateCopySnapshots {
+		req.UpdateCopySnapshots = updateCopySnapshots
+	}
+
+	deleteCopySnapshots := new(d.Get("delete_copy_snapshots").(bool))
+	if *deleteCopySnapshots {
+		req.DeleteCopySnapshots = deleteCopySnapshots
+	}
+
 	resp, _, err := connV2.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		return fmt.Errorf("error getting MongoDB Cloud Backup Schedule (%s): %s", clusterName, err)
@@ -563,14 +634,27 @@ func ExpandCopySetting(tfMap map[string]any) *admin.DiskBackupCopySetting2024080
 		return nil
 	}
 
-	frequencies := conversion.ExpandStringList(tfMap["frequencies"].(*schema.Set).List())
 	copySetting := &admin.DiskBackupCopySetting20240805{
 		CloudProvider:    new(tfMap["cloud_provider"].(string)),
-		Frequencies:      &frequencies,
 		RegionName:       new(tfMap["region_name"].(string)),
 		ZoneId:           tfMap["zone_id"].(string),
 		ShouldCopyOplogs: new(tfMap["should_copy_oplogs"].(bool)),
 	}
+
+	if frequencies, ok := tfMap["frequencies"]; ok && frequencies.(*schema.Set).Len() > 0 {
+		freqs := conversion.ExpandStringList(frequencies.(*schema.Set).List())
+		copySetting.Frequencies = &freqs
+	}
+
+	if copyPolicyItems, ok := tfMap["copy_policy_items"]; ok && len(copyPolicyItems.([]any)) > 0 {
+		items := ExpandCopyPolicyItems(copyPolicyItems.([]any))
+		copySetting.CopyPolicyItems = items
+	}
+
+	if lastNumberOfSnapshots, ok := tfMap["last_number_of_snapshots"]; ok && lastNumberOfSnapshots.(int) > 0 {
+		copySetting.LastNumberOfSnapshots = new(lastNumberOfSnapshots.(int))
+	}
+
 	return copySetting
 }
 
@@ -641,5 +725,57 @@ func getRequestPolicies(policiesItem []admin.DiskBackupApiPolicyItem, respPolici
 		}
 		return &[]admin.AdvancedDiskBackupSnapshotSchedulePolicy{policy}
 	}
+	return nil
+}
+
+func validateCopySettingsMutualExclusivity(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+	copySettings, ok := d.GetOk("copy_settings")
+	if !ok {
+		return nil
+	}
+
+	for i, settingRaw := range copySettings.([]any) {
+		setting, ok := settingRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		hasFrequencies := false
+		if frequencies, ok := setting["frequencies"]; ok {
+			if freqSet, ok := frequencies.(*schema.Set); ok && freqSet.Len() > 0 {
+				hasFrequencies = true
+			}
+		}
+
+		hasCopyPolicyItems := false
+		if copyPolicyItems, ok := setting["copy_policy_items"]; ok {
+			if items, ok := copyPolicyItems.([]any); ok && len(items) > 0 {
+				hasCopyPolicyItems = true
+			}
+		}
+
+		hasLastNumberOfSnapshots := false
+		if lastNumberOfSnapshots, ok := setting["last_number_of_snapshots"]; ok {
+			if num, ok := lastNumberOfSnapshots.(int); ok && num > 0 {
+				hasLastNumberOfSnapshots = true
+			}
+		}
+
+		fieldsSet := 0
+		if hasFrequencies {
+			fieldsSet++
+		}
+		if hasCopyPolicyItems {
+			fieldsSet++
+		}
+		if hasLastNumberOfSnapshots {
+			fieldsSet++
+		}
+
+		if fieldsSet > 1 {
+			return fmt.Errorf("copy_settings[%d]: frequencies, copy_policy_items, and last_number_of_snapshots are mutually exclusive - only one may be specified", i)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR implements the missing Admin API fields for the `mongodbatlas_cloud_backup_schedule` resource and data source. Previously, the resource only exposed a subset of available fields, limiting configuration options for advanced backup schedules.

This change introduces:
- **Copy-policy items**: `copy_policy_items_enabled` (bool) and the `copy_policy_items` block within `copy_settings` for time-based and on-demand policies.
- **Count-based copies**: `last_number_of_snapshots` (int, 1-500) within `copy_settings`.
- **Copy-snapshot lifecycle flags**: `update_copy_snapshots` (bool) and `delete_copy_snapshots` (bool) at the resource level.

These additions allow full configuration of copy-policy items, count-based copies, and copy-snapshot lifecycle behavior directly through the Terraform provider, aligning it with the Atlas Admin API capabilities.

Link to any related issue(s): CLOUDP-388562

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

- Implemented mutual exclusivity validation for `frequencies`, `copy_policy_items`, and `last_number_of_snapshots` within `copy_settings`.
- The field `delete_copied_backups` mentioned in the ticket was corrected to `delete_copy_snapshots` based on the actual Atlas Admin API structure.
- `update_copy_snapshots` and `delete_copy_snapshots` are operational flags and do not persist in the Terraform state.

<div><a href="https://cursor.com/agents/bc-f7daf38b-afc8-498b-b111-625ad924e020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7daf38b-afc8-498b-b111-625ad924e020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->