### PR TITLE
fix: Fix service account access list entry docs to use the correct import ID

### DIFF
--- a/.changelog/4289.txt
+++ b/.changelog/4289.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_service_account_access_list_entry: Fixes documentation to use the correct import ID separator (`/`)
+```

--- a/.changelog/4289.txt
+++ b/.changelog/4289.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/mongodbatlas_service_account_access_list_entry: Fixes documentation to use the correct import ID separator (`/`)
-```

--- a/docs/resources/project_service_account_access_list_entry.md
+++ b/docs/resources/project_service_account_access_list_entry.md
@@ -83,11 +83,9 @@ output "all_access_list_entries" {
 - `request_count` (Number) The number of requests that has originated from this network address.
 
 ## Import
-
-Access List entries for Project Service Accounts can be imported using the `project_id`, `client_id` and `cidr_block` or `ip_address`, e.g.
-
+Import the Project Service Account Access List Entry resource by using the Project ID, Client ID, and CIDR block or IP address in the format `PROJECT_ID/CLIENT_ID/CIDR_BLOCK` or `PROJECT_ID/CLIENT_ID/IP_ADDRESS`, e.g.
 ```
-$ terraform import mongodbatlas_project_service_account_access_list_entry.test 5d0f1f74cf09a29120e123cd-mdb_sa_id_1234567890abcdef12345678-10.242.88.0/21
+$ terraform import mongodbatlas_project_service_account_access_list_entry.test 6117ac2fe2a3d04ed27a987v/mdb_sa_id_1234567890abcdef12345678/10.242.88.0/21
 ```
 
 For more information, see [Add Access List Entries for One Project Service Account](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupserviceaccountaccesslist) in the MongoDB Atlas API documentation.

--- a/docs/resources/service_account_access_list_entry.md
+++ b/docs/resources/service_account_access_list_entry.md
@@ -83,11 +83,9 @@ output "all_access_list_entries" {
 - `request_count` (Number) The number of requests that has originated from this network address.
 
 ## Import
-
-Access List entries for Service Accounts can be imported using the `org_id`, `client_id` and `cidr_block` or `ip_address`, e.g.
-
+Import the Service Account Access List Entry resource by using the Organization ID, Client ID, and CIDR block or IP address in the format `ORG_ID/CLIENT_ID/CIDR_BLOCK` or `ORG_ID/CLIENT_ID/IP_ADDRESS`, e.g.
 ```
-$ terraform import mongodbatlas_service_account_access_list_entry.test 5d0f1f74cf09a29120e123cd-mdb_sa_id_1234567890abcdef12345678-10.242.88.0/21
+$ terraform import mongodbatlas_service_account_access_list_entry.test 5d0f1f74cf09a29120e123cd/mdb_sa_id_1234567890abcdef12345678/10.242.88.0/21
 ```
 
 For more information, see [Add Access List Entries for One Organization Service Account](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createorgserviceaccountaccesslist) in the MongoDB Atlas API documentation.

--- a/templates/resources/project_service_account_access_list_entry.md.tmpl
+++ b/templates/resources/project_service_account_access_list_entry.md.tmpl
@@ -17,11 +17,9 @@ subcategory: "Service Accounts"
 {{ .SchemaMarkdown | trimspace }}
 
 ## Import
-
-Access List entries for Project Service Accounts can be imported using the `project_id`, `client_id` and `cidr_block` or `ip_address`, e.g.
-
+Import the Project Service Account Access List Entry resource by using the Project ID, Client ID, and CIDR block or IP address in the format `PROJECT_ID/CLIENT_ID/CIDR_BLOCK` or `PROJECT_ID/CLIENT_ID/IP_ADDRESS`, e.g.
 ```
-$ terraform import {{.Name}}.test 5d0f1f74cf09a29120e123cd-mdb_sa_id_1234567890abcdef12345678-10.242.88.0/21
+$ terraform import {{.Name}}.test 6117ac2fe2a3d04ed27a987v/mdb_sa_id_1234567890abcdef12345678/10.242.88.0/21
 ```
 
 For more information, see [Add Access List Entries for One Project Service Account](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupserviceaccountaccesslist) in the MongoDB Atlas API documentation.

--- a/templates/resources/service_account_access_list_entry.md.tmpl
+++ b/templates/resources/service_account_access_list_entry.md.tmpl
@@ -17,11 +17,9 @@ subcategory: "Service Accounts"
 {{ .SchemaMarkdown | trimspace }}
 
 ## Import
-
-Access List entries for Service Accounts can be imported using the `org_id`, `client_id` and `cidr_block` or `ip_address`, e.g.
-
+Import the Service Account Access List Entry resource by using the Organization ID, Client ID, and CIDR block or IP address in the format `ORG_ID/CLIENT_ID/CIDR_BLOCK` or `ORG_ID/CLIENT_ID/IP_ADDRESS`, e.g.
 ```
-$ terraform import {{.Name}}.test 5d0f1f74cf09a29120e123cd-mdb_sa_id_1234567890abcdef12345678-10.242.88.0/21
+$ terraform import {{.Name}}.test 5d0f1f74cf09a29120e123cd/mdb_sa_id_1234567890abcdef12345678/10.242.88.0/21
 ```
 
 For more information, see [Add Access List Entries for One Organization Service Account](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createorgserviceaccountaccesslist) in the MongoDB Atlas API documentation.


### PR DESCRIPTION
## Description

Fixing the `service_account_access_list_entry` and `project_service_account_access_list_entry` docs to use the correct import ID separator (`/`)

Link to any related issue(s): CLOUDP-388694

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
