### PR TITLE
chore: Auto-skip discriminator validation for computed-only properties and single-type mappings

### DIFF
--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -427,24 +427,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"provider_name": schema.StringAttribute{
 										Computed:            true,
 										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`.",
-										Validators: []validator.String{
-											customvalidator.ValidateDiscriminator(customvalidator.DiscriminatorDefinition{
-												Mapping: map[string]customvalidator.VariantDefinition{
-													"AWS": {
-														Allowed: []string{"analytics_auto_scaling", "analytics_specs", "auto_scaling", "effective_analytics_specs", "effective_electable_specs", "effective_read_only_specs", "read_only_specs"},
-													},
-													"AZURE": {
-														Allowed: []string{"analytics_auto_scaling", "analytics_specs", "auto_scaling", "effective_analytics_specs", "effective_electable_specs", "effective_read_only_specs", "read_only_specs"},
-													},
-													"GCP": {
-														Allowed: []string{"analytics_auto_scaling", "analytics_specs", "auto_scaling", "effective_analytics_specs", "effective_electable_specs", "effective_read_only_specs", "read_only_specs"},
-													},
-													"TENANT": {
-														Allowed: []string{"backing_provider_name"},
-													},
-												},
-											}),
-										},
 									},
 									"read_only_specs": schema.SingleNestedAttribute{
 										Computed:            true,

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -26,6 +26,7 @@ func ApplyTransformationsToResource(resourceConfig *config.Resource, resource *R
 	}
 	applyAliasToDiscriminator(resourceConfig.SchemaOptions.Aliases, resource.Schema.Discriminator, &resource.Schema.Attributes)
 	applyIgnoreValidatorsToDiscriminators(resource.Schema.Discriminator, resource.Schema.Attributes, resourceConfig.SchemaOptions)
+	skipValidationForComputedDiscriminators(resource.Schema.Discriminator, resource.Schema.Attributes)
 	applyAliasToPathParams(&resource.Operations, resourceConfig.SchemaOptions.Aliases)
 	ApplyDeleteOnCreateTimeoutTransformation(resource)
 	ApplyTimeoutTransformation(resource)
@@ -476,6 +477,27 @@ func applyIgnoreValidatorsToNestedDiscriminators(attributes Attributes, schemaOp
 		if nested := attr.NestedObject(); nested != nil {
 			applyIgnoreValidatorsToDiscriminator(nested.Discriminator, schemaOptions, schemaPath)
 			applyIgnoreValidatorsToNestedDiscriminators(nested.Attributes, schemaOptions, schemaPath)
+		}
+	}
+}
+
+func skipValidationForComputedDiscriminators(disc *Discriminator, attrs Attributes) {
+	skipValidationIfComputed(disc, attrs)
+	for i := range attrs {
+		if nested := attrs[i].NestedObject(); nested != nil {
+			skipValidationForComputedDiscriminators(nested.Discriminator, nested.Attributes)
+		}
+	}
+}
+
+func skipValidationIfComputed(disc *Discriminator, attrs Attributes) {
+	if disc == nil {
+		return
+	}
+	for i := range attrs {
+		if attrs[i].TFSchemaName == disc.PropertyName.TFSchemaName && attrs[i].ComputedOptionalRequired == Computed {
+			disc.SkipValidation = true
+			return
 		}
 	}
 }

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -594,7 +594,8 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 					SingleNested: &codespec.SingleNestedAttribute{
 						NestedObject: codespec.NestedAttributeObject{
 							Discriminator: &codespec.Discriminator{
-								PropertyName: codespec.DiscriminatorAttrName{APIName: "innerType", TFSchemaName: "inner_kind"},
+								PropertyName:   codespec.DiscriminatorAttrName{APIName: "innerType", TFSchemaName: "inner_kind"},
+								SkipValidation: true,
 								Mapping: map[string]codespec.DiscriminatorType{
 									"TypeA": {
 										Allowed:  []codespec.DiscriminatorAttrName{{APIName: "attrA", TFSchemaName: "attr_a"}, {APIName: "innerType", TFSchemaName: "inner_kind"}},
@@ -726,7 +727,8 @@ func TestApplyTransformationsToResource_AliasDiscriminatorTransformation(t *test
 						NestedObject: codespec.NestedAttributeObject{
 							Discriminator: &codespec.Discriminator{
 								// NOT renamed - non-dotted alias only applies at root level
-								PropertyName: codespec.NewDiscriminatorAttrName("typeField"),
+								PropertyName:   codespec.NewDiscriminatorAttrName("typeField"),
+								SkipValidation: true,
 								Mapping: map[string]codespec.DiscriminatorType{
 									"InnerA": {
 										Allowed:  []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("innerAttr"), codespec.NewDiscriminatorAttrName("typeField")},

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -899,6 +899,70 @@ func TestApplyTransformationsToResource_IgnoreValidatorsTransformation(t *testin
 	}
 }
 
+func TestApplyTransformationsToResource_ComputedDiscriminatorAutoSkip(t *testing.T) {
+	inputResource := &codespec.Resource{
+		Schema: &codespec.Schema{
+			Discriminator: &codespec.Discriminator{
+				PropertyName: codespec.DiscriminatorAttrName{APIName: "type", TFSchemaName: "type"},
+				Mapping: map[string]codespec.DiscriminatorType{
+					"A": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "attrA", TFSchemaName: "attr_a"}}},
+					"B": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "attrB", TFSchemaName: "attr_b"}}},
+				},
+			},
+			Attributes: codespec.Attributes{
+				{
+					TFSchemaName:             "type",
+					TFModelName:              "Type",
+					APIName:                  "type",
+					ComputedOptionalRequired: codespec.Computed,
+					String:                   &codespec.StringAttribute{},
+					ReqBodyUsage:             codespec.OmitAlways,
+				},
+				{
+					TFSchemaName:             "nested_obj",
+					TFModelName:              "NestedObj",
+					APIName:                  "nestedObj",
+					ComputedOptionalRequired: codespec.Computed,
+					SingleNested: &codespec.SingleNestedAttribute{
+						NestedObject: codespec.NestedAttributeObject{
+							Discriminator: &codespec.Discriminator{
+								PropertyName: codespec.DiscriminatorAttrName{APIName: "kind", TFSchemaName: "kind"},
+								Mapping: map[string]codespec.DiscriminatorType{
+									"X": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "xAttr", TFSchemaName: "x_attr"}}},
+									"Y": {Allowed: []codespec.DiscriminatorAttrName{{APIName: "yAttr", TFSchemaName: "y_attr"}}},
+								},
+							},
+							Attributes: codespec.Attributes{
+								{
+									TFSchemaName:             "kind",
+									TFModelName:              "Kind",
+									APIName:                  "kind",
+									ComputedOptionalRequired: codespec.Computed,
+									String:                   &codespec.StringAttribute{},
+									ReqBodyUsage:             codespec.OmitAlways,
+								},
+							},
+						},
+					},
+					ReqBodyUsage: codespec.OmitAlways,
+				},
+			},
+		},
+		Operations: codespec.APIOperations{
+			Create: &codespec.APIOperation{},
+			Read:   &codespec.APIOperation{},
+		},
+	}
+
+	err := codespec.ApplyTransformationsToResource(&config.Resource{}, inputResource)
+	require.NoError(t, err)
+
+	assert.True(t, inputResource.Schema.Discriminator.SkipValidation, "root computed discriminator should auto-skip")
+
+	nestedDisc := inputResource.Schema.Attributes[1].SingleNested.NestedObject.Discriminator
+	assert.True(t, nestedDisc.SkipValidation, "nested computed discriminator should auto-skip")
+}
+
 func TestApplyTransformationsToDataSources_AliasTransformation(t *testing.T) {
 	tests := map[string]struct {
 		inputDataSources   *codespec.DataSources

--- a/tools/codegen/codespec/discriminator.go
+++ b/tools/codegen/codespec/discriminator.go
@@ -71,7 +71,7 @@ func extractDiscriminator(schema *APISpecSchema) *Discriminator {
 		}
 	}
 
-	if AllVariantsEmpty(mapping) {
+	if ShouldSkipDiscriminator(mapping) {
 		return nil
 	}
 
@@ -175,7 +175,10 @@ func clearRequired(disc *Discriminator) *Discriminator {
 	return result
 }
 
-func AllVariantsEmpty(mapping map[string]DiscriminatorType) bool {
+func ShouldSkipDiscriminator(mapping map[string]DiscriminatorType) bool {
+	if len(mapping) <= 1 {
+		return true
+	}
 	for _, variant := range mapping {
 		if len(variant.Allowed) > 0 {
 			return false

--- a/tools/codegen/codespec/discriminator.go
+++ b/tools/codegen/codespec/discriminator.go
@@ -23,11 +23,12 @@ func NewDiscriminatorAttrName(apiName string) DiscriminatorAttrName {
 // excludes the discriminator property itself from variant mappings,
 // and filters readOnly properties from the required list (keeping them in allowed).
 //
-// Returns nil when all variant mappings have empty allowed lists. This happens when
-// polymorphism is at the value level (different enum values for a specific property
-// like `units`) rather than at the structural level (different properties per variant).
-// In such cases the discriminator acts as a pure enum constraint on the discriminator
-// property itself and carries no actionable per-variant metadata for Terraform.
+// Returns nil when the discriminator does not provide actionable per-variant metadata
+// for Terraform. This includes cases where all variant mappings have empty allowed
+// lists (polymorphism is at the value level, e.g. different enum values for a single
+// property like `units`, rather than structural differences), or when the mapping has
+// fewer than two variants (0 or 1 entry), so there is effectively no meaningful
+// polymorphism to capture.
 func extractDiscriminator(schema *APISpecSchema) *Discriminator {
 	if schema == nil {
 		return nil

--- a/tools/codegen/codespec/discriminator_test.go
+++ b/tools/codegen/codespec/discriminator_test.go
@@ -7,13 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAllVariantsEmpty_AllEmpty(t *testing.T) {
-	mapping := map[string]codespec.DiscriminatorType{
-		"METRIC_A": {Allowed: nil},
-		"METRIC_B": {Allowed: []codespec.DiscriminatorAttrName{}},
-		"METRIC_C": {},
+func TestShouldSkipDiscriminator(t *testing.T) {
+	tests := map[string]struct {
+		mapping  map[string]codespec.DiscriminatorType
+		expected bool
+	}{
+		"all variants empty": {
+			mapping: map[string]codespec.DiscriminatorType{
+				"METRIC_A": {Allowed: nil},
+				"METRIC_B": {Allowed: []codespec.DiscriminatorAttrName{}},
+				"METRIC_C": {},
+			},
+			expected: true,
+		},
+		"single type mapping": {
+			mapping: map[string]codespec.DiscriminatorType{
+				"OnlyType": {Allowed: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")}},
+			},
+			expected: true,
+		},
+		"empty mapping": {
+			mapping:  map[string]codespec.DiscriminatorType{},
+			expected: true,
+		},
+		"multiple types with non-empty allowed": {
+			mapping: map[string]codespec.DiscriminatorType{
+				"TypeA": {Allowed: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrA")}},
+				"TypeB": {Allowed: []codespec.DiscriminatorAttrName{codespec.NewDiscriminatorAttrName("attrB")}},
+			},
+			expected: false,
+		},
 	}
-	assert.True(t, codespec.AllVariantsEmpty(mapping))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, codespec.ShouldSkipDiscriminator(tc.mapping))
+		})
+	}
 }
 
 func TestMergeDiscriminators_BothNil(t *testing.T) {

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -714,12 +714,6 @@ resources:
         ]
       aliases:
         tenantName: name # path param name does not match the API request property
-      overrides:
-        # discriminator is nested in an attribute that is fully computed, follow up in CLOUDP-383599 so this filtering is done automatically
-        connections.type:
-          ignore_validators: [discriminator]
-        connections.schema_registry_authentication.type:
-          ignore_validators: [discriminator]
 
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.
   # Custom methods :startWith and :stop are not called so state attribute is not supported as Optional like in the curated resource, only as Computed.

--- a/tools/codegen/models/cluster_api.yaml
+++ b/tools/codegen/models/cluster_api.yaml
@@ -476,6 +476,7 @@ schema:
                                 property_name:
                                     api_name: providerName
                                     tf_schema_name: provider_name
+                                skip_validation: true
                             attributes:
                                 - single_nested:
                                     nested_object:


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-388329

Automates discriminator skip logic that was previously configured manually in `config.yml`:
- **Unified skip function:** Replaces `AllVariantsEmpty` with `ShouldSkipDiscriminator` which also filters out single-type discriminators (only 1 mapping entry) at extraction time, since they provide no value for plan validation or docs. Relevant for cases like https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4258 in which API resource initial support single type but defines `oneOf`/`discriminator`, discriminator only adds noise in this case.
- **Computed auto-skip:** Automatically sets `SkipValidation = true` on discriminators whose property attribute is computed-only, removing the need for manual `ignore_validators: [discriminator]` overrides.
    - **Config cleanup:** Removes the now-redundant `stream_instance_api` overrides for `connections.type` and `connections.schema_registry_authentication.type` that were explicitly marked for automation (CLOUDP-383599).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments