### PR TITLE
CLOUDP-391406: add force_detach_policies, to allow terraform manage the clean up the iam resource

### DIFF
--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -1066,6 +1066,7 @@ func configureAWSLambda(projectID, instanceName, connectionName, awsIamRoleName 
 	config := fmt.Sprintf(`
 		resource "aws_iam_role" "test_role" {
 			name = %[4]q
+			force_detach_policies = true
 	  
 			assume_role_policy = jsonencode({
 				"Version" : "2012-10-17",


### PR DESCRIPTION

## Description

*  add force_detach_policies, to allow terraform manage the clean up the iam resource
* related to https://mongodb.slack.com/archives/C0A6DR06FC7/p1774055425487509
* The AWS account used for testing has reached the hard limit for IAM roles (1750).
Recommended Actions:

Cleanup Old IAM Roles: Manually or through automation/scripts, delete old or unused IAM roles in the AWS account to free up space.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
