### PR TITLE
feat: add desired_timestamp computed field to cloud-backup-snapshot-restore-job

### DIFF
--- a/docs/data-sources/cloud_backup_snapshot_restore_job.md
+++ b/docs/data-sources/cloud_backup_snapshot_restore_job.md
@@ -63,5 +63,8 @@ In addition to all arguments above, the following attributes are exported:
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
 * `oplogInc` - Oplog operation number from which to you want to restore this snapshot.
 * `pointInTimeUTCSeconds` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
+* `desired_timestamp` - BSON timestamp that indicates when the checkpoint token entry in the oplog occurred. Only populated for point-in-time restore jobs.
+  * `desired_timestamp.date` - Date and time when the oplog recorded this database operation, in ISO 8601 format.
+  * `desired_timestamp.increment` - Order of the database operation that the oplog recorded at that date and time.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/restore/get-one-restore-job/)

--- a/docs/data-sources/cloud_backup_snapshot_restore_jobs.md
+++ b/docs/data-sources/cloud_backup_snapshot_restore_jobs.md
@@ -70,6 +70,9 @@ In addition to all arguments above, the following attributes are exported:
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
 * `oplogInc` - Oplog operation number from which to you want to restore this snapshot.
 * `pointInTimeUTCSeconds` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
+* `desired_timestamp` - BSON timestamp that indicates when the checkpoint token entry in the oplog occurred. Only populated for point-in-time restore jobs.
+  * `desired_timestamp.date` - Date and time when the oplog recorded this database operation, in ISO 8601 format.
+  * `desired_timestamp.increment` - Order of the database operation that the oplog recorded at that date and time.
 
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/restore/get-all-restore-jobs/)

--- a/docs/resources/cloud_backup_snapshot_restore_job.md
+++ b/docs/resources/cloud_backup_snapshot_restore_job.md
@@ -203,6 +203,9 @@ In addition to all arguments above, the following attributes are exported:
     Two conditions apply to this parameter:
     * Enable Continuous Cloud Backup on your cluster.
     * Specify either pointInTimeUTCSeconds or oplogTs and oplogInc, but not both.
+* `desired_timestamp` - BSON timestamp that indicates when the checkpoint token entry in the oplog occurred. Only populated for point-in-time restore jobs.
+  * `desired_timestamp.date` - Date and time when the oplog recorded this database operation, in ISO 8601 format.
+  * `desired_timestamp.increment` - Order of the database operation that the oplog recorded at that date and time.
 
 ## Import
 

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
@@ -86,6 +86,22 @@ func DataSource() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"desired_timestamp": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"increment": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -132,6 +148,10 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if err = d.Set("oplog_inc", snapshotRes.GetOplogInc()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `oplog_inc` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
+	}
+
+	if err = d.Set("desired_timestamp", FlattenDesiredTimestamp(snapshotRes.DesiredTimestamp)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `desired_timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
 	d.SetId(snapshotRes.GetId())

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
@@ -100,6 +100,22 @@ func PluralDataSource() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"desired_timestamp": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"date": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"increment": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -164,6 +180,7 @@ func flattenCloudProviderSnapshotRestoreJobs(cloudProviderSnapshotRestoreJobs []
 				"oplog_ts":                  cloudProviderSnapshotRestoreJob.GetOplogTs(),
 				"point_in_time_utc_seconds": cloudProviderSnapshotRestoreJob.GetPointInTimeUTCSeconds(),
 				"oplog_inc":                 cloudProviderSnapshotRestoreJob.GetOplogInc(),
+				"desired_timestamp":         FlattenDesiredTimestamp(cloudProviderSnapshotRestoreJob.DesiredTimestamp),
 			}
 		}
 	}

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
@@ -124,6 +124,22 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"desired_timestamp": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"increment": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -207,7 +223,23 @@ func setCommonFields(d *schema.ResourceData, snapshotReq *admin.DiskBackupSnapsh
 		return diag.FromErr(fmt.Errorf("error setting `timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}
 
+	if err = d.Set("desired_timestamp", FlattenDesiredTimestamp(snapshotReq.DesiredTimestamp)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `desired_timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
+	}
+
 	return nil
+}
+
+func FlattenDesiredTimestamp(dt *admin.ApiBSONTimestamp) []map[string]any {
+	if dt == nil {
+		return nil
+	}
+	return []map[string]any{
+		{
+			"date":      conversion.TimePtrToStringPtr(dt.Date),
+			"increment": dt.GetIncrement(),
+		},
+	}
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_unit_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_unit_test.go
@@ -1,0 +1,61 @@
+package cloudbackupsnapshotrestorejob_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cloudbackupsnapshotrestorejob"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20250312016/admin"
+)
+
+func TestFlattenDesiredTimestamp(t *testing.T) {
+	sampleDate := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	sampleIncrement := 42
+
+	testCases := []struct {
+		name     string
+		input    *admin.ApiBSONTimestamp
+		expected []map[string]any
+	}{
+		{
+			name:     "nil input returns nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "populated timestamp",
+			input: &admin.ApiBSONTimestamp{
+				Date:      &sampleDate,
+				Increment: &sampleIncrement,
+			},
+			expected: []map[string]any{
+				{
+					"date":      conversion.StringPtr(sampleDate.Format(time.RFC3339)),
+					"increment": sampleIncrement,
+				},
+			},
+		},
+		{
+			name: "nil date and increment",
+			input: &admin.ApiBSONTimestamp{
+				Date:      nil,
+				Increment: nil,
+			},
+			expected: []map[string]any{
+				{
+					"date":      (*string)(nil),
+					"increment": 0,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cloudbackupsnapshotrestorejob.FlattenDesiredTimestamp(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `desired_timestamp` as a `Computed` attribute to `mongodbatlas_cloud_backup_snapshot_restore_job` resource
- Adds `desired_timestamp` to the singular data source `mongodbatlas_cloud_backup_snapshot_restore_job`
- Adds `desired_timestamp` to the plural data source `mongodbatlas_cloud_backup_snapshot_restore_jobs`

The field maps to `ApiBSONTimestamp` in the Atlas SDK, a nested object with:
- `date` (string) — ISO 8601 timestamp of when the oplog recorded the operation
- `increment` (int) — order of the DB operation at that timestamp

It is server-generated and only populated for point-in-time restore jobs.

## Test plan
- [ ] `TestFlattenDesiredTimestamp` unit test (3 cases: nil, populated, nil sub-fields) — passes
- [ ] `TestSdkV2Provider` schema validation — passes
- [ ] Acceptance test `TestAccCloudBackupSnapshotRestoreJob_basic` — requires `TF_ACC=1` and a live Atlas cluster

Closes CLOUDP-391549

Generated with [Claude Code](https://claude.com/claude-code)