### PR TITLE
chore: Fix flaky `TestAccProject_basic` by setting items_per_page

### DIFF
--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -1241,6 +1241,7 @@ func configBasic(orgID, projectName, projectOwnerID string, includeDataSource bo
 			}
 			data "mongodbatlas_projects" "test" {
 				depends_on = [mongodbatlas_project.test]
+				items_per_page = 250
 			}
 		`
 	}


### PR DESCRIPTION
## Description

`TestAccProject_basic` has been consistently failing in the last 2 nightly CI runs with:
```
Post-apply refresh state check(s) failed:
    none of the results.*.name matched
```

### Root cause

The test creates a project and then verifies it appears in the `mongodbatlas_projects` plural data source via a `ConfigStateChecks` that iterates over `results` looking for a matching `name`. The plural data source config had no `items_per_page` set.

When `items_per_page` is omitted, the Atlas API defaults to returning 100 results per page. The CI org currently has **149 projects**, so the newly created test project can land on page 2 and never be seen by the state check.

### Fix

Set `items_per_page = 250` in the plural data source config. 250 is the maximum number of projects an Atlas organization can have, so this guarantees all projects are returned in a single page.

Will follow up on revising our cleanup process and why our org currently has over 100 projects.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.