### PR TITLE
chore: Fix cleanup process to list all org projects

### DIFF
--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -88,7 +88,9 @@ func TestCleanProjectAndClusters(t *testing.T) {
 		require.NoError(t, err)
 		runRetries = attempts
 	}
-	projects := readAllProjects(t.Context(), t, client)
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	require.NotEmpty(t, orgID, "MONGODB_ATLAS_ORG_ID must be set")
+	projects := readAllProjects(t.Context(), t, client, orgID)
 	projectsBefore := len(projects)
 	t.Logf("found %d projects (DRY_RUN=%t)", projectsBefore, dryRun)
 	projectsToClean := map[string]string{}
@@ -146,15 +148,13 @@ func TestCleanProjectAndClusters(t *testing.T) {
 		})
 	}
 	t.Cleanup(func() {
-		projectsAfter := readAllProjects(context.Background(), t, client) // reason: using context.Background() here intentionally because t.Context() is canceled at cleanup
+		projectsAfter := readAllProjects(context.Background(), t, client, orgID) // reason: using context.Background() here intentionally because t.Context() is canceled at cleanup
 		t.Logf("SUMMARY\nProjects changed from %d to %d\ndelete_errors=%d\nempty_project_count=%d\nDRY_RUN=%t", projectsBefore, len(projectsAfter), deleteErrors, emptyProjectCount, dryRun)
 	})
 }
 
-func readAllProjects(ctx context.Context, t *testing.T, client *admin.APIClient) []admin.Group {
+func readAllProjects(ctx context.Context, t *testing.T, client *admin.APIClient, orgID string) []admin.Group {
 	t.Helper()
-	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
-	require.NotEmpty(t, orgID, "MONGODB_ATLAS_ORG_ID must be set")
 	projects, err := dsschema.AllPages(ctx, func(ctx context.Context, pageNum int) (dsschema.PaginateResponse[admin.Group], *http.Response, error) {
 		return client.OrganizationsApi.GetOrgGroups(ctx, orgID).ItemsPerPage(itemsPerPage).PageNum(pageNum).Execute()
 	})

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -153,8 +153,10 @@ func TestCleanProjectAndClusters(t *testing.T) {
 
 func readAllProjects(ctx context.Context, t *testing.T, client *admin.APIClient) []admin.Group {
 	t.Helper()
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	require.NotEmpty(t, orgID, "MONGODB_ATLAS_ORG_ID must be set")
 	projects, err := dsschema.AllPages(ctx, func(ctx context.Context, pageNum int) (dsschema.PaginateResponse[admin.Group], *http.Response, error) {
-		return client.ProjectsApi.ListGroups(ctx).ItemsPerPage(itemsPerPage).PageNum(pageNum).Execute()
+		return client.OrganizationsApi.GetOrgGroups(ctx, orgID).ItemsPerPage(itemsPerPage).PageNum(pageNum).Execute()
 	})
 	require.NoError(t, err)
 	return projects


### PR DESCRIPTION
## Description

The nightly cleanup process (`TestCleanProjectAndClusters`) is failing to remove orphaned test projects because it only sees a fraction of the projects in the org.

### Current state of the cloud-dev org (before fix)

The org had **149 projects**, of which **128 were bot projects** (prefixed with `test-acc-tf-p-` or `cfn-test-bot-`) that should have been cleaned up. These had been accumulating since mid-February, with large spikes on Mar 7 (37), Mar 12 (30), and Mar 19 (25).

### What cleanup was doing before the fix

In the latest nightly run (2026-03-25), the `clean-before` job logs showed:

```
found 24 projects (DRY_RUN=false)
deleting project resources and optionally delete projects for 3 projects
```

The cleanup only found **24 projects** out of 149, and only 3 of those matched the bot prefix criteria for deletion. The remaining 125 bot projects were invisible to it.

### Root cause

`readAllProjects` called `client.ProjectsApi.ListGroups(ctx)` which hits the `/api/atlas/v2/groups` endpoint. This endpoint only returns **projects the authenticated API key is a member of**, not all projects in the organization. Projects created by test runs may add the API key as project owner during creation, but if that doesn't happen (or the key is different), those projects are invisible.

### Fix

Switch to `client.OrganizationsApi.GetOrgGroups(ctx, orgID)` which hits `/api/atlas/v2/orgs/{orgId}/groups`. This returns **all projects in the organization** regardless of API key membership. The `MONGODB_ATLAS_ORG_ID` env var is already set in the `cleanup-test-env.yml` workflow for both dev and QA jobs.

### Verification

The cleanup workflow was [manually triggered](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/23545876571) using this branch (`fix-cleanup-process`). Results:

```
found 149 projects (DRY_RUN=false)
deleting project resources and optionally delete projects for 128 projects
SUMMARY
  delete_errors=1
  empty_project_count=1
  DRY_RUN=false
```

The org went from **149 projects down to 23** (21 non-bot + 1 intentionally kept + 1 with active clusters pending next cleanup cycle).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.