### PR TITLE
chore: Fix `service_account_jwt` test regex and CI job gating

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -614,6 +614,7 @@ jobs:
           MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}        
         run: make access-token-revoke token="${{ steps.create-token.outputs.access_token }}"
 
+  # Always runs using Service Account credentials (explicitly set in step env)
   service_account_jwt:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.service_account_jwt == 'true' || inputs.test_group == 'service_account_jwt' }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -616,7 +616,7 @@ jobs:
 
   service_account_jwt:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ inputs.use_sa == true && (needs.change-detection.outputs.service_account_jwt == 'true' || inputs.test_group == 'service_account_jwt') }}
+    if: ${{ needs.change-detection.outputs.service_account_jwt == 'true' || inputs.test_group == 'service_account_jwt' }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -632,6 +632,10 @@ jobs:
           terraform_wrapper: false
       - name: Acceptance Tests (Service Account JWT)
         env:
+          MONGODB_ATLAS_PUBLIC_KEY: ""
+          MONGODB_ATLAS_PRIVATE_KEY: ""
+          MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_REGEX_RUN: '^TestAccServiceAccountJWT'
           ACCTEST_PACKAGES: ./internal/service/serviceaccountjwt

--- a/internal/config/credential_resolver.go
+++ b/internal/config/credential_resolver.go
@@ -6,6 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
+const ErrPartialCreds = "Both client_id and client_secret must be provided together." //nolint:gosec // not a credential
+
 type CredentialResolver struct {
 	ProviderData *EphemeralResourceData
 }
@@ -23,7 +25,7 @@ func (cr *CredentialResolver) ResolveServiceAccountCredentials(argClientID, argC
 		return id, secret, cr.providerBaseURL(), diags
 	} else if id != "" || secret != "" {
 		diags.AddError("Invalid Service Account credentials",
-			"Both client_id and client_secret must be provided together.")
+			ErrPartialCreds)
 		return "", "", "", diags
 	}
 

--- a/internal/service/serviceaccountjwt/resource_test.go
+++ b/internal/service/serviceaccountjwt/resource_test.go
@@ -96,7 +96,7 @@ func TestAccServiceAccountJWT_partialResourceCredentials(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configPartialCredentials(),
-				ExpectError: regexp.MustCompile(`(?s)both client_id and\s+client_secret must be provided`),
+				ExpectError: regexp.MustCompile(`(?s)Both client_id and\s+client_secret must be provided`),
 			},
 		},
 	})

--- a/internal/service/serviceaccountjwt/resource_test.go
+++ b/internal/service/serviceaccountjwt/resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -96,7 +97,7 @@ func TestAccServiceAccountJWT_partialResourceCredentials(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configPartialCredentials(),
-				ExpectError: regexp.MustCompile(`(?s)Both client_id and\s+client_secret must be provided`),
+				ExpectError: regexp.MustCompile(config.ErrPartialCreds),
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/23467165590/job/68281954647 (todays nightly run)

Fixes `TestAccServiceAccountJWT_partialResourceCredentials` test failure caused by a case mismatch in the `ExpectError` regex (`both` vs `Both`).

Also removes the `use_sa == true` gate from the `service_account_jwt` CI job. Previously, these tests only ran during scheduled SA runs (Tue/Thu/Sat), meaning changes to this package were never validated in PRs or non-SA nightly runs. With this change, the `service_account_jwt` job will run:
- On **all nightly runs**, independent of the `use_sa` flag
- On **PRs that modify files** in `internal/service/serviceaccountjwt/`

The job now explicitly sets SA credentials and blanks PAKs in the step env, following the same pattern as the `authentication` job, ensuring it authenticates correctly regardless of the global auth mode.



## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments