### PR TITLE
doc: DOCSP-57765: [TF] - Create target example of Clusters

### DIFF
--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -507,6 +507,10 @@ Refer to the following for full privatelink endpoint connection string examples:
 
 **Target Examples (Recommended Starting Points):**
 - [Free Tier (M0)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/free-tier)
+- [Simple M10 Replica Set](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m10-replicaset)
+- [M10 High-Availability Replica Set (2-2-1)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m10-high-availability)
+- [Simple M30 Single-Shard Cluster](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m30-single-shard)
+- [M30 Multi-Shard Cluster (2 Shards)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m30-multi-shard)
 
 **Cluster Types:**
 - [Replicaset](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/replicaset)

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -505,6 +505,9 @@ Refer to the following for full privatelink endpoint connection string examples:
 
 ### Further Examples
 
+**Target Examples (Recommended Starting Points):**
+- [Free Tier (M0)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/free-tier)
+
 **Cluster Types:**
 - [Replicaset](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/replicaset)
 - [Symmetric Sharded Cluster](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/symmetric-sharded-cluster)

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -506,11 +506,11 @@ Refer to the following for full privatelink endpoint connection string examples:
 ### Further Examples
 
 **Target Examples (Recommended Starting Points):**
-- [Free Tier (M0)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/free-tier)
-- [Simple M10 Replica Set](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m10-replicaset)
-- [M10 High-Availability Replica Set (2-2-1)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m10-high-availability)
-- [Simple M30 Single-Shard Cluster](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m30-single-shard)
-- [M30 Multi-Shard Cluster (2 Shards)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_advanced_cluster/m30-multi-shard)
+- [Free Tier (M0)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/free-tier)
+- [Simple M10 Replica Set](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/m10-replicaset)
+- [M10 High-Availability Replica Set (2-2-1)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/m10-high-availability)
+- [Simple M30 Single-Shard Cluster](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/m30-single-shard)
+- [M30 Multi-Shard Cluster (2 Shards)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/m30-multi-shard)
 
 **Cluster Types:**
 - [Replicaset](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_advanced_cluster/replicaset)

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -1,0 +1,68 @@
+# MongoDB Atlas Provider — Free Tier (M0) Cluster
+
+This example creates an Atlas project and a **free tier M0 cluster** using the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource. M0 clusters are permanently free and are ideal for learning, prototyping, and early-stage development.
+
+> **NOTE**: M0 is a shared-tier cluster with limited resources. To learn more, see [Atlas M0 (Free Cluster) Limits](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/) for more information in the Atlas documentation.
+
+## Prerequisites
+
+To run this example, ensure you have the following tools:
+
+- Terraform MongoDB Atlas Provider v2.0.0 or later
+- A [MongoDB Atlas account](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/).
+
+## Procedure
+
+1. Set Up your MongoDB Atlas Credentials
+
+   Create a ``terraform.tfvars`` file with your credentials:
+
+   ```hcl
+   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   atlas_client_id     = "<ATLAS_CLIENT_ID>"
+   atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
+   ```
+
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+
+2. Review your Terraform Plan
+
+   The following command lists the resources that your configuration will create.
+
+   ```bash
+   terraform plan
+   ```
+
+   Review the following fields in the plan output before applying:
+
+   - `name`: The name of the cluster, set via `var.cluster_name` (Default for this example: `"free-tier-cluster"`)
+   - `cluster_type`: The type of cluster. Must be `"REPLICASET"` for M0 clusters
+   - `instance_size`: The instance size of the cluster. For M0 clusters, must be `"M0"`
+   - `provider_name`: The cloud service provider on which MongoDB Cloud provisions the hosts. For M0 clusters, must be `"TENANT"`
+   - `backing_provider_name`: The cloud provider hosting the cluster (Default for this example: `"AWS"`)
+   - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
+   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. Set to `false` for development; mark as `enabled` before moving to production
+
+3. Apply your configuration
+
+   The following command applies your configuration and creates the resources.
+
+   ```bash
+   terraform apply
+   ```
+
+4. Destroy the resources
+
+   The following command destroys the resources created by `terraform apply`.
+
+   ```bash
+   terraform destroy
+   ```
+
+## Variables
+
+The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
+
+- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -13,6 +13,8 @@ To run this example, ensure you have the following tools:
 
 ## Procedure
 
+Follow the next steps to run this example:
+
 1. Set Up your MongoDB Atlas Credentials
 
    Create a ``terraform.tfvars`` file with your credentials:

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -43,7 +43,7 @@ Follow the next steps to run this example:
    - `provider_name`: The cloud service provider on which MongoDB Cloud provisions the hosts. For M0 clusters, must be `"TENANT"`
    - `backing_provider_name`: The cloud provider hosting the cluster (Default for this example: `"AWS"`)
    - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
-   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. Set to `false` for development; mark as `enabled` before moving to production
+   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
 
 3. Apply your configuration
 
@@ -53,7 +53,7 @@ Follow the next steps to run this example:
    terraform apply
    ```
 
-4. Destroy the resources
+4. (Optional) Destroy the resources
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -25,7 +25,7 @@ To run this example, perform the following steps:
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
 
-   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn more, see [Authentication Methods](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/provider-configuration#authentication-methods) in the MongoDB Atlas Provider documentation.
 
 2. Review your Terraform Plan.
 

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -2,7 +2,7 @@
 
 This example creates an Atlas project and a **free tier M0 cluster** using the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource. M0 clusters are permanently free and are ideal for learning, prototyping, and early-stage development.
 
-> **NOTE**: M0 is a shared-tier cluster with limited resources. To learn more, see [Atlas M0 (Free Cluster) Limits](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/) for more information in the Atlas documentation.
+> **NOTE**: M0 is a shared-tier cluster with limited resources. To learn more, see [Atlas M0 (Free Cluster) Limits](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/).
 
 ## Prerequisites
 
@@ -13,9 +13,9 @@ To run this example, ensure you have the following tools:
 
 ## Procedure
 
-Follow the next steps to run this example:
+To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials
+1. Set Up your MongoDB Atlas Credentials.
 
    Create a ``terraform.tfvars`` file with your credentials:
 
@@ -27,9 +27,9 @@ Follow the next steps to run this example:
 
    Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
 
-2. Review your Terraform Plan
+2. Review your Terraform Plan.
 
-   The following command lists the resources that your configuration will create.
+   The following command lists the resources that your configuration creates.
 
    ```bash
    terraform plan
@@ -39,13 +39,13 @@ Follow the next steps to run this example:
 
    - `name`: The name of the cluster, set via `var.cluster_name` (Default for this example: `"free-tier-cluster"`)
    - `cluster_type`: The type of cluster. Must be `"REPLICASET"` for M0 clusters
-   - `instance_size`: The instance size of the cluster. For M0 clusters, must be `"M0"`
+   - `instance_size`: The instance size of the cluster. For M0 clusters, value must be `"M0"`
    - `provider_name`: The cloud service provider on which MongoDB Cloud provisions the hosts. For M0 clusters, must be `"TENANT"`
    - `backing_provider_name`: The cloud provider hosting the cluster (Default for this example: `"AWS"`)
    - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
-   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
 
-3. Apply your configuration
+3. Apply your configuration.
 
    The following command applies your configuration and creates the resources.
 
@@ -53,7 +53,7 @@ Follow the next steps to run this example:
    terraform apply
    ```
 
-4. (Optional) Destroy the resources
+4. (Optional) Destroy the resources.
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -20,7 +20,7 @@ To run this example, perform the following steps:
    Create a ``terraform.tfvars`` file with your credentials:
 
    ```hcl
-   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   org_id              = "<MONGODB_ATLAS_ORG_ID>"
    atlas_client_id     = "<ATLAS_CLIENT_ID>"
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
@@ -65,6 +65,6 @@ To run this example, perform the following steps:
 
 The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
 
-- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: The MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -15,7 +15,7 @@ To run this example, ensure you have the following tools:
 
 To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials.
+1. Set up your MongoDB Atlas credentials.
 
    Create a ``terraform.tfvars`` file with your credentials:
 
@@ -27,7 +27,7 @@ To run this example, perform the following steps:
 
    Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn more, see [Authentication Methods](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/provider-configuration#authentication-methods) in the MongoDB Atlas Provider documentation.
 
-2. Review your Terraform Plan.
+2. Review your Terraform plan.
 
    The following command lists the resources that your configuration creates.
 
@@ -37,13 +37,13 @@ To run this example, perform the following steps:
 
    Review the following fields in the plan output before applying:
 
-   - `name`: The name of the cluster, set via `var.cluster_name` (Default for this example: `"free-tier-cluster"`)
-   - `cluster_type`: The type of cluster. Must be `"REPLICASET"` for M0 clusters
-   - `instance_size`: The instance size of the cluster. For M0 clusters, value must be `"M0"`
-   - `provider_name`: The cloud service provider on which MongoDB Cloud provisions the hosts. For M0 clusters, must be `"TENANT"`
-   - `backing_provider_name`: The cloud provider hosting the cluster (Default for this example: `"AWS"`)
-   - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `name`: Name of the cluster, set via `var.cluster_name`. Default for this example: `"free-tier-cluster"`
+   - `cluster_type`: Type of cluster. Must be `"REPLICASET"` for M0 clusters
+   - `instance_size`: Instance size of the cluster. For M0 clusters, value must be `"M0"`
+   - `provider_name`: Cloud service provider on which MongoDB Cloud provisions the hosts. For M0 clusters, must be `"TENANT"`
+   - `backing_provider_name`: Cloud provider hosting the cluster. Default for this example: `"AWS"`
+   - `region_name`: Cloud region where the cluster is deployed. Default for this example: `"US_EAST_1"`)
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment
 
 3. Apply your configuration.
 
@@ -65,6 +65,6 @@ To run this example, perform the following steps:
 
 The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
 
-- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
-- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
-- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
+- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: MongoDB Atlas Service Account Client Secret

--- a/examples/mongodbatlas_advanced_cluster/free-tier/README.md
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/README.md
@@ -65,6 +65,6 @@ To run this example, perform the following steps:
 
 The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret

--- a/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
@@ -1,0 +1,40 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+  base_url      = var.atlas_base_url
+}
+
+resource "mongodbatlas_advanced_cluster" "cluster" {
+  project_id   = mongodbatlas_project.project.id
+  name         = var.cluster_name
+  cluster_type = "REPLICASET"
+
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          electable_specs = {
+            instance_size = "M0"
+          }
+          provider_name         = "TENANT"
+          backing_provider_name = "AWS"
+          region_name           = "US_EAST_1"
+          priority              = 7
+        }
+      ]
+    }
+  ]
+
+  # Termination protection is disabled by default for free-tier clusters used in
+  # development and evaluation. Enable it before moving to production.
+  termination_protection_enabled = false
+
+  tags = {
+    environment = "dev"
+  }
+}
+
+resource "mongodbatlas_project" "project" {
+  name   = var.project_name
+  org_id = var.atlas_org_id
+}

--- a/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
@@ -35,5 +35,5 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
 resource "mongodbatlas_project" "project" {
   name   = var.project_name
-  org_id = var.atlas_org_id
+  org_id = var.org_id
 }

--- a/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
@@ -1,7 +1,6 @@
 provider "mongodbatlas" {
   client_id     = var.atlas_client_id
   client_secret = var.atlas_client_secret
-  base_url      = var.atlas_base_url
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {

--- a/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/main.tf
@@ -14,7 +14,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M0"
+            instance_size = "M0" # Free tier. Permanently free, shared infrastructure
           }
           provider_name         = "TENANT"
           backing_provider_name = "AWS"

--- a/examples/mongodbatlas_advanced_cluster/free-tier/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/variables.tf
@@ -1,0 +1,30 @@
+variable "atlas_base_url" {
+  description = "Atlas base URL (defaults to cloud.mongodb.com)"
+  type        = string
+  default     = "https://cloud.mongodb.com/"
+}
+variable "atlas_org_id" {
+  description = "Atlas organization id"
+  type        = string
+}
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "project_name" {
+  description = "Atlas project name"
+  type        = string
+  default     = "free-tier-project"
+}
+variable "cluster_name" {
+  description = "Atlas cluster name"
+  type        = string
+  default     = "free-tier-cluster"
+}

--- a/examples/mongodbatlas_advanced_cluster/free-tier/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/variables.tf
@@ -1,4 +1,4 @@
-variable "atlas_org_id" {
+variable "org_id" {
   description = "Atlas organization id"
   type        = string
 }

--- a/examples/mongodbatlas_advanced_cluster/free-tier/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/variables.tf
@@ -1,8 +1,3 @@
-variable "atlas_base_url" {
-  description = "Atlas base URL (defaults to cloud.mongodb.com)"
-  type        = string
-  default     = "https://cloud.mongodb.com/"
-}
 variable "atlas_org_id" {
   description = "Atlas organization id"
   type        = string

--- a/examples/mongodbatlas_advanced_cluster/free-tier/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/examples/mongodbatlas_advanced_cluster/free-tier/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/free-tier/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "mongodb/mongodbatlas"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 }

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -1,0 +1,90 @@
+# MongoDB Atlas Provider — M10 High-Availability Replica Set (2-2-1)
+
+This example creates an Atlas project and a **five-node M10 replica set spread across three AWS regions** using the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource. This pattern is a cost-effective way to achieve high availability with protection against a full regional outage, without the cost of a sharded cluster.
+
+## Topology
+
+The cluster distributes nodes across three regions as follows:
+
+- `US_EAST_1` (AWS) — Two electable nodes, priority 7 (preferred primary region)
+- `US_WEST_2` (AWS) — Two electable nodes, priority 6 (secondary failover region)
+- `EU_WEST_1` (AWS) — One1 electable node, priority 5 (tiebreaker)
+
+### Why the odd node (2-2-1)?
+
+A four-node cluster (2+2) would have an even number of votes. If both regions in a 2-node group are simultaneously affected, neither side can reach a simple majority, causing an election stalemate. The fifth node in a third region adds one extra vote, ensuring a majority (3 of 5) is always reachable even if any single region goes down.
+
+Failover scenarios with five votes (majority = 3):
+
+- `US_EAST_1` lost — Three remaining votes (US_WEST_2: 2 + EU_WEST_1: 1) — election succeeds
+- `US_WEST_2` lost — Three remaining votes (US_EAST_1: 2 + EU_WEST_1: 1) — election succeeds
+- `EU_WEST_1` lost — Four remaining votes (US_EAST_1: 2 + US_WEST_2: 2) — election succeeds
+
+## Prerequisites
+
+To run this example, ensure you have the following tools:
+
+- Terraform MongoDB Atlas Provider v2.0.0 or later
+- A [MongoDB Atlas account](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/)
+
+## Procedure
+
+Follow the next steps to run this example:
+
+1. Set Up your MongoDB Atlas Credentials
+
+   Create a `terraform.tfvars` file with your credentials:
+
+   ```hcl
+   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   atlas_client_id     = "<ATLAS_CLIENT_ID>"
+   atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
+   ```
+
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+
+2. Review your Terraform plan
+
+   The following command lists the resources that your configuration will create.
+
+   ```bash
+   terraform plan
+   ```
+
+   Review the following fields in the plan output before applying:
+
+   - `name`: The name of the cluster (default: `"m10-high-availability"`)
+   - `cluster_type`: The type of cluster. Must be `"REPLICASET"`
+   - `instance_size`: The instance size for all nodes. Set to `"M10"`
+   - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
+   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
+   - `region_configs`: Three entries — `US_EAST_1` (2 nodes, priority 7), `US_WEST_2` (2 nodes, priority 6), `EU_WEST_1` (1 node, priority 5)
+
+3. Apply your configuration
+
+   The following command applies your configuration and creates the resources.
+
+   ```bash
+   terraform apply
+   ```
+
+   Note that the apply might take several minutes.
+
+4. Destroy the resources
+
+   The following command destroys the resources created by `terraform apply`.
+
+   ```bash
+   terraform destroy
+   ```
+
+## Variables
+
+The `terraform.tfvars` file must contain the following variables for the configuration to work:
+
+- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
+- `project_name`: The Atlas project name (default: `"m10-ha-project"`)
+- `cluster_name`: The Atlas cluster name (default: `"m10-high-availability"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -53,12 +53,12 @@ Follow the next steps to run this example:
 
    Review the following fields in the plan output before applying:
 
-   - `name`: The name of the cluster (default: `"m10-high-availability"`)
+   - `name`: The name of the cluster (Default for this example: `"m10-high-availability"`)
    - `cluster_type`: The type of cluster. Must be `"REPLICASET"`
    - `instance_size`: The instance size for all nodes. Set to `"M10"`
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
    - `region_configs`: Three entries — `US_EAST_1` (2 nodes, priority 7), `US_WEST_2` (2 nodes, priority 6), `EU_WEST_1` (1 node, priority 5)
 
 3. Apply your configuration
@@ -71,7 +71,7 @@ Follow the next steps to run this example:
 
    Note that the apply might take several minutes.
 
-4. Destroy the resources
+4. (Optional) Destroy the resources
 
    The following command destroys the resources created by `terraform apply`.
 
@@ -86,5 +86,5 @@ The `terraform.tfvars` file must contain the following variables for the configu
 - `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: The MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
-- `project_name`: The Atlas project name (default: `"m10-ha-project"`)
-- `cluster_name`: The Atlas cluster name (default: `"m10-high-availability"`)
+- `project_name`: The Atlas project name (Default for this example: `"m10-ha-project"`)
+- `cluster_name`: The Atlas cluster name (Default for this example: `"m10-high-availability"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -8,7 +8,7 @@ The cluster distributes nodes across three regions as follows:
 
 - `US_EAST_1` (AWS) — Two electable nodes, priority 7 (preferred primary region)
 - `US_WEST_2` (AWS) — Two electable nodes, priority 6 (secondary failover region)
-- `EU_WEST_1` (AWS) — One1 electable node, priority 5 (tiebreaker)
+- `EU_WEST_1` (AWS) — One electable node, priority 5 (tiebreaker)
 
 ### Why the odd node (2-2-1)?
 

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -31,7 +31,7 @@ To run this example, ensure you have the following tools:
 
 To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials.
+1. Set up your MongoDB Atlas credentials.
 
    Create a `terraform.tfvars` file with your credentials:
 
@@ -53,12 +53,12 @@ To run this example, perform the following steps:
 
    Review the following fields in the plan output before applying:
 
-   - `name`: The name of the cluster. Default for this example: `"m10-high-availability"`
-   - `cluster_type`: The type of cluster. Must be `"REPLICASET"`
-   - `instance_size`: The instance size for all nodes. Set to `"M10"`
-   - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
+   - `name`: Name of the cluster. Default for this example: `"m10-high-availability"`
+   - `cluster_type`: Type of cluster. Must be `"REPLICASET"`
+   - `instance_size`: Instance size for all nodes. Set to `"M10"`
+   - `provider_name`: Cloud service provider hosting the cluster. Set to `"AWS"`
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example
    - `region_configs`: Cloud provider region configuration. Three entries — `US_EAST_1` (2 nodes, priority 7), `US_WEST_2` (2 nodes, priority 6), `EU_WEST_1` (1 node, priority 5)
 
 3. Apply your configuration.
@@ -83,8 +83,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
-- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
-- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
-- `project_name`: The Atlas project name (Default for this example: `"m10-ha-project"`)
-- `cluster_name`: The Atlas cluster name (Default for this example: `"m10-high-availability"`)
+- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
+- `project_name`: Atlas project name. Default for this example: `"m10-ha-project"`)
+- `cluster_name`: Atlas cluster name. Default for this example: `"m10-high-availability"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -83,8 +83,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
-- `project_name`: Atlas project name. Default for this example: `"m10-ha-project"`)
-- `cluster_name`: Atlas cluster name. Default for this example: `"m10-high-availability"`)
+- `project_name`: MongoDB Atlas project name. Default for this example: `"m10-ha-project"`)
+- `cluster_name`: MongoDB Atlas cluster name. Default for this example: `"m10-high-availability"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -41,7 +41,7 @@ To run this example, perform the following steps:
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
 
-   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn more, see [Authentication Methods](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/provider-configuration#authentication-methods) in the MongoDB Atlas Provider documentation.
 
 2. Review your Terraform plan.
 

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -83,8 +83,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
-- `project_name`: MongoDB Atlas project name. Default for this example: `"m10-ha-project"`)
-- `cluster_name`: MongoDB Atlas cluster name. Default for this example: `"m10-high-availability"`)
+- `project_name`: MongoDB Atlas project name. Default for this example: `"m10-ha-project"`
+- `cluster_name`: MongoDB Atlas cluster name. Default for this example: `"m10-high-availability"`

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -8,11 +8,11 @@ The cluster distributes nodes across three regions as follows:
 
 - `US_EAST_1` (AWS) — Two electable nodes, priority 7 (preferred primary region)
 - `US_WEST_2` (AWS) — Two electable nodes, priority 6 (secondary failover region)
-- `EU_WEST_1` (AWS) — One1 electable node, priority 5 (tiebreaker)
+- `EU_WEST_1` (AWS) — One electable node, priority 5 (tiebreaker)
 
 ### Why the odd node (2-2-1)?
 
-A four-node cluster (2+2) would have an even number of votes. If both regions in a 2-node group are simultaneously affected, neither side can reach a simple majority, causing an election stalemate. The fifth node in a third region adds one extra vote, ensuring a majority (3 of 5) is always reachable even if any single region goes down.
+A four-node cluster (2+2) would have an even number of votes. If both regions in a 2-node group are simultaneously affected, neither side can reach a simple majority, resulting in an election stalemate. The fifth node in a third region adds one extra vote, ensuring a majority (3 of 5) is always reachable even if any single region goes down.
 
 Failover scenarios with five votes (majority = 3):
 
@@ -29,9 +29,9 @@ To run this example, ensure you have the following tools:
 
 ## Procedure
 
-Follow the next steps to run this example:
+To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials
+1. Set Up your MongoDB Atlas Credentials.
 
    Create a `terraform.tfvars` file with your credentials:
 
@@ -43,9 +43,9 @@ Follow the next steps to run this example:
 
    Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
 
-2. Review your Terraform plan
+2. Review your Terraform plan.
 
-   The following command lists the resources that your configuration will create.
+   The following command lists the resources that your configuration creates.
 
    ```bash
    terraform plan
@@ -53,15 +53,15 @@ Follow the next steps to run this example:
 
    Review the following fields in the plan output before applying:
 
-   - `name`: The name of the cluster (Default for this example: `"m10-high-availability"`)
+   - `name`: The name of the cluster. Default for this example: `"m10-high-availability"`
    - `cluster_type`: The type of cluster. Must be `"REPLICASET"`
    - `instance_size`: The instance size for all nodes. Set to `"M10"`
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
-   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
-   - `region_configs`: Three entries — `US_EAST_1` (2 nodes, priority 7), `US_WEST_2` (2 nodes, priority 6), `EU_WEST_1` (1 node, priority 5)
+   - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `region_configs`: Cloud provider region configuration. Three entries — `US_EAST_1` (2 nodes, priority 7), `US_WEST_2` (2 nodes, priority 6), `EU_WEST_1` (1 node, priority 5)
 
-3. Apply your configuration
+3. Apply your configuration.
 
    The following command applies your configuration and creates the resources.
 
@@ -69,9 +69,9 @@ Follow the next steps to run this example:
    terraform apply
    ```
 
-   Note that the apply might take several minutes.
+   This operation might take several minutes to complete.
 
-4. (Optional) Destroy the resources
+4. (Optional) Destroy the resources.
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -58,7 +58,7 @@ To run this example, perform the following steps:
    - `instance_size`: The instance size for all nodes. Set to `"M10"`
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example.
    - `region_configs`: Cloud provider region configuration. Three entries — `US_EAST_1` (2 nodes, priority 7), `US_WEST_2` (2 nodes, priority 6), `EU_WEST_1` (1 node, priority 5)
 
 3. Apply your configuration.

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/README.md
@@ -36,7 +36,7 @@ To run this example, perform the following steps:
    Create a `terraform.tfvars` file with your credentials:
 
    ```hcl
-   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   org_id              = "<MONGODB_ATLAS_ORG_ID>"
    atlas_client_id     = "<ATLAS_CLIENT_ID>"
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
@@ -83,7 +83,7 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: The MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
 - `project_name`: The Atlas project name (Default for this example: `"m10-ha-project"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -4,15 +4,6 @@ provider "mongodbatlas" {
   base_url      = var.atlas_base_url
 }
 
-# 2-2-1 replica set across three regions for high availability.
-#
-# Topology:
-#   Region A (US_EAST_1)  — 2 electable nodes, priority 7  (preferred primary)
-#   Region B (US_WEST_2)  — 2 electable nodes, priority 6
-#   Region C (EU_WEST_1)  — 1 electable node,  priority 5  (tiebreaker)
-#
-# With 5 total votes, a majority (3) can always be reached even if one full
-# region becomes unavailable, preventing split-brain without needing an arbiter.
 resource "mongodbatlas_advanced_cluster" "cluster" {
   project_id     = mongodbatlas_project.project.id
   name           = var.cluster_name

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -1,0 +1,73 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+  base_url      = var.atlas_base_url
+}
+
+# 2-2-1 replica set across three regions for high availability.
+#
+# Topology:
+#   Region A (US_EAST_1)  — 2 electable nodes, priority 7  (preferred primary)
+#   Region B (US_WEST_2)  — 2 electable nodes, priority 6
+#   Region C (EU_WEST_1)  — 1 electable node,  priority 5  (tiebreaker)
+#
+# With 5 total votes, a majority (3) can always be reached even if one full
+# region becomes unavailable, preventing split-brain without needing an arbiter.
+resource "mongodbatlas_advanced_cluster" "cluster" {
+  project_id     = mongodbatlas_project.project.id
+  name           = var.cluster_name
+  cluster_type   = "REPLICASET"
+  backup_enabled = true
+
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          # Primary region: 2 nodes ensure the primary stays in this region
+          # during normal operation.
+          electable_specs = {
+            instance_size = "M10"
+            node_count    = 2
+          }
+          provider_name = "AWS"
+          priority      = 7
+          region_name   = "US_EAST_1"
+        },
+        {
+          # Secondary region: 2 nodes provide a full failover target.
+          electable_specs = {
+            instance_size = "M10"
+            node_count    = 2
+          }
+          provider_name = "AWS"
+          priority      = 6
+          region_name   = "US_WEST_2"
+        },
+        {
+          # Tiebreaker region: 1 node provides the odd vote that prevents a
+          # split vote if the primary and secondary regions are simultaneously
+          # degraded. A smaller or geographically distant region is acceptable
+          # here since it will rarely become primary.
+          electable_specs = {
+            instance_size = "M10"
+            node_count    = 1
+          }
+          provider_name = "AWS"
+          priority      = 5
+          region_name   = "EU_WEST_1"
+        }
+      ]
+    }
+  ]
+
+  termination_protection_enabled = false
+
+  tags = {
+    environment = "production"
+  }
+}
+
+resource "mongodbatlas_project" "project" {
+  name   = var.project_name
+  org_id = var.atlas_org_id
+}

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -4,10 +4,11 @@ provider "mongodbatlas" {
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {
-  project_id     = mongodbatlas_project.project.id
-  name           = var.cluster_name
-  cluster_type   = "REPLICASET"
-  backup_enabled = true
+  project_id           = mongodbatlas_project.project.id
+  name                 = var.cluster_name
+  cluster_type         = "REPLICASET"
+  backup_enabled       = true
+  use_effective_fields = true
 
   replication_specs = [
     {
@@ -18,6 +19,14 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
           electable_specs = {
             instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 2
+            disk_size_gb  = 10
+          }
+          auto_scaling = {
+            compute_enabled            = true
+            compute_scale_down_enabled = true
+            compute_min_instance_size  = "M10"
+            compute_max_instance_size  = "M40"
+            disk_gb_enabled            = true
           }
           provider_name = "AWS"
           priority      = 7
@@ -28,6 +37,14 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
           electable_specs = {
             instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 2
+            disk_size_gb  = 10
+          }
+          auto_scaling = {
+            compute_enabled            = true
+            compute_scale_down_enabled = true
+            compute_min_instance_size  = "M10"
+            compute_max_instance_size  = "M40"
+            disk_gb_enabled            = true
           }
           provider_name = "AWS"
           priority      = 6
@@ -41,6 +58,14 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
           electable_specs = {
             instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 1
+            disk_size_gb  = 10
+          }
+          auto_scaling = {
+            compute_enabled            = true
+            compute_scale_down_enabled = true
+            compute_min_instance_size  = "M10"
+            compute_max_instance_size  = "M40"
+            disk_gb_enabled            = true
           }
           provider_name = "AWS"
           priority      = 5

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -17,7 +17,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
           # Primary region: 2 nodes ensure the primary stays in this region
           # during normal operation.
           electable_specs = {
-            instance_size = "M10"
+            instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 2
           }
           provider_name = "AWS"
@@ -27,7 +27,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
         {
           # Secondary region: 2 nodes provide a full failover target.
           electable_specs = {
-            instance_size = "M10"
+            instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 2
           }
           provider_name = "AWS"
@@ -40,7 +40,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
           # degraded. A smaller or geographically distant region is acceptable
           # here since it will rarely become primary.
           electable_specs = {
-            instance_size = "M10"
+            instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 1
           }
           provider_name = "AWS"

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -25,7 +25,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             compute_enabled            = true
             compute_scale_down_enabled = true
             compute_min_instance_size  = "M10"
-            compute_max_instance_size  = "M40"
+            compute_max_instance_size  = "M50"
             disk_gb_enabled            = true
           }
           provider_name = "AWS"
@@ -43,7 +43,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             compute_enabled            = true
             compute_scale_down_enabled = true
             compute_min_instance_size  = "M10"
-            compute_max_instance_size  = "M40"
+            compute_max_instance_size  = "M50"
             disk_gb_enabled            = true
           }
           provider_name = "AWS"
@@ -64,7 +64,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             compute_enabled            = true
             compute_scale_down_enabled = true
             compute_min_instance_size  = "M10"
-            compute_max_instance_size  = "M40"
+            compute_max_instance_size  = "M50"
             disk_gb_enabled            = true
           }
           provider_name = "AWS"

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -1,7 +1,6 @@
 provider "mongodbatlas" {
   client_id     = var.atlas_client_id
   client_secret = var.atlas_client_secret
-  base_url      = var.atlas_base_url
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -75,7 +75,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   ]
 
-  termination_protection_enabled = false
+  termination_protection_enabled = true
 
   tags = {
     environment = "production"

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/main.tf
@@ -84,5 +84,5 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
 resource "mongodbatlas_project" "project" {
   name   = var.project_name
-  org_id = var.atlas_org_id
+  org_id = var.org_id
 }

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
@@ -1,0 +1,30 @@
+variable "atlas_base_url" {
+  description = "MongoDB Atlas Base URL"
+  type        = string
+  default     = "https://cloud.mongodb.com/"
+}
+variable "atlas_org_id" {
+  description = "Atlas organization id"
+  type        = string
+}
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "project_name" {
+  description = "Atlas project name"
+  type        = string
+  default     = "m10-ha-project"
+}
+variable "cluster_name" {
+  description = "Atlas cluster name"
+  type        = string
+  default     = "m10-high-availability"
+}

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
@@ -1,5 +1,5 @@
 variable "atlas_base_url" {
-  description = "MongoDB Atlas Base URL"
+  description = "Atlas base URL (defaults to cloud.mongodb.com)"
   type        = string
   default     = "https://cloud.mongodb.com/"
 }

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
@@ -1,8 +1,3 @@
-variable "atlas_base_url" {
-  description = "MongoDB Atlas Base URL"
-  type        = string
-  default     = "https://cloud.mongodb.com/"
-}
 variable "atlas_org_id" {
   description = "Atlas organization id"
   type        = string

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
@@ -1,4 +1,4 @@
-variable "atlas_org_id" {
+variable "org_id" {
   description = "Atlas organization id"
   type        = string
 }

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/variables.tf
@@ -1,11 +1,3 @@
-<<<<<<< HEAD
-=======
-variable "atlas_base_url" {
-  description = "Atlas base URL (defaults to cloud.mongodb.com)"
-  type        = string
-  default     = "https://cloud.mongodb.com/"
-}
->>>>>>> origin/DOCSP-57765
 variable "atlas_org_id" {
   description = "Atlas organization id"
   type        = string

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/examples/mongodbatlas_advanced_cluster/m10-high-availability/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-high-availability/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "mongodb/mongodbatlas"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 }

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -50,7 +50,7 @@ Follow the next steps to run this example:
    - `provider_name`: The cloud service provider hosting the cluster (Default for this example: `"AWS"`)
    - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
    - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled. (Default for this example: `false`)
+   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
 
 3. Apply your configuration
 

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -50,7 +50,7 @@ Follow the next steps to run this example:
    - `provider_name`: The cloud service provider hosting the cluster (Default for this example: `"AWS"`)
    - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
    - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
 
 3. Apply your configuration
 
@@ -62,7 +62,7 @@ Follow the next steps to run this example:
 
    Note that the apply might take several minutes.
 
-4. Destroy the resources
+4. (Optional) Destroy the resources
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -50,7 +50,7 @@ Follow the next steps to run this example:
    - `provider_name`: The cloud service provider hosting the cluster (Default for this example: `"AWS"`)
    - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
    - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled. Set to `true`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled. (Default for this example: `false`)
 
 3. Apply your configuration
 

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -1,0 +1,81 @@
+# MongoDB Atlas Provider — Simple M10 Replica Set
+
+This example creates an Atlas project and a **three-node M10 replica set** using the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource. M10 is the recommended entry-level dedicated cluster for development, internal tooling, and low-volume production workloads.
+
+## Topology
+
+A three-node replica set provides:
+
+- Automatic failover (a new primary is elected if the current one goes down)
+- Data redundancy across three copies
+- Sufficient votes (three) to always reach a majority
+
+## Prerequisites
+
+To run this example, ensure you have the following tools:
+
+- Terraform MongoDB Atlas Provider v2.0.0 or later
+- A [MongoDB Atlas account](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/)
+
+## Procedure
+
+Follow the next steps to run this example:
+
+1. Set Up your MongoDB Atlas Credentials
+
+   Create a ``terraform.tfvars`` file with your credentials:
+
+   ```hcl
+   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   atlas_client_id     = "<ATLAS_CLIENT_ID>"
+   atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
+   ```
+
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+
+2. Review your Terraform Plan
+
+   The following command lists the resources that your configuration will create.
+
+   ```bash
+   terraform plan
+   ```
+
+   Review the following fields in the plan output before applying:
+
+   - `name`: The name of the cluster, set via `var.cluster_name` (Default for this example: `"m10-replicaset"`)
+   - `cluster_type`: The type of cluster. Must be `"REPLICASET"`
+   - `instance_size`: The instance size of the cluster. Set to `"M10"`
+   - `node_count`: The number of electable nodes. Set to `3`
+   - `provider_name`: The cloud service provider hosting the cluster (Default for this example: `"AWS"`)
+   - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
+   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled. Set to `true`
+
+3. Apply your configuration
+
+   The following command applies your configuration and creates the resources.
+
+   ```bash
+   terraform apply
+   ```
+
+   Note that the apply might take several minutes.
+
+4. Destroy the resources
+
+   The following command destroys the resources created by `terraform apply`.
+
+   ```bash
+   terraform destroy
+   ```
+
+## Variables
+
+The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
+
+- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
+- `project_name`: The Atlas project name (default: `"m10-replicaset-project"`)
+- `cluster_name`: The Atlas cluster name (default: `"m10-replicaset"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -74,8 +74,8 @@ To run this example, perform the following steps:
 
 The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
-- `project_name`: Atlas project name (default: `"m10-replicaset-project"`)
-- `cluster_name`: Atlas cluster name (default: `"m10-replicaset"`)
+- `project_name`: MongoDB Atlas project name (default: `"m10-replicaset-project"`)
+- `cluster_name`: MongoDB Atlas cluster name (default: `"m10-replicaset"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -31,7 +31,7 @@ To run this example, perform the following steps:
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
 
-   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn more, see [Authentication Methods](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/provider-configuration#authentication-methods) in the MongoDB Atlas Provider documentation.
 
 2. Review your Terraform Plan.
 

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -50,7 +50,7 @@ To run this example, perform the following steps:
    - `provider_name`: Cloud service provider hosting the cluster. Default for this example: `"AWS"`)
    - `region_name`: Cloud region where the cluster is deployed. Default for this example: `"US_EAST_1"`)
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example.
 
 3. Apply your configuration.
 

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -26,7 +26,7 @@ To run this example, perform the following steps:
    Create a ``terraform.tfvars`` file with your credentials:
 
    ```hcl
-   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   org_id              = "<MONGODB_ATLAS_ORG_ID>"
    atlas_client_id     = "<ATLAS_CLIENT_ID>"
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
@@ -74,7 +74,7 @@ To run this example, perform the following steps:
 
 The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
 
-- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: The MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
 - `project_name`: The Atlas project name (default: `"m10-replicaset-project"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -21,7 +21,7 @@ To run this example, ensure you have the following tools:
 
 To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials.
+1. Set up your MongoDB Atlas credentials.
 
    Create a ``terraform.tfvars`` file with your credentials:
 
@@ -33,7 +33,7 @@ To run this example, perform the following steps:
 
    Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn more, see [Authentication Methods](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/provider-configuration#authentication-methods) in the MongoDB Atlas Provider documentation.
 
-2. Review your Terraform Plan.
+2. Review your Terraform plan.
 
    The following command lists the resources that your configuration creates.
 
@@ -43,14 +43,14 @@ To run this example, perform the following steps:
 
    Review the following fields in the plan output before applying:
 
-   - `name`: The name of the cluster, set via `var.cluster_name` (Default for this example: `"m10-replicaset"`)
-   - `cluster_type`: The type of cluster. Must be `"REPLICASET"`
-   - `instance_size`: The instance size of the cluster. Set to `"M10"`
-   - `node_count`: The number of electable nodes. Set to `3`
-   - `provider_name`: The cloud service provider hosting the cluster (Default for this example: `"AWS"`)
-   - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
+   - `name`: Name of the cluster, set via `var.cluster_name`. Default for this example: `"m10-replicaset"`)
+   - `cluster_type`: Type of cluster. Must be `"REPLICASET"`
+   - `instance_size`: Instance size of the cluster. Set to `"M10"`
+   - `node_count`: Number of electable nodes. Set to `3`
+   - `provider_name`: Cloud service provider hosting the cluster. Default for this example: `"AWS"`)
+   - `region_name`: Cloud region where the cluster is deployed. Default for this example: `"US_EAST_1"`)
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment
 
 3. Apply your configuration.
 
@@ -74,8 +74,8 @@ To run this example, perform the following steps:
 
 The ``terraform.tfvars`` file must contain the following variables for the configuration to work:
 
-- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
-- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
-- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
-- `project_name`: The Atlas project name (default: `"m10-replicaset-project"`)
-- `cluster_name`: The Atlas cluster name (default: `"m10-replicaset"`)
+- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
+- `project_name`: Atlas project name (default: `"m10-replicaset-project"`)
+- `cluster_name`: Atlas cluster name (default: `"m10-replicaset"`)

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -6,7 +6,7 @@ This example creates an Atlas project and a **three-node M10 replica set** using
 
 A three-node replica set provides:
 
-- Automatic failover (a new primary is elected if the current one goes down)
+- Automatic failover where a new primary is elected if the current one goes down
 - Data redundancy across three copies
 - Sufficient votes (three) to always reach a majority
 

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/README.md
@@ -19,9 +19,9 @@ To run this example, ensure you have the following tools:
 
 ## Procedure
 
-Follow the next steps to run this example:
+To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials
+1. Set Up your MongoDB Atlas Credentials.
 
    Create a ``terraform.tfvars`` file with your credentials:
 
@@ -33,9 +33,9 @@ Follow the next steps to run this example:
 
    Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
 
-2. Review your Terraform Plan
+2. Review your Terraform Plan.
 
-   The following command lists the resources that your configuration will create.
+   The following command lists the resources that your configuration creates.
 
    ```bash
    terraform plan
@@ -49,10 +49,10 @@ Follow the next steps to run this example:
    - `node_count`: The number of electable nodes. Set to `3`
    - `provider_name`: The cloud service provider hosting the cluster (Default for this example: `"AWS"`)
    - `region_name`: The cloud region where the cluster is deployed (Default for this example: `"US_EAST_1"`)
-   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
 
-3. Apply your configuration
+3. Apply your configuration.
 
    The following command applies your configuration and creates the resources.
 
@@ -60,9 +60,9 @@ Follow the next steps to run this example:
    terraform apply
    ```
 
-   Note that the apply might take several minutes.
+   This operation might take several minutes to complete.
 
-4. (Optional) Destroy the resources
+4. (Optional) Destroy the resources.
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -26,7 +26,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   ]
 
-  termination_protection_enabled = true
+  termination_protection_enabled = false
 
   tags = {
     environment = "production"

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -1,0 +1,39 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+  base_url      = var.atlas_base_url
+}
+
+resource "mongodbatlas_advanced_cluster" "cluster" {
+  project_id     = mongodbatlas_project.project.id
+  name           = var.cluster_name
+  cluster_type   = "REPLICASET"
+  backup_enabled = true
+
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          electable_specs = {
+            instance_size = "M10"
+            node_count    = 3
+          }
+          provider_name = "AWS"
+          priority      = 7
+          region_name   = "US_EAST_1"
+        }
+      ]
+    }
+  ]
+
+  termination_protection_enabled = true
+
+  tags = {
+    environment = "production"
+  }
+}
+
+resource "mongodbatlas_project" "project" {
+  name   = var.project_name
+  org_id = var.atlas_org_id
+}

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -4,8 +4,8 @@ provider "mongodbatlas" {
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {
-  project_id     = mongodbatlas_project.project.id
-  name           = var.cluster_name
+  project_id           = mongodbatlas_project.project.id
+  name                 = var.cluster_name
   cluster_type         = "REPLICASET"
   backup_enabled       = true
   use_effective_fields = true

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -1,7 +1,6 @@
 provider "mongodbatlas" {
   client_id     = var.atlas_client_id
   client_secret = var.atlas_client_secret
-  base_url      = var.atlas_base_url
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -43,5 +43,5 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
 resource "mongodbatlas_project" "project" {
   name   = var.project_name
-  org_id = var.atlas_org_id
+  org_id = var.org_id
 }

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -34,7 +34,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   ]
 
-  termination_protection_enabled = false
+  termination_protection_enabled = true
 
   tags = {
     environment = "production"

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -6,8 +6,9 @@ provider "mongodbatlas" {
 resource "mongodbatlas_advanced_cluster" "cluster" {
   project_id     = mongodbatlas_project.project.id
   name           = var.cluster_name
-  cluster_type   = "REPLICASET"
-  backup_enabled = true
+  cluster_type         = "REPLICASET"
+  backup_enabled       = true
+  use_effective_fields = true
 
   replication_specs = [
     {
@@ -16,6 +17,14 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
           electable_specs = {
             instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 3
+            disk_size_gb  = 10
+          }
+          auto_scaling = {
+            compute_enabled            = true
+            compute_scale_down_enabled = true
+            compute_min_instance_size  = "M10"
+            compute_max_instance_size  = "M40"
+            disk_gb_enabled            = true
           }
           provider_name = "AWS"
           priority      = 7

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -15,7 +15,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M10"
+            instance_size = "M10" # Paid tier. Entry-level dedicated cluster
             node_count    = 3
           }
           provider_name = "AWS"

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/main.tf
@@ -23,7 +23,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             compute_enabled            = true
             compute_scale_down_enabled = true
             compute_min_instance_size  = "M10"
-            compute_max_instance_size  = "M40"
+            compute_max_instance_size  = "M50"
             disk_gb_enabled            = true
           }
           provider_name = "AWS"

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/variables.tf
@@ -1,0 +1,30 @@
+variable "atlas_base_url" {
+  description = "Atlas base URL (defaults to cloud.mongodb.com)"
+  type        = string
+  default     = "https://cloud.mongodb.com/"
+}
+variable "atlas_org_id" {
+  description = "Atlas organization id"
+  type        = string
+}
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "project_name" {
+  description = "Atlas project name"
+  type        = string
+  default     = "m10-replicaset-project"
+}
+variable "cluster_name" {
+  description = "Atlas cluster name"
+  type        = string
+  default     = "m10-replicaset"
+}

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/variables.tf
@@ -1,4 +1,4 @@
-variable "atlas_org_id" {
+variable "org_id" {
   description = "Atlas organization id"
   type        = string
 }

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/variables.tf
@@ -1,8 +1,3 @@
-variable "atlas_base_url" {
-  description = "Atlas base URL (defaults to cloud.mongodb.com)"
-  type        = string
-  default     = "https://cloud.mongodb.com/"
-}
 variable "atlas_org_id" {
   description = "Atlas organization id"
   type        = string

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/examples/mongodbatlas_advanced_cluster/m10-replicaset/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m10-replicaset/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "mongodb/mongodbatlas"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 }

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -1,0 +1,85 @@
+# MongoDB Atlas Provider — M30 Multi-Shard Cluster (2 Shards)
+
+This example creates an Atlas project and a **two-shard M30 sharded cluster** using the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource. This is the recommended configuration for workloads that have outgrown a single replica set and need horizontal write scaling or want to distribute data across multiple shards.
+
+Both shards are configured symmetrically (same instance size and region), which simplifies capacity planning and ensures even data distribution with a standard hashing shard key.
+
+## Topology
+
+The cluster distributes data across two shards as follows:
+
+- Shard 1 — `US_EAST_1` (AWS), 3 electable nodes, instance size M30
+- Shard 2 — `US_EAST_1` (AWS), 3 electable nodes, instance size M30
+
+ **Tip:** To add a third shard, append another `replication_specs` block with the same shape as shards 1 and 2. Atlas performs a live online shard addition — no downtime is required.
+
+## Prerequisites
+
+To run this example, ensure you have the following tools:
+
+- Terraform MongoDB Atlas Provider v2.0.0 or later
+- A [MongoDB Atlas account](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/)
+
+## Procedure
+
+Follow the next steps to run this example:
+
+1. Set Up your MongoDB Atlas Credentials
+
+   Create a `terraform.tfvars` file with your credentials:
+
+   ```hcl
+   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   atlas_client_id     = "<ATLAS_CLIENT_ID>"
+   atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
+   ```
+
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+
+2. Review your Terraform plan
+
+   The following command lists the resources that your configuration will create.
+
+   ```bash
+   terraform plan
+   ```
+
+   Review the following fields in the plan output before applying:
+
+   - `name`: The name of the cluster (default: `"m30-multi-shard"`)
+   - `cluster_type`: The type of cluster. Must be `"SHARDED"`
+   - `instance_size`: The instance size for all nodes. Set to `"M30"`
+   - `node_count`: The number of electable nodes per shard. Set to `3`
+   - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
+   - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
+   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
+   - `replication_specs`: Two entries, one per shard, each with identical region configuration
+
+3. Apply your configuration
+
+   The following command applies your configuration and creates the resources.
+
+   ```bash
+   terraform apply
+   ```
+
+   Note that the apply might take several minutes.
+
+4. Destroy the resources
+
+   The following command destroys the resources created by `terraform apply`.
+
+   ```bash
+   terraform destroy
+   ```
+
+## Variables
+
+The `terraform.tfvars` file must contain the following variables for the configuration to work:
+
+- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
+- `project_name`: The Atlas project name (default: `"m30-multi-shard-project"`)
+- `cluster_name`: The Atlas cluster name (default: `"m30-multi-shard"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -53,7 +53,7 @@ Follow the next steps to run this example:
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
    - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
    - `replication_specs`: Two entries, one per shard, each with identical region configuration
 
 3. Apply your configuration
@@ -66,7 +66,7 @@ Follow the next steps to run this example:
 
    Note that the apply might take several minutes.
 
-4. Destroy the resources
+4. (Optional) Destroy the resources
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -11,7 +11,7 @@ The cluster distributes data across two shards as follows:
 - Shard 1 — `US_EAST_1` (AWS), 3 electable nodes, instance size M30
 - Shard 2 — `US_EAST_1` (AWS), 3 electable nodes, instance size M30
 
- **Tip:** To add a third shard, append another `replication_specs` block with the same shape as shards 1 and 2. Atlas performs a live online shard addition — no downtime is required.
+ **Tip:** To add a third shard, append another `replication_specs` block with the same shape as shards 1 and 2. Atlas performs a live online shard addition with no downtime.
 
 ## Prerequisites
 

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -34,7 +34,7 @@ To run this example, perform the following steps:
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
 
-   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn more, see [Authentication Methods](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/provider-configuration#authentication-methods) in the MongoDB Atlas Provider documentation.
 
 2. Review your Terraform plan.
 

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -22,9 +22,9 @@ To run this example, ensure you have the following tools:
 
 ## Procedure
 
-Follow the next steps to run this example:
+To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials
+1. Set Up your MongoDB Atlas Credentials.
 
    Create a `terraform.tfvars` file with your credentials:
 
@@ -36,9 +36,9 @@ Follow the next steps to run this example:
 
    Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
 
-2. Review your Terraform plan
+2. Review your Terraform plan.
 
-   The following command lists the resources that your configuration will create.
+   The following command lists the resources that your configuration creates.
 
    ```bash
    terraform plan
@@ -52,11 +52,11 @@ Follow the next steps to run this example:
    - `node_count`: The number of electable nodes per shard. Set to `3`
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
-   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
    - `replication_specs`: Two entries, one per shard, each with identical region configuration
 
-3. Apply your configuration
+3. Apply your configuration.
 
    The following command applies your configuration and creates the resources.
 
@@ -64,9 +64,9 @@ Follow the next steps to run this example:
    terraform apply
    ```
 
-   Note that the apply might take several minutes.
+   This operation might take several minutes to complete.
 
-4. (Optional) Destroy the resources
+4. (Optional) Destroy the resources.
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -53,7 +53,7 @@ To run this example, perform the following steps:
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example.
    - `replication_specs`: Two entries, one per shard, each with identical region configuration
 
 3. Apply your configuration.

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -24,7 +24,7 @@ To run this example, ensure you have the following tools:
 
 To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials.
+1. Set up your MongoDB Atlas credentials.
 
    Create a `terraform.tfvars` file with your credentials:
 
@@ -46,14 +46,14 @@ To run this example, perform the following steps:
 
    Review the following fields in the plan output before applying:
 
-   - `name`: The name of the cluster (default: `"m30-multi-shard"`)
-   - `cluster_type`: The type of cluster. Must be `"SHARDED"`
-   - `instance_size`: The instance size for all nodes. Set to `"M30"`
-   - `node_count`: The number of electable nodes per shard. Set to `3`
-   - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
-   - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
+   - `name`: Name of the cluster (default: `"m30-multi-shard"`)
+   - `cluster_type`: Type of cluster. Must be `"SHARDED"`
+   - `instance_size`: Instance size for all nodes. Set to `"M30"`
+   - `node_count`: Number of electable nodes per shard. Set to `3`
+   - `provider_name`: Cloud service provider hosting the cluster. Set to `"AWS"`
+   - `region_name`: Cloud region where the cluster is deployed. Set to `"US_EAST_1"`
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example
    - `replication_specs`: Two entries, one per shard, each with identical region configuration
 
 3. Apply your configuration.
@@ -78,8 +78,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
-- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
-- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
-- `project_name`: The Atlas project name (default: `"m30-multi-shard-project"`)
-- `cluster_name`: The Atlas cluster name (default: `"m30-multi-shard"`)
+- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
+- `project_name`: Atlas project name (default: `"m30-multi-shard-project"`)
+- `cluster_name`: Atlas cluster name (default: `"m30-multi-shard"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -78,8 +78,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
-- `project_name`: MongoDB Atlas project name (default: `"m30-multi-shard-project"`)
-- `cluster_name`: MongoDB Atlas cluster name (default: `"m30-multi-shard"`)
+- `project_name`: MongoDB Atlas project name (default: `"m30-multi-shard-project"`
+- `cluster_name`: MongoDB Atlas cluster name (default: `"m30-multi-shard"`

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -29,7 +29,7 @@ To run this example, perform the following steps:
    Create a `terraform.tfvars` file with your credentials:
 
    ```hcl
-   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   org_id              = "<MONGODB_ATLAS_ORG_ID>"
    atlas_client_id     = "<ATLAS_CLIENT_ID>"
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
@@ -78,7 +78,7 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: The MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
 - `project_name`: The Atlas project name (default: `"m30-multi-shard-project"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/README.md
@@ -78,8 +78,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
-- `project_name`: Atlas project name (default: `"m30-multi-shard-project"`)
-- `cluster_name`: Atlas cluster name (default: `"m30-multi-shard"`)
+- `project_name`: MongoDB Atlas project name (default: `"m30-multi-shard-project"`)
+- `cluster_name`: MongoDB Atlas cluster name (default: `"m30-multi-shard"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -1,0 +1,56 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+  base_url      = var.atlas_base_url
+}
+
+resource "mongodbatlas_advanced_cluster" "cluster" {
+  project_id     = mongodbatlas_project.project.id
+  name           = var.cluster_name
+  cluster_type   = "SHARDED"
+  backup_enabled = true
+
+  replication_specs = [
+    {
+      # shard 1
+      region_configs = [
+        {
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+            disk_size_gb  = 10
+          }
+          provider_name = "AWS"
+          priority      = 7
+          region_name   = "US_EAST_1"
+        }
+      ]
+    },
+    {
+      # shard 2
+      region_configs = [
+        {
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+            disk_size_gb  = 10
+          }
+          provider_name = "AWS"
+          priority      = 7
+          region_name   = "US_EAST_1"
+        }
+      ]
+    }
+  ]
+
+  termination_protection_enabled = false
+
+  tags = {
+    environment = "production"
+  }
+}
+
+resource "mongodbatlas_project" "project" {
+  name   = var.project_name
+  org_id = var.atlas_org_id
+}

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -57,7 +57,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   ]
 
-  termination_protection_enabled = false
+  termination_protection_enabled = true
 
   tags = {
     environment = "production"

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -1,7 +1,6 @@
 provider "mongodbatlas" {
   client_id     = var.atlas_client_id
   client_secret = var.atlas_client_secret
-  base_url      = var.atlas_base_url
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -16,7 +16,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30"
+            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
             node_count    = 3
             disk_size_gb  = 10
           }
@@ -31,7 +31,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30"
+            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
             node_count    = 3
             disk_size_gb  = 10
           }

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -4,8 +4,8 @@ provider "mongodbatlas" {
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {
-  project_id     = mongodbatlas_project.project.id
-  name           = var.cluster_name
+  project_id           = mongodbatlas_project.project.id
+  name                 = var.cluster_name
   cluster_type         = "SHARDED"
   backup_enabled       = true
   use_effective_fields = true

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -66,5 +66,5 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
 resource "mongodbatlas_project" "project" {
   name   = var.project_name
-  org_id = var.atlas_org_id
+  org_id = var.org_id
 }

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -24,7 +24,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             compute_enabled            = true
             compute_scale_down_enabled = true
             compute_min_instance_size  = "M30"
-            compute_max_instance_size  = "M80"
+            compute_max_instance_size  = "M50"
             disk_gb_enabled            = true
           }
           provider_name = "AWS"
@@ -46,7 +46,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             compute_enabled            = true
             compute_scale_down_enabled = true
             compute_min_instance_size  = "M30"
-            compute_max_instance_size  = "M80"
+            compute_max_instance_size  = "M50"
             disk_gb_enabled            = true
           }
           provider_name = "AWS"

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -6,8 +6,9 @@ provider "mongodbatlas" {
 resource "mongodbatlas_advanced_cluster" "cluster" {
   project_id     = mongodbatlas_project.project.id
   name           = var.cluster_name
-  cluster_type   = "SHARDED"
-  backup_enabled = true
+  cluster_type         = "SHARDED"
+  backup_enabled       = true
+  use_effective_fields = true
 
   replication_specs = [
     {
@@ -15,9 +16,16 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
+            instance_size = "M30" # paid — production-grade dedicated cluster; auto-scaling may increase this
             node_count    = 3
             disk_size_gb  = 10
+          }
+          auto_scaling = {
+            compute_enabled            = true
+            compute_scale_down_enabled = true
+            compute_min_instance_size  = "M30"
+            compute_max_instance_size  = "M80"
+            disk_gb_enabled            = true
           }
           provider_name = "AWS"
           priority      = 7
@@ -30,9 +38,16 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
+            instance_size = "M30" # paid — production-grade dedicated cluster; auto-scaling may increase this
             node_count    = 3
             disk_size_gb  = 10
+          }
+          auto_scaling = {
+            compute_enabled            = true
+            compute_scale_down_enabled = true
+            compute_min_instance_size  = "M30"
+            compute_max_instance_size  = "M80"
+            disk_gb_enabled            = true
           }
           provider_name = "AWS"
           priority      = 7

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/main.tf
@@ -16,7 +16,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30" # paid — production-grade dedicated cluster; auto-scaling may increase this
+            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
             node_count    = 3
             disk_size_gb  = 10
           }
@@ -38,7 +38,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30" # paid — production-grade dedicated cluster; auto-scaling may increase this
+            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
             node_count    = 3
             disk_size_gb  = 10
           }

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/variables.tf
@@ -1,0 +1,30 @@
+variable "atlas_base_url" {
+  description = "Atlas base URL (defaults to cloud.mongodb.com)"
+  type        = string
+  default     = "https://cloud.mongodb.com/"
+}
+variable "atlas_org_id" {
+  description = "Atlas organization id"
+  type        = string
+}
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "project_name" {
+  description = "Atlas project name"
+  type        = string
+  default     = "m30-multi-shard-project"
+}
+variable "cluster_name" {
+  description = "Atlas cluster name"
+  type        = string
+  default     = "m30-multi-shard"
+}

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/variables.tf
@@ -1,4 +1,4 @@
-variable "atlas_org_id" {
+variable "org_id" {
   description = "Atlas organization id"
   type        = string
 }

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/variables.tf
@@ -1,8 +1,3 @@
-variable "atlas_base_url" {
-  description = "Atlas base URL (defaults to cloud.mongodb.com)"
-  type        = string
-  default     = "https://cloud.mongodb.com/"
-}
 variable "atlas_org_id" {
   description = "Atlas organization id"
   type        = string

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/examples/mongodbatlas_advanced_cluster/m30-multi-shard/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-multi-shard/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "mongodb/mongodbatlas"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 }

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -52,7 +52,7 @@ Follow the next steps to run this example:
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
    - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
 
 3. Apply your configuration
 
@@ -64,7 +64,7 @@ Follow the next steps to run this example:
 
    Note that the apply might take several minutes.
 
-4. Destroy the resources
+4. (Optional) Destroy the resources
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -1,0 +1,83 @@
+# MongoDB Atlas Provider — Simple M30 Single-Shard Cluster
+
+This example creates an Atlas project and a **single-shard M30 sharded cluster** using the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource. Starting with a single-shard `SHARDED` cluster (rather than a `REPLICASET`) allows you to scale horizontally by adding more shards later without migrating data or recreating the cluster.
+
+This is a good fit for applications that expect significant data growth or write volume over time and want to avoid a future migration from a replica set to a sharded cluster.
+
+## Topology
+
+The cluster runs a single shard as follows:
+
+- Shard 1 — `US_EAST_1` (AWS), three electable nodes, instance size M30
+
+Each shard runs as a three-node replica set internally, so all the automatic failover and data redundancy guarantees of a replica set apply to each shard.
+
+## Prerequisites
+
+To run this example, ensure you have the following tools:
+
+- Terraform MongoDB Atlas Provider v2.0.0 or later
+- A [MongoDB Atlas account](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/)
+
+## Procedure
+
+Follow the next steps to run this example:
+
+1. Set Up your MongoDB Atlas Credentials
+
+   Create a `terraform.tfvars` file with your credentials:
+
+   ```hcl
+   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   atlas_client_id     = "<ATLAS_CLIENT_ID>"
+   atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
+   ```
+
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+
+2. Review your Terraform plan
+
+   The following command lists the resources that your configuration will create.
+
+   ```bash
+   terraform plan
+   ```
+
+   Review the following fields in the plan output before applying:
+
+   - `name`: The name of the cluster (default: `"m30-single-shard"`)
+   - `cluster_type`: The type of cluster. Must be `"SHARDED"`
+   - `instance_size`: The instance size for all nodes. Set to `"M30"`
+   - `node_count`: The number of electable nodes per shard. Set to `3`
+   - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
+   - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
+   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flags whether termination protection is enabled. If enabled, you cannot destroy the cluster using `terraform destroy`. Set to `false`
+
+3. Apply your configuration
+
+   The following command applies your configuration and creates the resources.
+
+   ```bash
+   terraform apply
+   ```
+
+   Note that the apply might take several minutes.
+
+4. Destroy the resources
+
+   The following command destroys the resources created by `terraform apply`.
+
+   ```bash
+   terraform destroy
+   ```
+
+## Variables
+
+The `terraform.tfvars` file must contain the following variables for the configuration to work:
+
+- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
+- `project_name`: The Atlas project name (default: `"m30-single-shard-project"`)
+- `cluster_name`: The Atlas cluster name (default: `"m30-single-shard"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -21,9 +21,9 @@ To run this example, ensure you have the following tools:
 
 ## Procedure
 
-Follow the next steps to run this example:
+To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials
+1. Set Up your MongoDB Atlas Credentials.
 
    Create a `terraform.tfvars` file with your credentials:
 
@@ -35,9 +35,9 @@ Follow the next steps to run this example:
 
    Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
 
-2. Review your Terraform plan
+2. Review your Terraform plan.
 
-   The following command lists the resources that your configuration will create.
+   The following command lists the resources that your configuration creates.
 
    ```bash
    terraform plan
@@ -51,10 +51,10 @@ Follow the next steps to run this example:
    - `node_count`: The number of electable nodes per shard. Set to `3`
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
-   - `backup_enabled`: Flags whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flags whether termination protection is enabled on the cluster. If set to `true`, you cannot delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
 
-3. Apply your configuration
+3. Apply your configuration.
 
    The following command applies your configuration and creates the resources.
 
@@ -62,9 +62,9 @@ Follow the next steps to run this example:
    terraform apply
    ```
 
-   Note that the apply might take several minutes.
+   This operation might take several minutes to complete.
 
-4. (Optional) Destroy the resources
+4. (Optional) Destroy the resources.
 
    The following command destroys the resources created by `terraform apply`.
 

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -2,7 +2,7 @@
 
 This example creates an Atlas project and a **single-shard M30 sharded cluster** using the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource. Starting with a single-shard `SHARDED` cluster (rather than a `REPLICASET`) allows you to scale horizontally by adding more shards later without migrating data or recreating the cluster.
 
-This is a good fit for applications that expect significant data growth or write volume over time and want to avoid a future migration from a replica set to a sharded cluster.
+This is a useful for applications that expect significant data growth or write volume over time and want to avoid a future migration from a replica set to a sharded cluster.
 
 ## Topology
 
@@ -10,7 +10,7 @@ The cluster runs a single shard as follows:
 
 - Shard 1 — `US_EAST_1` (AWS), three electable nodes, instance size M30
 
-Each shard runs as a three-node replica set internally, so all the automatic failover and data redundancy guarantees of a replica set apply to each shard.
+The shard runs as a three-node replica set internally and so, all the automatic failover and data redundancy guarantees of a replica set apply to the shard.
 
 ## Prerequisites
 

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -28,7 +28,7 @@ To run this example, perform the following steps:
    Create a `terraform.tfvars` file with your credentials:
 
    ```hcl
-   atlas_org_id        = "<MONGODB_ATLAS_ORG_ID>"
+   org_id              = "<MONGODB_ATLAS_ORG_ID>"
    atlas_client_id     = "<ATLAS_CLIENT_ID>"
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
@@ -76,7 +76,7 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `atlas_org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: The MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
 - `project_name`: The Atlas project name (default: `"m30-single-shard-project"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -33,7 +33,7 @@ To run this example, perform the following steps:
    atlas_client_secret = "<ATLAS_CLIENT_SECRET>"
    ```
 
-   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn how to create a Service Account, see [Manage Service Accounts](https://www.mongodb.com/docs/atlas/configure-api-access/#manage-service-accounts) in the Atlas documentation.
+   Service Accounts are the recommended way to authenticate with the MongoDB Atlas API. To learn more, see [Authentication Methods](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/provider-configuration#authentication-methods) in the MongoDB Atlas Provider documentation.
 
 2. Review your Terraform plan.
 

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -76,8 +76,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
-- `project_name`: MongoDB Atlas project name (default: `"m30-single-shard-project"`)
-- `cluster_name`: MongoDB Atlas cluster name (default: `"m30-single-shard"`)
+- `project_name`: MongoDB Atlas project name (default: `"m30-single-shard-project"`
+- `cluster_name`: MongoDB Atlas cluster name (default: `"m30-single-shard"`

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -52,7 +52,7 @@ To run this example, perform the following steps:
    - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
    - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `false` for development. Set as `true` before moving to a production environment.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example.
 
 3. Apply your configuration.
 

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -76,8 +76,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `org_id`: ID of the MongoDB Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
-- `project_name`: Atlas project name (default: `"m30-single-shard-project"`)
-- `cluster_name`: Atlas cluster name (default: `"m30-single-shard"`)
+- `project_name`: MongoDB Atlas project name (default: `"m30-single-shard-project"`)
+- `cluster_name`: MongoDB Atlas cluster name (default: `"m30-single-shard"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -23,7 +23,7 @@ To run this example, ensure you have the following tools:
 
 To run this example, perform the following steps:
 
-1. Set Up your MongoDB Atlas Credentials.
+1. Set up your MongoDB Atlas credentials.
 
    Create a `terraform.tfvars` file with your credentials:
 
@@ -45,14 +45,14 @@ To run this example, perform the following steps:
 
    Review the following fields in the plan output before applying:
 
-   - `name`: The name of the cluster (default: `"m30-single-shard"`)
-   - `cluster_type`: The type of cluster. Must be `"SHARDED"`
-   - `instance_size`: The instance size for all nodes. Set to `"M30"`
-   - `node_count`: The number of electable nodes per shard. Set to `3`
-   - `provider_name`: The cloud service provider hosting the cluster. Set to `"AWS"`
-   - `region_name`: The cloud region where the cluster is deployed. Set to `"US_EAST_1"`
+   - `name`: Name of the cluster (default: `"m30-single-shard"`)
+   - `cluster_type`: Type of cluster. Must be `"SHARDED"`
+   - `instance_size`: Instance size for all nodes. Set to `"M30"`
+   - `node_count`: Number of electable nodes per shard. Set to `3`
+   - `provider_name`: Cloud service provider hosting the cluster. Set to `"AWS"`
+   - `region_name`: Cloud region where the cluster is deployed. Set to `"US_EAST_1"`
    - `backup_enabled`: Flag that specifies whether cloud backup is enabled. Set to `true`
-   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example.
+   - `termination_protection_enabled`: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, you can't delete the cluster using `terraform destroy`. Set to `true` in this example
 
 3. Apply your configuration.
 
@@ -76,8 +76,8 @@ To run this example, perform the following steps:
 
 The `terraform.tfvars` file must contain the following variables for the configuration to work:
 
-- `org_id`: The ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
-- `atlas_client_id`: The MongoDB Atlas Service Account Client ID
-- `atlas_client_secret`: The MongoDB Atlas Service Account Client Secret
-- `project_name`: The Atlas project name (default: `"m30-single-shard-project"`)
-- `cluster_name`: The Atlas cluster name (default: `"m30-single-shard"`)
+- `org_id`: ID of the Atlas organization. To learn how to retrieve an organization's details, see [View Organizations](https://www.mongodb.com/docs/atlas/access/orgs-create-view-edit-delete/#view-organizations) in the Atlas documentation.
+- `atlas_client_id`: MongoDB Atlas Service Account Client ID
+- `atlas_client_secret`: MongoDB Atlas Service Account Client Secret
+- `project_name`: Atlas project name (default: `"m30-single-shard-project"`)
+- `cluster_name`: Atlas cluster name (default: `"m30-single-shard"`)

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/README.md
@@ -10,7 +10,7 @@ The cluster runs a single shard as follows:
 
 - Shard 1 — `US_EAST_1` (AWS), three electable nodes, instance size M30
 
-The shard runs as a three-node replica set internally and so, all the automatic failover and data redundancy guarantees of a replica set apply to the shard.
+The shard runs as a three-node replica set internally. All the automatic failover and data redundancy guarantees of a replica set apply to the shard.
 
 ## Prerequisites
 

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -1,0 +1,41 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+  base_url      = var.atlas_base_url
+}
+
+resource "mongodbatlas_advanced_cluster" "cluster" {
+  project_id     = mongodbatlas_project.project.id
+  name           = var.cluster_name
+  cluster_type   = "SHARDED"
+  backup_enabled = true
+
+  replication_specs = [
+    {
+      # shard 1
+      region_configs = [
+        {
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+            disk_size_gb  = 10
+          }
+          provider_name = "AWS"
+          priority      = 7
+          region_name   = "US_EAST_1"
+        }
+      ]
+    }
+  ]
+
+  termination_protection_enabled = false
+
+  tags = {
+    environment = "production"
+  }
+}
+
+resource "mongodbatlas_project" "project" {
+  name   = var.project_name
+  org_id = var.atlas_org_id
+}

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -16,7 +16,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30"
+            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
             node_count    = 3
             disk_size_gb  = 10
           }

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -35,7 +35,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   ]
 
-  termination_protection_enabled = false
+  termination_protection_enabled = true
 
   tags = {
     environment = "production"

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -1,7 +1,6 @@
 provider "mongodbatlas" {
   client_id     = var.atlas_client_id
   client_secret = var.atlas_client_secret
-  base_url      = var.atlas_base_url
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -6,8 +6,9 @@ provider "mongodbatlas" {
 resource "mongodbatlas_advanced_cluster" "cluster" {
   project_id     = mongodbatlas_project.project.id
   name           = var.cluster_name
-  cluster_type   = "SHARDED"
-  backup_enabled = true
+  cluster_type         = "SHARDED"
+  backup_enabled       = true
+  use_effective_fields = true
 
   replication_specs = [
     {
@@ -15,9 +16,16 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
+            instance_size = "M30" # paid — production-grade dedicated cluster; auto-scaling may increase this
             node_count    = 3
             disk_size_gb  = 10
+          }
+          auto_scaling = {
+            compute_enabled            = true
+            compute_scale_down_enabled = true
+            compute_min_instance_size  = "M30"
+            compute_max_instance_size  = "M80"
+            disk_gb_enabled            = true
           }
           provider_name = "AWS"
           priority      = 7

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -4,8 +4,8 @@ provider "mongodbatlas" {
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {
-  project_id     = mongodbatlas_project.project.id
-  name           = var.cluster_name
+  project_id           = mongodbatlas_project.project.id
+  name                 = var.cluster_name
   cluster_type         = "SHARDED"
   backup_enabled       = true
   use_effective_fields = true

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -24,7 +24,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             compute_enabled            = true
             compute_scale_down_enabled = true
             compute_min_instance_size  = "M30"
-            compute_max_instance_size  = "M80"
+            compute_max_instance_size  = "M50"
             disk_gb_enabled            = true
           }
           provider_name = "AWS"

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -44,5 +44,5 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
 resource "mongodbatlas_project" "project" {
   name   = var.project_name
-  org_id = var.atlas_org_id
+  org_id = var.org_id
 }

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/main.tf
@@ -16,7 +16,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_configs = [
         {
           electable_specs = {
-            instance_size = "M30" # paid — production-grade dedicated cluster; auto-scaling may increase this
+            instance_size = "M30" # Paid tier. Production-grade dedicated cluster
             node_count    = 3
             disk_size_gb  = 10
           }

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/variables.tf
@@ -1,0 +1,30 @@
+variable "atlas_base_url" {
+  description = "Atlas base URL (defaults to cloud.mongodb.com)"
+  type        = string
+  default     = "https://cloud.mongodb.com/"
+}
+variable "atlas_org_id" {
+  description = "Atlas organization id"
+  type        = string
+}
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "project_name" {
+  description = "Atlas project name"
+  type        = string
+  default     = "m30-single-shard-project"
+}
+variable "cluster_name" {
+  description = "Atlas cluster name"
+  type        = string
+  default     = "m30-single-shard"
+}

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/variables.tf
@@ -1,4 +1,4 @@
-variable "atlas_org_id" {
+variable "org_id" {
   description = "Atlas organization id"
   type        = string
 }

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/variables.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/variables.tf
@@ -1,8 +1,3 @@
-variable "atlas_base_url" {
-  description = "Atlas base URL (defaults to cloud.mongodb.com)"
-  type        = string
-  default     = "https://cloud.mongodb.com/"
-}
 variable "atlas_org_id" {
   description = "Atlas organization id"
   type        = string

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/examples/mongodbatlas_advanced_cluster/m30-single-shard/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/m30-single-shard/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "mongodb/mongodbatlas"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 }


### PR DESCRIPTION
## Description

This PR generates new targeted examples for the following cluster configs:

- Free Tier
- Simple M10 replica (with recommended settings)
- Simple M30 2 single shard cluster (with recommended settings)
- 2-2-1 M10 replica for high availability (including odd node considerations (with recommended settings)
- Multi shard M30 (2 shards with recommended settings)

All examples have been tested. 

Link to any related issue(s): [DOCSP-57765](https://jira.mongodb.org/browse/DOCSP-57765)
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
