### PR TITLE
doc: Update `oplog_min_retention_hours` doc

### DIFF
--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -277,7 +277,7 @@ Key-value pairs that categorize the cluster. Each key and value has a maximum le
   - TLS1_3
 * `no_table_scan` - When true, the cluster disables the execution of any query that requires a collection scan to return results. When false, the cluster allows the execution of those operations.
 * `oplog_size_mb` - The custom oplog size of the cluster. Without a value that indicates that the cluster uses the default oplog size calculated by Atlas.
-* `oplog_min_retention_hours` - Minimum retention window for cluster's oplog expressed in hours. A value of null indicates that the cluster uses the default minimum oplog window that MongoDB Cloud calculates.
+* `oplog_min_retention_hours` - Minimum retention window for cluster's oplog expressed in hours.
 * `sample_size_bi_connector` - Number of documents per database to sample when gathering schema information. Defaults to 100. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 * `sample_refresh_interval_bi_connector` - Interval in seconds at which the mongosqld process re-samples data to create its relational schema. The default value is 300. The specified value must be a positive integer. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 * `transaction_lifetime_limit_seconds` - Lifetime, in seconds, of multi-document transactions. Defaults to 60 seconds.

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -313,7 +313,7 @@ Key-value pairs that categorize the cluster. Each key and value has a maximum le
   - TLS1_3
 * `no_table_scan` - When true, the cluster disables the execution of any query that requires a collection scan to return results. When false, the cluster allows the execution of those operations.
 * `oplog_size_mb` - The custom oplog size of the cluster. Without a value that indicates that the cluster uses the default oplog size calculated by Atlas.
-* `oplog_min_retention_hours` - Minimum retention window for cluster's oplog expressed in hours. A value of null indicates that the cluster uses the default minimum oplog window that MongoDB Cloud calculates.
+* `oplog_min_retention_hours` - Minimum retention window for cluster's oplog expressed in hours.
 * `sample_size_bi_connector` - Number of documents per database to sample when gathering schema information. Defaults to 100. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 * `sample_refresh_interval_bi_connector` - Interval in seconds at which the mongosqld process re-samples data to create its relational schema. The default value is 300. The specified value must be a positive integer. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 * `default_max_time_ms` - Default time limit in milliseconds for individual read operations to complete. This option corresponds to the [defaultMaxTimeMS](https://www.mongodb.com/docs/upcoming/reference/cluster-parameters/defaultMaxTimeMS/) cluster parameter. This parameter is supported only for MongoDB version 8.0 and above.

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -607,15 +607,7 @@ bi_connector_config = {
 
 -> **NOTE:** Prior to setting these options, read [Configure Additional Settings](https://docs.atlas.mongodb.com/cluster-config/additional-options/).
 
--> **NOTE:** To reset an attribute to its original value after you
-explicitly change its value, you must set it back to the desired value
-instead of removing it from your configuration. For example, if you
-previously set `javascript_enabled` to `false` and later you want to go
-back to the default value (`true`), you must set it back to `true`
-instead of removing it. For `oplog_min_retention_hours` specifically,
-once set to a non-null value, removing the attribute or setting it to
-`null` retains the last applied value rather than reverting to the
-Atlas-computed default.
+-> **NOTE:** To reset an attribute to its original value after you explicitly change its value, you must set it back to the desired value instead of removing it from your configuration. For example, if you previously set `javascript_enabled` to `false` and later you want to go back to the default value (`true`), you must set it back to `true` instead of removing it. Similarly, if you set `oplog_min_retention_hours` to a non-null value, removing the attribute or setting it to `null` retains the last applied value rather than reverting to the default value.
 
 Include **desired options** within advanced_configuration:
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -608,11 +608,14 @@ bi_connector_config = {
 -> **NOTE:** Prior to setting these options, read [Configure Additional Settings](https://docs.atlas.mongodb.com/cluster-config/additional-options/).
 
 -> **NOTE:** To reset an attribute to its original value after you
-explicitly change its value, you must explicitly set the attribute back
-to its original value. For example, if you previously set
-`javascript_enabled` to `false` and want to return to the default value
-(`true`), you must explicitly it back to `true` (not just delete the
-attribute from the configuration).
+explicitly change its value, you must set it back to the desired value
+instead of removing it from your configuration. For example, if you
+previously set `javascript_enabled` to `false` and later you want to go
+back to the default value (`true`), you must set it back to `true`
+instead of removing it. This is particularly important for
+`oplog_min_retention_hours`, where removing the attribute or setting it
+to `null` retains the last applied value rather than reverting to the
+Atlas-computed default.
 
 Include **desired options** within advanced_configuration:
 
@@ -631,7 +634,7 @@ Include **desired options** within advanced_configuration:
   - TLS1_3
 * `no_table_scan` - (Optional) When true, the cluster disables the execution of any query that requires a collection scan to return results. When false, the cluster allows the execution of those operations.
 * `oplog_size_mb` - (Optional) The custom oplog size of the cluster. Without a value that indicates that the cluster uses the default oplog size calculated by Atlas.
-* `oplog_min_retention_hours` - (Optional) Minimum retention window for cluster's oplog expressed in hours. A value of null indicates that the cluster uses the default minimum oplog window that MongoDB Cloud calculates.
+* `oplog_min_retention_hours` - (Optional) Minimum retention window for cluster's oplog expressed in hours. Once this attribute has been set to a non-null value, removing it from your configuration or setting it to `null` will retain the last applied value rather than reverting to the Atlas-computed default.
   -> **NOTE:**  A minimum oplog retention is required when seeking to change a cluster's class to Local NVMe SSD. To learn more and for latest guidance see [`oplogMinRetentionHours`](https://www.mongodb.com/docs/manual/core/replica-set-oplog/#std-label-replica-set-minimum-oplog-size) 
 * `sample_size_bi_connector` - (Optional) Number of documents per database to sample when gathering schema information. Defaults to 100. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 * `sample_refresh_interval_bi_connector` - (Optional) Interval in seconds at which the mongosqld process re-samples data to create its relational schema. The default value is 300. The specified value must be a positive integer. Available only for Atlas deployments in which BI Connector for Atlas is enabled.

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -612,9 +612,9 @@ explicitly change its value, you must set it back to the desired value
 instead of removing it from your configuration. For example, if you
 previously set `javascript_enabled` to `false` and later you want to go
 back to the default value (`true`), you must set it back to `true`
-instead of removing it. This is particularly important for
-`oplog_min_retention_hours`, where removing the attribute or setting it
-to `null` retains the last applied value rather than reverting to the
+instead of removing it. For `oplog_min_retention_hours` specifically,
+once set to a non-null value, removing the attribute or setting it to
+`null` retains the last applied value rather than reverting to the
 Atlas-computed default.
 
 Include **desired options** within advanced_configuration:
@@ -634,7 +634,7 @@ Include **desired options** within advanced_configuration:
   - TLS1_3
 * `no_table_scan` - (Optional) When true, the cluster disables the execution of any query that requires a collection scan to return results. When false, the cluster allows the execution of those operations.
 * `oplog_size_mb` - (Optional) The custom oplog size of the cluster. Without a value that indicates that the cluster uses the default oplog size calculated by Atlas.
-* `oplog_min_retention_hours` - (Optional) Minimum retention window for cluster's oplog expressed in hours. Once this attribute has been set to a non-null value, removing it from your configuration or setting it to `null` will retain the last applied value rather than reverting to the Atlas-computed default.
+* `oplog_min_retention_hours` - (Optional) Minimum retention window for cluster's oplog expressed in hours. Once this attribute has been set to a non-null value, removing it from your configuration or setting it to `null` will retain the last applied value rather than reverting to the default value.
   -> **NOTE:**  A minimum oplog retention is required when seeking to change a cluster's class to Local NVMe SSD. To learn more and for latest guidance see [`oplogMinRetentionHours`](https://www.mongodb.com/docs/manual/core/replica-set-oplog/#std-label-replica-set-minimum-oplog-size) 
 * `sample_size_bi_connector` - (Optional) Number of documents per database to sample when gathering schema information. Defaults to 100. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 * `sample_refresh_interval_bi_connector` - (Optional) Interval in seconds at which the mongosqld process re-samples data to create its relational schema. The default value is 300. The specified value must be a positive integer. Available only for Atlas deployments in which BI Connector for Atlas is enabled.

--- a/internal/service/advancedcluster/schema.go
+++ b/internal/service/advancedcluster/schema.go
@@ -618,7 +618,7 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 			"oplog_min_retention_hours": schema.Float64Attribute{
 				Computed:            true,
 				Optional:            true,
-				MarkdownDescription: "Minimum retention window for cluster's oplog expressed in hours. Once this attribute has been set to a non-null value, removing it from your configuration or setting it to `null` will retain the last applied value rather than reverting to the Atlas-computed default.",
+				MarkdownDescription: "Minimum retention window for cluster's oplog expressed in hours. Once this attribute has been set to a non-null value, removing it from your configuration or setting it to `null` will retain the last applied value rather than reverting to the default value.",
 			},
 			"oplog_size_mb": schema.Int64Attribute{
 				Optional: true,

--- a/internal/service/advancedcluster/schema.go
+++ b/internal/service/advancedcluster/schema.go
@@ -618,7 +618,7 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 			"oplog_min_retention_hours": schema.Float64Attribute{
 				Computed:            true,
 				Optional:            true,
-				MarkdownDescription: "Minimum retention window for cluster's oplog expressed in hours. A value of null indicates that the cluster uses the default minimum oplog window that MongoDB Cloud calculates.",
+				MarkdownDescription: "Minimum retention window for cluster's oplog expressed in hours. Once this attribute has been set to a non-null value, removing it from your configuration or setting it to `null` will retain the last applied value rather than reverting to the Atlas-computed default.",
 			},
 			"oplog_size_mb": schema.Int64Attribute{
 				Optional: true,


### PR DESCRIPTION
## Description

Update documentation to reflect `oplog_min_retention_hours` field behaviour when setting to null.

Link to any related issue(s): CLOUDP-387414

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
