### PR TITLE
chore: Include guides directory in versioned URL update script

### DIFF
--- a/scripts/update-examples-reference-in-docs.sh
+++ b/scripts/update-examples-reference-in-docs.sh
@@ -15,15 +15,13 @@ FILES=()
 # 1) docs/index.md
 FILES+=("./docs/index.md")
 
-# 2) collect all *.md and *.md.tmpl under docs/resources, templates/resources,
-#    docs/data-sources, templates/data-sources, docs/guides, and templates/guides
+# 2) collect all *.md and *.md.tmpl under target directories.
 TARGET_DIRS=(
   "./docs/resources"
   "./templates/resources"
   "./docs/data-sources"
   "./templates/data-sources"
   "./docs/guides"
-  "./templates/guides"
 )
 
 for DIR in "${TARGET_DIRS[@]}"; do

--- a/scripts/update-examples-reference-in-docs.sh
+++ b/scripts/update-examples-reference-in-docs.sh
@@ -16,12 +16,14 @@ FILES=()
 FILES+=("./docs/index.md")
 
 # 2) collect all *.md and *.md.tmpl under docs/resources, templates/resources,
-#    docs/data-sources, and templates/data-sources
+#    docs/data-sources, templates/data-sources, docs/guides, and templates/guides
 TARGET_DIRS=(
   "./docs/resources"
   "./templates/resources"
   "./docs/data-sources"
   "./templates/data-sources"
+  "./docs/guides"
+  "./templates/guides"
 )
 
 for DIR in "${TARGET_DIRS[@]}"; do


### PR DESCRIPTION
## Description

Include `guides` directory in versioned URL update script.

Link to related issue: CLOUDP-388110

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

No changelog entry needed since this is an internal script fix that does not affect provider behavior or user-facing functionality.