### PR TITLE
fix: Mark ldap_verify bind_password attribute as sensitive

### DIFF
--- a/.changelog/4349.txt
+++ b/.changelog/4349.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_ldap_verify: Fixes `bind_password` not being marked as sensitive
+```

--- a/internal/service/ldapverify/resource_ldap_verify.go
+++ b/internal/service/ldapverify/resource_ldap_verify.go
@@ -52,9 +52,10 @@ func Resource() *schema.Resource {
 				ForceNew: true,
 			},
 			"bind_password": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				ForceNew:  true,
 			},
 			"ca_certificate": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## Description

The `mongodbatlas_ldap_verify.bind_password` attribute was missing the Sensitive flag, so it appears in plaintext in the plan/apply output.
The same field in `mongodbatlas_ldap_configuration` is already marked as Sensitive.

Verified that the API does not return this field, the issue only happens when the user configuration is printed as part of a TF plan/apply.

Note that the acc tests were already ignoring the bind_password field on import: https://github.com/mongodb/terraform-provider-mongodbatlas/blob/1179b584dbdcb36b4a325399c3ed4266bc43e6e1/internal/service/ldapverify/resource_ldap_verify_test.go#L98

Link to any related issue(s): HELP-91249

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
