### PR TITLE
doc: Add cross-region AWS privatelink endpoint example

### DIFF
--- a/docs/resources/privatelink_endpoint.md
+++ b/docs/resources/privatelink_endpoint.md
@@ -37,6 +37,7 @@ resource "mongodbatlas_privatelink_endpoint" "cross_region" {
 
 ### Further Examples
 - [AWS PrivateLink Endpoint](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_privatelink_endpoint/aws)
+- [AWS Cross-Region PrivateLink Endpoint](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_privatelink_endpoint/aws/cross-region)
 - [Azure PrivateLink Endpoint](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_privatelink_endpoint/azure)
 - [GCP Private Service Connect Endpoint (Port-Mapped Architecture)](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.8.0/examples/mongodbatlas_privatelink_endpoint/gcp-port-mapped)
 

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/README.md
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/README.md
@@ -1,0 +1,78 @@
+# Example - Cluster Private Connection String via AWS Cross-Region PrivateLink
+
+Setup private connection to a [MongoDB Atlas Cluster](https://www.mongodb.com/basics/clusters/mongodb-cluster-setup) utilizing [Amazon Virtual Private Cloud (aws vpc)](https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html) with cross-region connectivity.
+
+Unlike the [geosharded example](../cluster-geosharded/) which creates a separate endpoint service per region, this example uses a single endpoint service with `supported_remote_regions` to accept connections from multiple AWS regions.
+
+## Dependencies
+
+* Terraform >= 1.0
+* An AWS account - provider.aws: version = "~> 5.0"
+* A MongoDB Atlas account - provider.mongodbatlas
+
+## Usage
+
+**1\. Ensure your AWS and MongoDB Atlas credentials are set up.**
+
+This can be done using environment variables:
+
+```bash
+export MONGODB_ATLAS_CLIENT_ID="<ATLAS_CLIENT_ID>"
+export MONGODB_ATLAS_CLIENT_SECRET="<ATLAS_CLIENT_SECRET>"
+```
+
+``` bash
+export AWS_SECRET_ACCESS_KEY='<AWS_SECRET_ACCESS_KEY>'
+export AWS_ACCESS_KEY_ID='<AWS_ACCESS_KEY_ID>'
+```
+
+... or follow as in the `variables.tf` file and create **terraform.tfvars** file with all the variable values, ex:
+```
+access_key      = "<AWS_ACCESS_KEY_ID>"
+secret_key      = "<AWS_SECRET_ACCESS_KEY>"
+client_id       = "<ATLAS_CLIENT_ID>"
+client_secret   = "<ATLAS_CLIENT_SECRET>"
+project_id      = "<ATLAS_PROJECT_ID>"
+cluster_name    = "aws-cross-region-private-connection"
+```
+
+**2\. Review the Terraform plan.**
+
+Execute the below command and ensure you are happy with the plan.
+
+``` bash
+$ terraform plan
+```
+This project currently does the below deployments:
+
+- MongoDB cluster - M10
+- AWS Custom VPC, Internet Gateway, Route Tables, Subnets in us-east-1 (primary)
+- AWS Custom VPC, Internet Gateway, Route Tables, Subnets in us-west-2 (remote)
+- PrivateLink Connection at MongoDB Atlas with cross-region support
+- VPC Endpoints in both regions connecting to the single Atlas endpoint service
+
+**3\. Execute the Terraform apply.**
+
+Now execute the plan to provision the AWS and Atlas resources.
+
+``` bash
+$ terraform apply
+```
+
+**4\. Destroy the resources.**
+
+Once you are finished your testing, ensure you destroy the resources to avoid unnecessary charges.
+
+``` bash
+$ terraform destroy
+```
+
+**What's the resource dependency chain?**
+1. `mongodbatlas_privatelink_endpoint` creates a single endpoint service with `supported_remote_regions` for cross-region connectivity.
+2. `aws_vpc_endpoint` in each region (east and west) connects to the same Atlas endpoint service.
+3. `mongodbatlas_privatelink_endpoint_service` links each VPC endpoint to Atlas.
+4. `mongodbatlas_advanced_cluster` depends on both endpoint services for private connection strings.
+
+**Cross-Region vs Multi-Region**
+
+The [geosharded example](../cluster-geosharded/) creates separate `mongodbatlas_privatelink_endpoint` resources per region. With `supported_remote_regions`, you create one endpoint service and connect from multiple regions, simplifying the setup.

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/atlas-cluster.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/atlas-cluster.tf
@@ -1,0 +1,22 @@
+resource "mongodbatlas_advanced_cluster" "this" {
+  project_id     = var.project_id
+  name           = var.cluster_name
+  cluster_type   = "REPLICASET"
+  backup_enabled = true
+
+  replication_specs = [{
+    region_configs = [{
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_EAST_1"
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 3
+      }
+    }]
+  }]
+  depends_on = [
+    mongodbatlas_privatelink_endpoint_service.pe_east_service,
+    mongodbatlas_privatelink_endpoint_service.pe_west_service,
+  ]
+}

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/atlas-privatelink.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/atlas-privatelink.tf
@@ -1,0 +1,25 @@
+# Create a single AWS PrivateLink endpoint service with cross-region support.
+# Instead of creating one endpoint service per region (see cluster-geosharded example),
+# this creates one endpoint service that accepts connections from both regions.
+resource "mongodbatlas_privatelink_endpoint" "pe_east" {
+  project_id               = var.project_id
+  provider_name            = "AWS"
+  region                   = var.aws_region_east
+  supported_remote_regions = [var.aws_region_west]
+}
+
+# Connect from the primary region (us-east-1).
+resource "mongodbatlas_privatelink_endpoint_service" "pe_east_service" {
+  project_id          = mongodbatlas_privatelink_endpoint.pe_east.project_id
+  endpoint_service_id = aws_vpc_endpoint.vpce_east.id
+  private_link_id     = mongodbatlas_privatelink_endpoint.pe_east.id
+  provider_name       = "AWS"
+}
+
+# Connect from the remote region (us-west-2) using the same endpoint service.
+resource "mongodbatlas_privatelink_endpoint_service" "pe_west_service" {
+  project_id          = mongodbatlas_privatelink_endpoint.pe_east.project_id
+  endpoint_service_id = aws_vpc_endpoint.vpce_west.id
+  private_link_id     = mongodbatlas_privatelink_endpoint.pe_east.id
+  provider_name       = "AWS"
+}

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/aws-vpc-east.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/aws-vpc-east.tf
@@ -1,0 +1,50 @@
+resource "aws_vpc_endpoint" "vpce_east" {
+  vpc_id             = aws_vpc.vpc_east.id
+  service_name       = mongodbatlas_privatelink_endpoint.pe_east.endpoint_service_name
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = [aws_subnet.subnet_east.id]
+  security_group_ids = [aws_security_group.sg_east.id]
+}
+
+resource "aws_vpc" "vpc_east" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_internet_gateway" "ig_east" {
+  vpc_id = aws_vpc.vpc_east.id
+}
+
+resource "aws_route" "route_east" {
+  route_table_id         = aws_vpc.vpc_east.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.ig_east.id
+}
+
+resource "aws_subnet" "subnet_east" {
+  vpc_id                  = aws_vpc.vpc_east.id
+  cidr_block              = "10.0.2.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "${var.aws_region_east}a"
+}
+
+resource "aws_security_group" "sg_east" {
+  name_prefix = "default-"
+  description = "Default security group for all instances in ${aws_vpc.vpc_east.id}"
+  vpc_id      = aws_vpc.vpc_east.id
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = [
+      aws_vpc.vpc_east.cidr_block,
+    ]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/aws-vpc-west.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/aws-vpc-west.tf
@@ -1,0 +1,56 @@
+resource "aws_vpc_endpoint" "vpce_west" {
+  provider           = aws.west
+  vpc_id             = aws_vpc.vpc_west.id
+  service_name       = mongodbatlas_privatelink_endpoint.pe_east.endpoint_service_name
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = [aws_subnet.subnet_west.id]
+  security_group_ids = [aws_security_group.sg_west.id]
+}
+
+resource "aws_vpc" "vpc_west" {
+  provider             = aws.west
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_internet_gateway" "ig_west" {
+  provider = aws.west
+  vpc_id   = aws_vpc.vpc_west.id
+}
+
+resource "aws_route" "route_west" {
+  provider               = aws.west
+  route_table_id         = aws_vpc.vpc_west.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.ig_west.id
+}
+
+resource "aws_subnet" "subnet_west" {
+  provider                = aws.west
+  vpc_id                  = aws_vpc.vpc_west.id
+  cidr_block              = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "${var.aws_region_west}b"
+}
+
+resource "aws_security_group" "sg_west" {
+  provider    = aws.west
+  name_prefix = "default-"
+  description = "Default security group for all instances in ${aws_vpc.vpc_west.id}"
+  vpc_id      = aws_vpc.vpc_west.id
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = [
+      aws_vpc.vpc_west.cidr_block,
+    ]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/output.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/output.tf
@@ -1,0 +1,19 @@
+locals {
+  private_endpoints = flatten([for cs in mongodbatlas_advanced_cluster.this.connection_strings : cs.private_endpoint])
+
+  connection_strings_east = [
+    for pe in local.private_endpoints : pe.srv_connection_string
+    if contains([for e in pe.endpoints : e.endpoint_id], aws_vpc_endpoint.vpce_east.id)
+  ]
+  connection_strings_west = [
+    for pe in local.private_endpoints : pe.srv_connection_string
+    if contains([for e in pe.endpoints : e.endpoint_id], aws_vpc_endpoint.vpce_west.id)
+  ]
+}
+
+output "connection_string_east" {
+  value = length(local.connection_strings_east) > 0 ? local.connection_strings_east[0] : ""
+}
+output "connection_string_west" {
+  value = length(local.connection_strings_west) > 0 ? local.connection_strings_west[0] : ""
+}

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/provider.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/provider.tf
@@ -1,0 +1,15 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+}
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.aws_region_east
+}
+provider "aws" {
+  alias      = "west"
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.aws_region_west
+}

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/variables.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/variables.tf
@@ -1,0 +1,38 @@
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "project_id" {
+  description = "Atlas project ID"
+  type        = string
+}
+variable "cluster_name" {
+  description = "Atlas cluster name"
+  default     = "aws-cross-region-private-connection"
+  type        = string
+}
+variable "access_key" {
+  description = "The access key for AWS Account"
+  type        = string
+}
+variable "secret_key" {
+  description = "The secret key for AWS Account"
+  type        = string
+}
+variable "aws_region_east" {
+  default     = "us-east-1"
+  description = "AWS Region East (primary endpoint service region)"
+  type        = string
+}
+variable "aws_region_west" {
+  default     = "us-west-2"
+  description = "AWS Region West (remote region for cross-region connectivity)"
+  type        = string
+}

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cross-region/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 1.0"
+}


### PR DESCRIPTION
## Description

Add example Terraform configuration demonstrating cross-region private endpoint connectivity using the `supported_remote_regions` attribute. Also adds the cross-region example snippet and link to the `privatelink_endpoint` resource documentation.

Link to any related issue(s): CLOUDP-390366

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

This PR is stacked on #4315 and adds the cross-region example files and documentation link.