### PR TITLE
chore: Adds delete wait to search_index_api to fix QA test failures

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,23 +2,6 @@ package provider
 
 import (
 	"context"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/alertconfigurationapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/auditingapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusterapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusteroldapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/controlplaneipaddressesapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/customdbroleapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/databaseuserapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/maintenancewindowapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectsettingsapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/pushbasedlogexportapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/resourcepolicyapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchdeploymentapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchindexapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streamconnectionapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streaminstanceapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streamprocessorapi"
 	"log"
 	"slices"
 
@@ -283,9 +266,6 @@ func applyGovBaseURLIfNeeded(providerBaseURL string, providerIsMongodbGovCloud b
 
 func (p *MongodbatlasProvider) DataSources(context.Context) []func() datasource.DataSource {
 	dataSources := []func() datasource.DataSource{
-		alertconfigurationapi.DataSource,
-		alertconfigurationapi.PluralDataSource,
-		controlplaneipaddressesapi.DataSource,
 		project.DataSource,
 		project.PluralDataSource,
 		databaseuser.DataSource,
@@ -356,22 +336,6 @@ func (p *MongodbatlasProvider) DataSources(context.Context) []func() datasource.
 
 func (p *MongodbatlasProvider) Resources(context.Context) []func() resource.Resource {
 	resources := []func() resource.Resource{
-		alertconfigurationapi.Resource,
-		auditingapi.Resource,
-		clusterapi.Resource,
-		clusteroldapi.Resource,
-		customdbroleapi.Resource,
-		databaseuserapi.Resource,
-		maintenancewindowapi.Resource,
-		projectapi.Resource,
-		projectsettingsapi.Resource,
-		pushbasedlogexportapi.Resource,
-		resourcepolicyapi.Resource,
-		searchdeploymentapi.Resource,
-		searchindexapi.Resource,
-		streamconnectionapi.Resource,
-		streaminstanceapi.Resource,
-		streamprocessorapi.Resource,
 		project.Resource,
 		logintegration.Resource,
 		encryptionatrest.Resource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,23 @@ package provider
 
 import (
 	"context"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/alertconfigurationapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/auditingapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusterapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusteroldapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/controlplaneipaddressesapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/customdbroleapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/databaseuserapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/maintenancewindowapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectsettingsapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/pushbasedlogexportapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/resourcepolicyapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchdeploymentapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchindexapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streamconnectionapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streaminstanceapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streamprocessorapi"
 	"log"
 	"slices"
 
@@ -266,6 +283,9 @@ func applyGovBaseURLIfNeeded(providerBaseURL string, providerIsMongodbGovCloud b
 
 func (p *MongodbatlasProvider) DataSources(context.Context) []func() datasource.DataSource {
 	dataSources := []func() datasource.DataSource{
+		alertconfigurationapi.DataSource,
+		alertconfigurationapi.PluralDataSource,
+		controlplaneipaddressesapi.DataSource,
 		project.DataSource,
 		project.PluralDataSource,
 		databaseuser.DataSource,
@@ -336,6 +356,22 @@ func (p *MongodbatlasProvider) DataSources(context.Context) []func() datasource.
 
 func (p *MongodbatlasProvider) Resources(context.Context) []func() resource.Resource {
 	resources := []func() resource.Resource{
+		alertconfigurationapi.Resource,
+		auditingapi.Resource,
+		clusterapi.Resource,
+		clusteroldapi.Resource,
+		customdbroleapi.Resource,
+		databaseuserapi.Resource,
+		maintenancewindowapi.Resource,
+		projectapi.Resource,
+		projectsettingsapi.Resource,
+		pushbasedlogexportapi.Resource,
+		resourcepolicyapi.Resource,
+		searchdeploymentapi.Resource,
+		searchindexapi.Resource,
+		streamconnectionapi.Resource,
+		streaminstanceapi.Resource,
+		streamprocessorapi.Resource,
 		project.Resource,
 		logintegration.Resource,
 		encryptionatrest.Resource,

--- a/internal/serviceapi/searchindexapi/resource.go
+++ b/internal/serviceapi/searchindexapi/resource.go
@@ -150,6 +150,20 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		return
 	}
 	reqHandle := deleteRequest(r, r.Client, &state, &resp.Diagnostics)
+	timeout, diags := state.Timeouts.Delete(ctx, 10800*time.Second)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	reqHandle.Wait = &autogen.WaitReq{
+		StateProperty:     "status",
+		PendingStates:     []string{"DELETING"},
+		TargetStates:      []string{"DELETED"},
+		Timeout:           timeout,
+		MinTimeoutSeconds: 30,
+		DelaySeconds:      30,
+		CallParams:        readAPICallParams,
+	}
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 

--- a/internal/serviceapi/searchindexapi/resource.go
+++ b/internal/serviceapi/searchindexapi/resource.go
@@ -150,7 +150,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		return
 	}
 	reqHandle := deleteRequest(r, r.Client, &state, &resp.Diagnostics)
-	timeout, diags := state.Timeouts.Delete(ctx, 10800*time.Second)
+	timeout, diags := state.Timeouts.Delete(ctx, 300*time.Second)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -160,8 +160,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		PendingStates:     []string{"DELETING"},
 		TargetStates:      []string{"DELETED"},
 		Timeout:           timeout,
-		MinTimeoutSeconds: 30,
-		DelaySeconds:      30,
+		MinTimeoutSeconds: 5,
+		DelaySeconds:      5,
 		CallParams:        readAPICallParams,
 	}
 	autogen.HandleDelete(ctx, *reqHandle)

--- a/internal/serviceapi/searchindexapi/resource_schema.go
+++ b/internal/serviceapi/searchindexapi/resource_schema.go
@@ -490,6 +490,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
+				Delete: true,
 			}),
 		},
 	}

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -665,7 +665,7 @@ resources:
       method: PATCH
       wait:
         <<: *search-index-create-wait
-    delete: # Not a LRO (long-running operation).
+    delete:
       path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}
       method: DELETE
       wait:

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -668,6 +668,10 @@ resources:
     delete: # Not a LRO (long-running operation).
       path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}
       method: DELETE
+      wait:
+        <<: *search-index-create-wait
+        pending_states: ["DELETING"]
+        target_states: ["DELETED"]
     version_header: application/vnd.atlas.2024-05-30+json
     schema:
       aliases:

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -672,6 +672,9 @@ resources:
         <<: *search-index-create-wait
         pending_states: ["DELETING"]
         target_states: ["DELETED"]
+        delay_seconds: 5 # Lower delay than create/update
+        timeout_seconds: 300 # 5 minutes
+        min_timeout_seconds: 5
     version_header: application/vnd.atlas.2024-05-30+json
     schema:
       aliases:

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -1303,6 +1303,7 @@ schema:
             configurable_timeouts:
                 - create
                 - update
+                - delete
           computed_optional_required: ""
           tf_schema_name: timeouts
           tf_model_name: Timeouts
@@ -1313,6 +1314,15 @@ schema:
           request_only_required_on_create: false
 operations:
     delete:
+        wait:
+            state_property: status
+            pending_states:
+                - DELETING
+            target_states:
+                - DELETED
+            timeout_seconds: 10800
+            min_timeout_seconds: 30
+            delay_seconds: 30
         http_method: DELETE
         path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexID}
     create:

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -1320,9 +1320,9 @@ operations:
                 - DELETING
             target_states:
                 - DELETED
-            timeout_seconds: 10800
-            min_timeout_seconds: 30
-            delay_seconds: 30
+            timeout_seconds: 300
+            min_timeout_seconds: 5
+            delay_seconds: 5
         http_method: DELETE
         path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexID}
     create:


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-389794

- Test verification [job](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/23249419770)

- Adds a `wait` block to the `search_index_api` delete operation in `config.yml`, causing the resource's `Delete` method to poll until the index is fully removed (404) rather than returning immediately after the DELETE call
- The QA backend processes search index deletions asynchronously, leaving indexes in a `DELETING` state visible via GET, which causes Terraform to report "resource still exists" during state cleanup
- DEV deletes are effectively synchronous (immediate 404), masking this issue in DEV-only testing

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
