### PR TITLE
feat: Add GCPPubSub connection type support for stream connections

### DIFF
--- a/.changelog/4354.txt
+++ b/.changelog/4354.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds support for `GCPPubSub` connection type with `gcp` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connection: Adds support for `GCPPubSub` connection type with `gcp` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connections: Adds support for `GCPPubSub` connection type with `gcp` attribute
+```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -37,7 +37,7 @@ data "mongodbatlas_stream_connection" "example" {
 
 ## Attributes Reference
 
-* `type` - Type of connection. Can be `AWSLambda`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
+* `type` - Type of connection. Can be `AWSLambda`, `Cluster`, `GCPPubSub`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -53,6 +53,9 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 
 If `type` is of value `AWSLambda` the following additional attributes are defined:
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
+
+If `type` is of value `GCPPubSub` the following additional attributes are defined:
+* `gcp` - The configuration for GCP Pub/Sub connection. See [GCP](#GCP)
 
 If `type` is of value `Https` the following additional attributes are defined:
 * `url` - URL of the HTTPs endpoint that will be used for creating a connection.
@@ -94,6 +97,9 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 
 ### AWS
 * `role_arn` - Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account. 
+
+### GCP
+* `service_account_id` - Email address of the Google Cloud Platform (GCP) service account that Atlas Streams uses to connect to GCP Pub/Sub resources.
 
 ### Schema Registry Authentication
 * `type` - Authentication type discriminator. Specifies the authentication mechanism for Confluent Schema Registry. Valid values are `USER_INFO` or `SASL_INHERIT`.

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -39,7 +39,7 @@ In addition to all arguments above, it also exports the following attributes:
 * `project_id` - Unique 24-hexadecimal digit string that identifies your project.
 * `workspace_name` - Label that identifies the stream processing workspace.
 * `connection_name` - Label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - Type of connection. `AWSLambda`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
+* `type` - Type of connection. `AWSLambda`, `Cluster`, `GCPPubSub`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -54,6 +54,9 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 
 If `type` is of value `AWSLambda` the following additional attributes are defined::
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
+
+If `type` is of value `GCPPubSub` the following additional attributes are defined:
+* `gcp` - The configuration for GCP Pub/Sub connection. See [GCP](#GCP)
 
 If `type` is of value `Https` the following additional attributes are defined:
 * `url` - URL of the HTTPs endpoint that will be used for creating a connection.
@@ -95,6 +98,9 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 
 ### AWS
 * `role_arn` - Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account.
+
+### GCP
+* `service_account_id` - Email address of the Google Cloud Platform (GCP) service account that Atlas Streams uses to connect to GCP Pub/Sub resources.
 
 ### Schema Registry Authentication
 * `type` - Authentication type discriminator. Specifies the authentication mechanism for Confluent Schema Registry. Valid values are `USER_INFO` or `SASL_INHERIT`.

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -133,6 +133,31 @@ resource "mongodbatlas_stream_connection" "test" {
 
 ```
 
+### Example GCPPubSub Connection
+
+```terraform
+resource "mongodbatlas_cloud_provider_access_setup" "gcp_setup" {
+    project_id    = var.project_id
+    provider_name = "GCP"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "gcp_auth" {
+    project_id = var.project_id
+    role_id    = mongodbatlas_cloud_provider_access_setup.gcp_setup.role_id
+}
+
+resource "mongodbatlas_stream_connection" "example-gcp-pubsub" {
+    project_id      = var.project_id
+    workspace_name  = mongodbatlas_stream_workspace.example.workspace_name
+    connection_name = "GCPPubSubConnection"
+    type            = "GCPPubSub"
+    gcp = {
+      service_account_id = mongodbatlas_cloud_provider_access_setup.gcp_setup.gcp_config[0].service_account_for_atlas
+    }
+    depends_on = [mongodbatlas_cloud_provider_access_authorization.gcp_auth]
+}
+```
+
 ### Example Https Connection
 
 ```terraform
@@ -241,7 +266,7 @@ resource "mongodbatlas_stream_processor" "example" {
 * `workspace_name` - (Optional) Label that identifies the stream processing workspace.
 * `instance_name` - (Optional, Deprecated) Label that identifies the stream processing workspace. Use `workspace_name` instead; this attribute will be removed in a future major version.
 * `connection_name` - (Required) Label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - (Required) Type of connection. Can be `AWSLambda`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
+* `type` - (Required) Type of connection. Can be `AWSLambda`, `Cluster`, `GCPPubSub`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
 
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -257,6 +282,9 @@ If `type` is of value `Kafka` the following additional arguments are defined:
 
 If `type` is of value `AWSLambda` the following additional arguments are defined:
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
+
+If `type` is of value `GCPPubSub` the following additional arguments are defined:
+* `gcp` - The configuration for GCP Pub/Sub connection. See [GCP](#GCP)
 
 If `type` is of value `Https` the following additional attributes are defined:
 * `url` - URL of the HTTPs endpoint that will be used for creating a connection.
@@ -298,6 +326,9 @@ If `type` is of value `SchemaRegistry` the following additional arguments are de
 
 ### AWS
 * `role_arn` - Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account.
+
+### GCP
+* `service_account_id` - Email address of the Google Cloud Platform (GCP) service account that Atlas Streams uses to connect to GCP Pub/Sub resources.
 
 ### Schema Registry Authentication
 * `type` - Authentication type discriminator. Specifies the authentication mechanism for Confluent Schema Registry. Valid values are `USER_INFO` or `SASL_INHERIT`.

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -65,7 +65,7 @@ resource "mongodbatlas_stream_connection" "test" {
 ### Example Kafka SASL OAuthbearer Connection
 
 ```terraform
-resource "mongodbatlas_stream_connection" "example-kafka-oauthbearer" {
+resource "mongodbatlas_stream_connection" "example_kafka_oauthbearer" {
     project_id      = var.project_id
     workspace_name  = mongodbatlas_stream_workspace.example.workspace_name
     connection_name = "KafkaOAuthbearerConnection"
@@ -146,7 +146,7 @@ resource "mongodbatlas_cloud_provider_access_authorization" "gcp_auth" {
     role_id    = mongodbatlas_cloud_provider_access_setup.gcp_setup.role_id
 }
 
-resource "mongodbatlas_stream_connection" "example-gcp-pubsub" {
+resource "mongodbatlas_stream_connection" "example_gcp_pubsub" {
     project_id      = var.project_id
     workspace_name  = mongodbatlas_stream_workspace.example.workspace_name
     connection_name = "GCPPubSubConnection"
@@ -161,7 +161,7 @@ resource "mongodbatlas_stream_connection" "example-gcp-pubsub" {
 ### Example Https Connection
 
 ```terraform
-resource "mongodbatlas_stream_connection" "example-https" {
+resource "mongodbatlas_stream_connection" "example_https" {
   project_id      = var.project_id
   workspace_name  = mongodbatlas_stream_workspace.example.workspace_name
   connection_name = "https_connection_tf_new"
@@ -177,7 +177,7 @@ resource "mongodbatlas_stream_connection" "example-https" {
 ### Example Schema Registry Connection with USER_INFO Authentication
 
 ```terraform
-resource "mongodbatlas_stream_connection" "example-schema-registry" {
+resource "mongodbatlas_stream_connection" "example_schema_registry" {
   project_id               = var.project_id
   workspace_name           = mongodbatlas_stream_workspace.example.workspace_name
   connection_name          = "SchemaRegistryConnection"
@@ -195,7 +195,7 @@ resource "mongodbatlas_stream_connection" "example-schema-registry" {
 ### Example Schema Registry Connection with SASL_INHERIT Authentication
 
 ```terraform
-resource "mongodbatlas_stream_connection" "example-schema-registry-sasl" {
+resource "mongodbatlas_stream_connection" "example_schema_registry_sasl" {
   project_id               = var.project_id
   workspace_name           = mongodbatlas_stream_workspace.example.workspace_name
   connection_name          = "SchemaRegistryConnectionSASL"

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -97,6 +97,16 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 		}
 	}
 
+	if !plan.GCP.IsNull() {
+		gcpModel := &TFGCPModel{}
+		if diags := plan.GCP.As(ctx, gcpModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return nil, diags
+		}
+		streamConnection.Gcp = &admin.StreamsGCPConnectionConfig{
+			ServiceAccountId: gcpModel.ServiceAccountID.ValueStringPointer(),
+		}
+	}
+
 	if !plan.Headers.IsNull() {
 		headersMap := make(map[string]string)
 		if diags := plan.Headers.ElementsAs(ctx, &headersMap, true); diags.HasError() {
@@ -240,11 +250,20 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName, workspaceN
 		connectionModel.DBRoleToExecute = dbRoleToExecuteModel
 	}
 
+	// The API returns networking in either Networking (Kafka, S3) or PublicPrivateNetworking (GCPPubSub, Azure) depending on connection type.
 	connectionModel.Networking = types.ObjectNull(NetworkingObjectType.AttrTypes)
-	if apiResp.Networking != nil {
+	var networkingAccessType, networkingConnectionID *string
+	if apiResp.Networking != nil && apiResp.Networking.Access != nil {
+		networkingAccessType = apiResp.Networking.Access.Type
+		networkingConnectionID = apiResp.Networking.Access.ConnectionId
+	} else if apiResp.PublicPrivateNetworking != nil && apiResp.PublicPrivateNetworking.Access != nil {
+		networkingAccessType = apiResp.PublicPrivateNetworking.Access.Type
+		networkingConnectionID = apiResp.PublicPrivateNetworking.Access.ConnectionId
+	}
+	if networkingAccessType != nil {
 		networkingAccessModel, diags := types.ObjectValueFrom(ctx, NetworkingAccessObjectType.AttrTypes, TFNetworkingAccessModel{
-			Type:         types.StringPointerValue(apiResp.Networking.Access.Type),
-			ConnectionID: types.StringPointerValue(apiResp.Networking.Access.ConnectionId),
+			Type:         types.StringPointerValue(networkingAccessType),
+			ConnectionID: types.StringPointerValue(networkingConnectionID),
 		})
 		if diags.HasError() {
 			return nil, diags
@@ -267,6 +286,17 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName, workspaceN
 			return nil, diags
 		}
 		connectionModel.AWS = aws
+	}
+
+	connectionModel.GCP = types.ObjectNull(GCPObjectType.AttrTypes)
+	if apiResp.Gcp != nil {
+		gcp, diags := types.ObjectValueFrom(ctx, GCPObjectType.AttrTypes, TFGCPModel{
+			ServiceAccountID: types.StringPointerValue(apiResp.Gcp.ServiceAccountId),
+		})
+		if diags.HasError() {
+			return nil, diags
+		}
+		connectionModel.GCP = gcp
 	}
 
 	connectionModel.Headers = types.MapNull(types.StringType)

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -37,6 +37,8 @@ const (
 	awslambdaConnectionName   = "aws_lambda_connection"
 	sampleRoleArn             = "rn:aws:iam::123456789123:role/sample"
 	httpsURL                  = "https://example.com"
+	gcpPubSubConnectionName   = "gcp_pubsub_connection"
+	sampleServiceAccountID    = "projects/my-project/serviceAccounts/streams@my-project.iam.gserviceaccount.com"
 )
 
 var (
@@ -90,6 +92,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -125,6 +128,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -163,6 +167,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -205,6 +210,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -232,6 +238,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -270,6 +277,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -296,6 +304,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -323,6 +332,35 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          tfAWSLambdaConfigObject(t, sampleRoleArn),
+					GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
+					Headers:                      types.MapNull(types.StringType),
+					SchemaRegistryURLs:           types.ListNull(types.StringType),
+					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
+				},
+			},
+		},
+		{
+			name: "GCPPubSub connection type with serviceAccountId",
+			SDKResp: &admin.StreamsConnection{
+				Name: new(gcpPubSubConnectionName),
+				Type: new("GCPPubSub"),
+				Gcp:  &admin.StreamsGCPConnectionConfig{ServiceAccountId: new(sampleServiceAccountID)},
+			},
+			providedProjID:       dummyProjectID,
+			providedInstanceName: instanceName,
+			expectedTFModel: &streamconnection.TFStreamConnectionModel{
+				TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
+					ProjectID:                    types.StringValue(dummyProjectID),
+					WorkspaceName:                types.StringValue(instanceName),
+					ConnectionName:               types.StringValue(gcpPubSubConnectionName),
+					Type:                         types.StringValue("GCPPubSub"),
+					Authentication:               types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+					Config:                       types.MapNull(types.StringType),
+					Security:                     types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
+					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                          tfGCPConfigObject(t, sampleServiceAccountID),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -359,6 +397,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:        types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:             types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                    types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					GCP:                    types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 					Headers:                types.MapNull(types.StringType),
 					SchemaRegistryProvider: types.StringValue("CONFLUENT"),
 					SchemaRegistryURLs: types.ListValueMust(types.StringType, []attr.Value{
@@ -546,6 +585,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   tfNetworkingObject(t, networkingType, nil),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -565,6 +605,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -584,6 +625,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -603,6 +645,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          tfAWSLambdaConfigObject(t, sampleRoleArn),
+							GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -622,6 +665,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							GCP:                          types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 							Headers:                      tfConfigMap(t, headersMap),
 							URL:                          types.StringValue(httpsURL),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
@@ -642,6 +686,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:        types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:             types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                    types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							GCP:                    types.ObjectNull(streamconnection.GCPObjectType.AttrTypes),
 							Headers:                types.MapNull(types.StringType),
 							SchemaRegistryProvider: types.StringValue("CONFLUENT"),
 							SchemaRegistryURLs: types.ListValueMust(types.StringType, []attr.Value{
@@ -814,6 +859,25 @@ func TestStreamInstanceTFToSDKCreateModel(t *testing.T) {
 				Type: new("AWSLambda"),
 				Aws: &admin.StreamsAWSConnectionConfig{
 					RoleArn: new(sampleRoleArn),
+				},
+			},
+		},
+		{
+			name: "GCPPubSub type TF state",
+			tfModel: &streamconnection.TFStreamConnectionModel{
+				TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
+					ProjectID:      types.StringValue(dummyProjectID),
+					InstanceName:   types.StringValue(instanceName),
+					ConnectionName: types.StringValue(gcpPubSubConnectionName),
+					Type:           types.StringValue("GCPPubSub"),
+					GCP:            tfGCPConfigObject(t, sampleServiceAccountID),
+				},
+			},
+			expectedSDKReq: &admin.StreamsConnection{
+				Name: new(gcpPubSubConnectionName),
+				Type: new("GCPPubSub"),
+				Gcp: &admin.StreamsGCPConnectionConfig{
+					ServiceAccountId: new(sampleServiceAccountID),
 				},
 			},
 		},
@@ -1043,4 +1107,15 @@ func tfSchemaRegistryAuthObjectNoPassword(t *testing.T, authType, username strin
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
 	}
 	return auth
+}
+
+func tfGCPConfigObject(t *testing.T, serviceAccountID string) types.Object {
+	t.Helper()
+	gcp, diags := types.ObjectValueFrom(t.Context(), streamconnection.GCPObjectType.AttrTypes, streamconnection.TFGCPModel{
+		ServiceAccountID: types.StringValue(serviceAccountID),
+	})
+	if diags.HasError() {
+		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
+	}
+	return gcp
 }

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -174,6 +174,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 
+			// GCPPubSub type specific
+			"gcp": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"service_account_id": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+
 			// https type specific
 			"url": schema.StringAttribute{
 				Optional: true,

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -51,6 +51,7 @@ type TFStreamConnectionCommonModel struct {
 	DBRoleToExecute  types.Object `tfsdk:"db_role_to_execute"`
 	Networking       types.Object `tfsdk:"networking"`
 	AWS              types.Object `tfsdk:"aws"`
+	GCP              types.Object `tfsdk:"gcp"`
 	// https connection
 	Headers types.Map    `tfsdk:"headers"`
 	URL     types.String `tfsdk:"url"`
@@ -157,6 +158,14 @@ type TFAWSModel struct {
 
 var AWSObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"role_arn": types.StringType,
+}}
+
+type TFGCPModel struct {
+	ServiceAccountID types.String `tfsdk:"service_account_id"`
+}
+
+var GCPObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"service_account_id": types.StringType,
 }}
 
 func (r *streamConnectionRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -498,6 +498,30 @@ func TestAccStreamRSStreamConnection_AWSLambda(t *testing.T) {
 	})
 }
 
+func TestAccStreamRSStreamConnection_GCPPubSub(t *testing.T) {
+	var (
+		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		connectionName          = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: configureGCPPubSub(projectID, instanceName, connectionName),
+				Check:  checkGCPPubSubAttributes(resourceName, instanceName, connectionName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: checkStreamConnectionImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccStreamRSStreamConnection_instanceName(t *testing.T) {
 	var (
 		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
@@ -1110,6 +1134,43 @@ func configureAWSLambda(projectID, instanceName, connectionName, awsIamRoleName 
 		}
 	`, projectID, instanceName, connectionName, awsIamRoleName)
 	return config
+}
+
+func configureGCPPubSub(projectID, instanceName, connectionName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cloud_provider_access_setup" "gcp_setup" {
+			project_id    = %[1]q
+			provider_name = "GCP"
+		}
+
+		resource "mongodbatlas_cloud_provider_access_authorization" "gcp_auth" {
+			project_id = %[1]q
+			role_id    = mongodbatlas_cloud_provider_access_setup.gcp_setup.role_id
+		}
+
+		resource "mongodbatlas_stream_connection" "test" {
+			project_id      = %[1]q
+			workspace_name  = %[2]q
+			connection_name = %[3]q
+			type            = "GCPPubSub"
+			gcp = {
+				service_account_id = mongodbatlas_cloud_provider_access_setup.gcp_setup.gcp_config[0].service_account_for_atlas
+			}
+			depends_on = [mongodbatlas_cloud_provider_access_authorization.gcp_auth]
+		}
+	`, projectID, instanceName, connectionName)
+}
+
+func checkGCPPubSubAttributes(resourceName, workspaceName, connectionName string) resource.TestCheckFunc {
+	resourceChecks := []resource.TestCheckFunc{
+		checkStreamConnectionExists(),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttr(resourceName, "workspace_name", workspaceName),
+		resource.TestCheckResourceAttr(resourceName, "connection_name", connectionName),
+		resource.TestCheckResourceAttr(resourceName, "type", "GCPPubSub"),
+		resource.TestCheckResourceAttrSet(resourceName, "gcp.service_account_id"),
+	}
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }
 
 func checkAWSLambdaAttributes(resourceName, workspaceName, connectionName string) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

Adds support for `GCPPubSub` as a new stream connection type in `mongodbatlas_stream_connection` resource and data sources.

This enables users to create GCP Pub/Sub connections in the Atlas Stream Processing connection registry using Terraform. The `gcp` attribute accepts a `service_account_id` obtained from `mongodbatlas_cloud_provider_access_setup` with `provider_name = "GCP"`.

Link to any related issue(s): [CLOUDP-380440](https://jira.mongodb.org/browse/CLOUDP-380440)

## Type of change:

- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [x] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

### Example usage

```hcl
resource "mongodbatlas_cloud_provider_access_setup" "gcp_setup" {
  project_id    = var.project_id
  provider_name = "GCP"
}

resource "mongodbatlas_cloud_provider_access_authorization" "gcp_auth" {
  project_id = var.project_id
  role_id    = mongodbatlas_cloud_provider_access_setup.gcp_setup.role_id
}

resource "mongodbatlas_stream_connection" "gcp_pubsub" {
  project_id      = var.project_id
  workspace_name  = "MyWorkspace"
  connection_name = "GCPPubSubConnection"
  type            = "GCPPubSub"
  gcp = {
    service_account_id = mongodbatlas_cloud_provider_access_setup.gcp_setup.gcp_config[0].service_account_for_atlas
  }
}
```

### Testing

- Unit tests: all passing (`TestStreamConnectionSDKToTFModel`, `TestStreamInstanceTFToSDKCreateModel`, `TestStreamConnectionsSDKToTFModel`)
- Local manual test: verified `terraform plan` and `terraform apply` against cloud-dev
- Acceptance test added: `TestAccStreamRSStreamConnection_GCPPubSub` (uses `cloud_provider_access_setup` inline, no env vars needed)