### PR TITLE
chore: Replace failing flex timeout test with replicaset timeout test

### DIFF
--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -1123,8 +1123,9 @@ type basicReplicasetConfig struct {
 
 func configBasicReplicaset(t *testing.T, cfg *basicReplicasetConfig) string {
 	t.Helper()
-	if cfg.TimeoutStr == "" {
-		cfg.TimeoutStr = `
+	timeoutStr := cfg.TimeoutStr
+	if timeoutStr == "" {
+		timeoutStr = `
 			timeouts = {
 				create = "6000s"
 			}`
@@ -1154,7 +1155,7 @@ func configBasicReplicaset(t *testing.T, cfg *basicReplicasetConfig) string {
 			}]
 			%[3]s
 		}
-	`, cfg.ProjectID, cfg.ClusterName, cfg.Extra, cfg.TimeoutStr, cfg.InstanceSize) + dataSourcesConfig
+	`, cfg.ProjectID, cfg.ClusterName, cfg.Extra, timeoutStr, cfg.InstanceSize) + dataSourcesConfig
 }
 
 func configSharded(t *testing.T, projectID, clusterName string, withUpdate bool) string {
@@ -2900,6 +2901,7 @@ func TestAccAdvancedCluster_updateDeleteTimeoutReplicaset(t *testing.T) {
 		timeoutConfig          = acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout)
 	)
 	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -1,6 +1,7 @@
 package advancedcluster_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
 )
@@ -2900,6 +2902,15 @@ func TestAccAdvancedCluster_updateDeleteTimeoutReplicaset(t *testing.T) {
 		deleteTimeout          = "1s"
 		timeoutConfig          = acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout)
 	)
+	t.Cleanup(func() {
+		// Step 3 triggers cluster deletion but times out after 1s, leaving the cluster in DELETING state.
+		// We must wait for deletion to complete before test cleanup tries to delete the project.
+		stateConf := cluster.DeleteStateChangeConfig(context.Background(), acc.ConnV2(), projectID, clusterName, 15*time.Minute)
+		_, err := stateConf.WaitForStateContext(context.Background())
+		if err != nil {
+			t.Logf("Warning: error waiting for cluster %s deletion: %v", clusterName, err)
+		}
+	})
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -2903,6 +2903,9 @@ func TestAccAdvancedCluster_updateDeleteTimeoutReplicaset(t *testing.T) {
 		timeoutConfig          = acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout)
 	)
 	t.Cleanup(func() {
+		if acc.InUnitTest() {
+			return
+		}
 		// Step 3 triggers cluster deletion but times out after 1s, leaving the cluster in DELETING state.
 		// We must wait for deletion to complete before test cleanup tries to delete the project.
 		stateConf := cluster.DeleteStateChangeConfig(context.Background(), acc.ConnV2(), projectID, clusterName, 15*time.Minute)

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -962,15 +962,15 @@ func TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasicReplicaset(t, projectID, clusterName, "", ""),
+				Config: configBasicReplicaset(t, &basicReplicasetConfig{ProjectID: projectID, ClusterName: clusterName, InstanceSize: "M10"}),
 				Check:  checks,
 			},
 			{
-				Config: configBasicReplicaset(t, projectID, clusterName, fullUpdate, ""),
+				Config: configBasicReplicaset(t, &basicReplicasetConfig{ProjectID: projectID, ClusterName: clusterName, Extra: fullUpdate, InstanceSize: "M10"}),
 				Check:  checksUpdate,
 			},
 			{
-				Config: configBasicReplicaset(t, projectID, clusterName, "", ""),
+				Config: configBasicReplicaset(t, &basicReplicasetConfig{ProjectID: projectID, ClusterName: clusterName, InstanceSize: "M10"}),
 				Check:  checks,
 			},
 			acc.TestStepImportCluster(resourceName),
@@ -1052,7 +1052,7 @@ func TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateReplicaset(t *testing
 	var (
 		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
 		configCall             = func(timeoutSection string) string {
-			return configBasicReplicaset(t, projectID, clusterName, "", timeoutSection)
+			return configBasicReplicaset(t, &basicReplicasetConfig{ProjectID: projectID, ClusterName: clusterName, TimeoutStr: timeoutSection, InstanceSize: "M10"})
 		}
 		timeoutsStrShort = `
 			timeouts = {
@@ -1113,17 +1113,25 @@ func waitOnClusterDeleteDone(t *testing.T, projectID, clusterName string) {
 	time.Sleep(2 * time.Minute) // Decrease the chance of `CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP`: "A transient error occurred. Please try again in a minute or use a different name".
 }
 
-func configBasicReplicaset(t *testing.T, projectID, clusterName, extra, timeoutStr string) string {
+type basicReplicasetConfig struct {
+	ProjectID    string
+	ClusterName  string
+	Extra        string
+	TimeoutStr   string
+	InstanceSize string
+}
+
+func configBasicReplicaset(t *testing.T, cfg *basicReplicasetConfig) string {
 	t.Helper()
-	if timeoutStr == "" {
-		timeoutStr = `
+	if cfg.TimeoutStr == "" {
+		cfg.TimeoutStr = `
 			timeouts = {
 				create = "6000s"
 			}`
 	}
 	return fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
-			%[4]s		
+			%[4]s
 			project_id = %[1]q
 			name = %[2]q
 			cluster_type = "REPLICASET"
@@ -1139,14 +1147,14 @@ func configBasicReplicaset(t *testing.T, projectID, clusterName, extra, timeoutS
 					}
 					electable_specs = {
 						node_count = 3
-						instance_size = "M10"
+						instance_size = %[5]q
 						disk_size_gb = 10
 					}
 				}]
 			}]
 			%[3]s
 		}
-	`, projectID, clusterName, extra, timeoutStr) + dataSourcesConfig
+	`, cfg.ProjectID, cfg.ClusterName, cfg.Extra, cfg.TimeoutStr, cfg.InstanceSize) + dataSourcesConfig
 }
 
 func configSharded(t *testing.T, projectID, clusterName string, withUpdate bool) string {
@@ -2884,31 +2892,30 @@ func TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex(t *testing.T) {
 	})
 }
 
-func TestAccAdvancedCluster_updateDeleteTimeoutFlex(t *testing.T) {
+func TestAccAdvancedCluster_updateDeleteTimeoutReplicaset(t *testing.T) {
 	var (
-		projectID     = acc.ProjectIDExecution(t)
-		clusterName   = acc.RandomName()
-		updateTimeout = "1s"
-		deleteTimeout = "1s"
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
+		updateTimeout          = "1s"
+		deleteTimeout          = "1s"
+		timeoutConfig          = acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout)
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyFlexCluster,
+		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout), false, nil),
+				Config: configBasicReplicaset(t, &basicReplicasetConfig{ProjectID: projectID, ClusterName: clusterName, TimeoutStr: timeoutConfig, InstanceSize: "M10"}),
 			},
 			{
-				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout), true, nil),
+				Config:      configBasicReplicaset(t, &basicReplicasetConfig{ProjectID: projectID, ClusterName: clusterName, TimeoutStr: timeoutConfig, InstanceSize: "M20"}),
 				ExpectError: regexp.MustCompile("timeout while waiting for state to become 'IDLE'"),
 			},
 			{
 				Config:      acc.ConfigEmpty(), // triggers delete and because delete timeout is 1s, it times out
-				ExpectError: regexp.MustCompile("Error in flex delete"),
+				ExpectError: regexp.MustCompile("Error in delete"),
 			},
 			{
-				// deletion of the flex cluster has been triggered, but has timed out in previous step, so this is needed in order to avoid "Error running post-test destroy, there may be dangling resource [...] Cluster already requested to be deleted"
+				// deletion of the cluster has been triggered, but has timed out in previous step, so this is needed in order to avoid "Error running post-test destroy, there may be dangling resource"
 				Config: acc.ConfigRemove(resourceName),
 			},
 		},

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -2902,10 +2902,10 @@ func TestAccAdvancedCluster_updateDeleteTimeoutReplicaset(t *testing.T) {
 		deleteTimeout          = "1s"
 		timeoutConfig          = acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout)
 	)
+	// SkipInUnitTest is needed before t.Cleanup because the cleanup calls acc.ConnV2() which
+	// races with mock clients in unit test mode.
+	acc.SkipInUnitTest(t)
 	t.Cleanup(func() {
-		if acc.InUnitTest() {
-			return
-		}
 		// Step 3 triggers cluster deletion but times out after 1s, leaving the cluster in DELETING state.
 		// We must wait for deletion to complete before test cleanup tries to delete the project.
 		stateConf := cluster.DeleteStateChangeConfig(context.Background(), acc.ConnV2(), projectID, clusterName, 15*time.Minute)


### PR DESCRIPTION
## Description

### Why `TestAccAdvancedCluster_updateDeleteTimeoutFlex` test has been failing

`TestAccAdvancedCluster_updateDeleteTimeoutFlex` has been failing consistently since ~March 13, with the last passing run on March 15. The test's Step 2 expected that updating a flex cluster's tags with a 1s `update` timeout would trigger a timeout error (`timeout while waiting for state to become 'IDLE'`). However, flex cluster tag updates are now processed synchronously by the Atlas API.

Currently no flex cluster update would trigger an async operation. The only supported flex updates (tags and termination_protection_enabled) are lightweight metadata changes that never cause a state transition, making it impossible to test update timeout behavior with flex clusters.

### Current timeout test coverage

| Test | What it covers |
|------|---------------|
| `TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateReplicaset` | Create timeout + `delete_on_create_timeout` for dedicated clusters |
| `TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex` | Create timeout + `delete_on_create_timeout` for flex |
| `TestAccAdvancedCluster_updateDeleteTimeoutFlex` (broken) | Update timeout (always fails) + delete timeout for flex |

### Approach

The new test (`TestAccAdvancedCluster_updateDeleteTimeoutReplicaset`) uses a replicaset cluster and triggers an instance size change from M10 to M20 with a 1s update timeout. This scaling operation causes a real state transition (UPDATING → IDLE) that reliably exceeds the 1s timeout, properly validating the update timeout behavior. The test also validates delete timeout by attempting cluster deletion with a 1s timeout.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments