### PR TITLE
fix: Fixes `autoExportEnabled` being omitted from PATCH requests and `auto_export_enabled`/`export` not synced to state from API response

### DIFF
--- a/.changelog/4291.txt
+++ b/.changelog/4291.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_cloud_backup_schedule: Fixes `autoExportEnabled` being omitted from PATCH requests and `auto_export_enabled`/`export` not synced to state from API response
+```

--- a/.changelog/4291.txt
+++ b/.changelog/4291.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_cloud_backup_schedule: Fixes `autoExportEnabled` being omitted from PATCH requests and `auto_export_enabled`/`export` not synced to state from API response
+resource/mongodbatlas_cloud_backup_schedule: Fixes `autoExportEnabled` being omitted from PATCH requests and `auto_export_enabled`/`export` not synchronized to state from API response
 ```

--- a/.changelog/4291.txt
+++ b/.changelog/4291.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_cloud_backup_schedule: Fixes `autoExportEnabled` being omitted from PATCH requests and `auto_export_enabled`/`export` not synchronized to state from API response
+resource/mongodbatlas_cloud_backup_schedule: Fixes `autoExportEnabled` being omitted from PATCH requests and `auto_export_enabled`/`export` not synchronized to state from the API response. This can lead to a plan updating the actual infrastructure to your current configuration
 ```

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -395,6 +395,14 @@ func setSchemaFields(d *schema.ResourceData, backupSchedule *admin.DiskBackupSna
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "use_org_and_group_names_in_export_prefix", clusterName, err)
 	}
 
+	if err := d.Set("auto_export_enabled", backupSchedule.GetAutoExportEnabled()); err != nil {
+		return diag.Errorf(errorSnapshotBackupScheduleSetting, "auto_export_enabled", clusterName, err)
+	}
+
+	if err := d.Set("export", FlattenExport(backupSchedule)); err != nil {
+		return diag.Errorf(errorSnapshotBackupScheduleSetting, "export", clusterName, err)
+	}
+
 	if err := d.Set("policy_item_hourly", FlattenPolicyItem(backupSchedule.GetPolicies()[0].GetPolicyItems(), Hourly)); err != nil {
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_hourly", clusterName, err)
 	}
@@ -513,8 +521,8 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 		policiesItem = append(policiesItem, *ExpandPolicyItems(v.([]any), Yearly)...)
 	}
 
-	if d.HasChange("auto_export_enabled") {
-		req.AutoExportEnabled = new(d.Get("auto_export_enabled").(bool))
+	if v, ok := d.GetOkExists("auto_export_enabled"); ok {
+		req.AutoExportEnabled = new(v.(bool))
 	}
 
 	if v, ok := d.GetOk("export"); ok {

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -205,7 +205,7 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 				Config: configWithoutExport,
 				Check:  checksNoExport,
 			},
-			// Go from export disabled to export enabled to test the PATCH behavior
+			// rejected PATCH must not pollute state; empty plan confirms setSchemaFields syncs auto_export_enabled+export from API
 			{
 				Config:      configWithExportInvalid,
 				ExpectError: regexp.MustCompile(".* policy item retention cannot be less than restore window"),

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -3,6 +3,8 @@ package cloudbackupschedule_test
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 
 	"go.mongodb.org/atlas-sdk/v20250312014/admin"
@@ -153,13 +155,18 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 	var (
 		// A snapshot export bucket can't be deleted it there exist a cluster that is still using it. So the cluster resource needs to depend on it
-		clusterInfo         = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
-		policyName          = acc.RandomName()
-		roleName            = acc.RandomIAMRole()
-		bucketName          = acc.RandomBucketName()
-		configWithExport    = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, true, true)
-		configWithoutExport = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, false, false)
-		checksWithExport    = resource.ComposeAggregateTestCheckFunc(
+		clusterInfo             = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
+		policyName              = acc.RandomName()
+		roleName                = acc.RandomIAMRole()
+		bucketName              = acc.RandomBucketName()
+		configWithExport        = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, true, true)
+		configWithoutExport     = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, false, false)
+		configWithExportInvalid = strings.ReplaceAll(
+			configWithExport,
+			"restore_window_days      = 4",
+			"restore_window_days      = 99", // cannot be longer than default retention period 7 days
+		)
+		checksWithExport = resource.ComposeAggregateTestCheckFunc(
 			checkExists(resourceName),
 			resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.Name),
 			resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "true"),
@@ -196,13 +203,10 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 			},
 			// Go from export disabled to export enabled to test the PATCH behavior
 			{
-				Config: configWithExport,
-				Check:  checksWithExport,
+				Config:      configWithExportInvalid,
+				ExpectError: regexp.MustCompile(".* policy item retention cannot be less than restore window"),
 			},
-			{
-				Config: configWithoutExport,
-				Check:  checksNoExport,
-			},
+			acc.TestStepCheckEmptyPlan(configWithoutExport),
 		},
 	})
 }

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -164,7 +164,7 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 		configWithExportInvalid = strings.ReplaceAll(
 			configWithExport,
 			"restore_window_days      = 4",
-			"restore_window_days      = 99", // cannot be longer than default retention period 7 days
+			"restore_window_days      = 999", // cannot be longer than default retention period 7 days
 		)
 		checksWithExport = resource.ComposeAggregateTestCheckFunc(
 			checkExists(resourceName),
@@ -186,6 +186,7 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceName, "export.#", "0"),
 		)
 	)
+	fmt.Println(configWithExportInvalid)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, &clusterInfo, "", ""),

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -153,10 +153,31 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 	var (
 		// A snapshot export bucket can't be deleted it there exist a cluster that is still using it. So the cluster resource needs to depend on it
-		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
-		policyName  = acc.RandomName()
-		roleName    = acc.RandomIAMRole()
-		bucketName  = acc.RandomBucketName()
+		clusterInfo         = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
+		policyName          = acc.RandomName()
+		roleName            = acc.RandomIAMRole()
+		bucketName          = acc.RandomBucketName()
+		configWithExport    = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, true, true)
+		configWithoutExport = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, false, false)
+		checksWithExport    = resource.ComposeAggregateTestCheckFunc(
+			checkExists(resourceName),
+			resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.Name),
+			resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "true"),
+			resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "20"),
+			resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "5"),
+			resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
+			resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
+			resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
+			resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
+			resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "4"),
+			resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+		)
+		checksNoExport = resource.ComposeAggregateTestCheckFunc(
+			checkExists(resourceName),
+			resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.Name),
+			resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceName, "export.#", "0"),
+		)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -166,28 +187,21 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: configExportPolicies(&clusterInfo, policyName, roleName, bucketName, true, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.Name),
-					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "20"),
-					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "5"),
-					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "4"),
-				),
+				Config: configWithExport,
+				Check:  checksWithExport,
 			},
 			{
-				Config: configExportPolicies(&clusterInfo, policyName, roleName, bucketName, false, false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.Name),
-					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "export.#", "0"),
-				),
+				Config: configWithoutExport,
+				Check:  checksNoExport,
+			},
+			// Go from export disabled to export enabled to test the PATCH behavior
+			{
+				Config: configWithExport,
+				Check:  checksWithExport,
+			},
+			{
+				Config: configWithoutExport,
+				Check:  checksNoExport,
 			},
 		},
 	})

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -155,16 +155,17 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 	var (
 		// A snapshot export bucket can't be deleted it there exist a cluster that is still using it. So the cluster resource needs to depend on it
-		clusterInfo             = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
-		policyName              = acc.RandomName()
-		roleName                = acc.RandomIAMRole()
-		bucketName              = acc.RandomBucketName()
-		configWithExport        = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, true, true)
-		configWithoutExport     = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, false, false)
-		configWithExportInvalid = strings.ReplaceAll(
+		clusterInfo              = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, PitEnabled: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
+		policyName               = acc.RandomName()
+		roleName                 = acc.RandomIAMRole()
+		bucketName               = acc.RandomBucketName()
+		configWithExport         = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, true, true)
+		configWithoutExport      = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, false, false)
+		invalidRestoreWindowDays = "restore_window_days      = 99" // cannot be longer than the configured retention period of 4 days
+		configWithExportInvalid  = strings.ReplaceAll(
 			configWithExport,
 			"restore_window_days      = 4",
-			"restore_window_days      = 999", // cannot be longer than default retention period 7 days
+			invalidRestoreWindowDays,
 		)
 		checksWithExport = resource.ComposeAggregateTestCheckFunc(
 			checkExists(resourceName),
@@ -186,8 +187,10 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceName, "export.#", "0"),
 		)
 	)
-	fmt.Println(configWithExportInvalid)
-
+	// Sanity check in case formatting changes below
+	if !strings.Contains(configWithExport, invalidRestoreWindowDays) {
+		t.Fatalf("configWithExport does not contain invalidRestoreWindowDays: %s\n%s", invalidRestoreWindowDays, configWithExport)
+	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, &clusterInfo, "", ""),
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -188,8 +188,8 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 		)
 	)
 	// Sanity check in case formatting changes below
-	if !strings.Contains(configWithExport, invalidRestoreWindowDays) {
-		t.Fatalf("configWithExport does not contain invalidRestoreWindowDays: %s\n%s", invalidRestoreWindowDays, configWithExport)
+	if !strings.Contains(configWithExportInvalid, invalidRestoreWindowDays) {
+		t.Fatalf("configWithExportInvalid does not contain invalidRestoreWindowDays: %s\n%s", invalidRestoreWindowDays, configWithExportInvalid)
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, &clusterInfo, "", ""),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes a bug in the `mongodbatlas_cloud_backup_schedule` resource where the `autoExportEnabled` field was omitted from PATCH requests (discovered during internal testing). This omission caused the Atlas Admin API to return an `INVALID_BACKUP_POLICY` error when `export` settings were configured and `auto_export_enabled` was set to `true`.

The fix ensures that `autoExportEnabled` is always included in the PATCH request body when it is configured in the Terraform resource. Additionally, it updates the `setSchemaFields` function to correctly read `auto_export_enabled` and `export` from the API response, ensuring proper state synchronization.

Link to any related issue(s): [CLOUDP-388915](https://jira.mongodb.org/browse/CLOUDP-388915)

Passing test in [QA](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/23286023536/job/67709614829)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

### Non-empty plan fix (test discovery)

Before this fix, `setSchemaFields` did not write `auto_export_enabled` or `export` back to state from the API response. This caused state drift when a PATCH was rejected by the API -- the state would reflect the config values rather than the actual API state.

The updated `TestAccBackupRSCloudBackupSchedule_export` test exposes this with two new steps:

- **Step 3**: Applies a config with `auto_export_enabled=true` and an `export` block but with an invalid `restore_window_days=99`. The API rejects the PATCH, but without the `setSchemaFields` fix, the state would still be updated with config values (`auto_export_enabled=true`).
- **Step 4**: Re-applies the Step 2 config (export disabled) and asserts an empty plan. Before the fix, this failed because state had `auto_export_enabled=true` (from Step 3's config) while the API had `false` (the PATCH was never accepted):

```
Pre-apply plan check(s) failed:
expected empty plan, but mongodbatlas_cloud_backup_schedule.schedule_test has planned action(s): [update]
```

The fix in `setSchemaFields` -- adding `d.Set("auto_export_enabled", ...)` and `d.Set("export", ...)` -- ensures state is always synced from the API response, not from stale config values.