### PR TITLE
feat: Add new AzureBlobStorage connection type in stream processing

### DIFF
--- a/.changelog/4356.txt
+++ b/.changelog/4356.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds `AzureBlobStorage` connection
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connection: Adds `AzureBlobStorage` connection
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connections: Adds `AzureBlobStorage` connection
+```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds `PRIVATE_LINK` networking access type for `AzureBlobStorage` connections
+```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -37,7 +37,7 @@ data "mongodbatlas_stream_connection" "example" {
 
 ## Attributes Reference
 
-* `type` - Type of connection. Can be `AWSLambda`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
+* `type` - Type of connection. Can be `AWSLambda`, `AzureBlobStorage`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -50,6 +50,10 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `config` - A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.
 * `security` - Properties for the secure transport connection to Kafka. For SASL_SSL, this can include the trusted certificate to use. See [security](#security).
 * `networking` - Networking Access Type can either be `PUBLIC` (default) or `VPC`. See [networking](#networking).
+
+If `type` is of value `AzureBlobStorage` the following additional attributes are defined:
+* `azure` - The configuration for Azure Blob Storage connection. See [Azure](#Azure).
+* `networking` - Networking Access Type can be `PUBLIC` or `PRIVATE_LINK`. See [networking](#networking).
 
 If `type` is of value `AWSLambda` the following additional attributes are defined:
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
@@ -93,7 +97,12 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 * `connection_id` - Id of the Private Link connection when type is `PRIVATE_LINK`.
 
 ### AWS
-* `role_arn` - Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account. 
+* `role_arn` - Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account.
+
+### Azure
+* `service_principal_id` - UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account.
+* `storage_account_name` - Name of the Azure Storage account.
+* `region` - Azure region where the storage account is located.
 
 ### Schema Registry Authentication
 * `type` - Authentication type discriminator. Specifies the authentication mechanism for Confluent Schema Registry. Valid values are `USER_INFO` or `SASL_INHERIT`.

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -39,7 +39,7 @@ In addition to all arguments above, it also exports the following attributes:
 * `project_id` - Unique 24-hexadecimal digit string that identifies your project.
 * `workspace_name` - Label that identifies the stream processing workspace.
 * `connection_name` - Label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - Type of connection. `AWSLambda`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
+* `type` - Type of connection. `AWSLambda`, `AzureBlobStorage`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -52,7 +52,11 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `security` - Properties for the secure transport connection to Kafka. For SASL_SSL, this can include the trusted certificate to use. See [security](#security).
 * `networking` - Networking Access Type can either be `PUBLIC` (default) or `VPC`. See [networking](#networking).
 
-If `type` is of value `AWSLambda` the following additional attributes are defined::
+If `type` is of value `AzureBlobStorage` the following additional attributes are defined:
+* `azure` - The configuration for Azure Blob Storage connection. See [Azure](#Azure).
+* `networking` - Networking Access Type can be `PUBLIC` or `PRIVATE_LINK`. See [networking](#networking).
+
+If `type` is of value `AWSLambda` the following additional attributes are defined:
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
 
 If `type` is of value `Https` the following additional attributes are defined:
@@ -95,6 +99,11 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 
 ### AWS
 * `role_arn` - Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account.
+
+### Azure
+* `service_principal_id` - UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account.
+* `storage_account_name` - Name of the Azure Storage account.
+* `region` - Azure region where the storage account is located.
 
 ### Schema Registry Authentication
 * `type` - Authentication type discriminator. Specifies the authentication mechanism for Confluent Schema Registry. Valid values are `USER_INFO` or `SASL_INHERIT`.

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -118,6 +118,27 @@ resource "mongodbatlas_stream_connection" "test" {
 }
 ```
 
+### Example Azure Blob Storage Connection
+
+```terraform
+resource "mongodbatlas_stream_connection" "test" {
+    project_id      = var.project_id
+    workspace_name  = "NewWorkspace"
+    connection_name = "AzureBlobStorageConnection"
+    type            = "AzureBlobStorage"
+    azure = {
+      service_principal_id = "<AZURE_SERVICE_PRINCIPAL_ID>"
+      storage_account_name = "<AZURE_STORAGE_ACCOUNT_NAME>"
+      region               = "<AZURE_REGION>"
+    }
+    networking = {
+      access = {
+        type = "PUBLIC"
+      }
+    }
+}
+```
+
 ### Example AWSLambda Connection
 
 ```terraform
@@ -241,7 +262,7 @@ resource "mongodbatlas_stream_processor" "example" {
 * `workspace_name` - (Optional) Label that identifies the stream processing workspace.
 * `instance_name` - (Optional, Deprecated) Label that identifies the stream processing workspace. Use `workspace_name` instead; this attribute will be removed in a future major version.
 * `connection_name` - (Required) Label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - (Required) Type of connection. Can be `AWSLambda`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
+* `type` - (Required) Type of connection. Can be `AWSLambda`, `AzureBlobStorage`, `Cluster`, `Https`, `Kafka`, `Sample`, or `SchemaRegistry`.
 
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -254,6 +275,10 @@ If `type` is of value `Kafka` the following additional arguments are defined:
 * `config` - A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.
 * `security` - Properties for the secure transport connection to Kafka. For SASL_SSL, this can include the trusted certificate to use. See [security](#security).
 * `networking` - Networking Access Type can either be `PUBLIC` (default) or `VPC`. See [networking](#networking).
+
+If `type` is of value `AzureBlobStorage` the following additional arguments are defined:
+* `azure` - The configuration for Azure Blob Storage connection. See [Azure](#Azure).
+* `networking` - Networking Access Type can be `PUBLIC` or `PRIVATE_LINK`. See [networking](#networking).
 
 If `type` is of value `AWSLambda` the following additional arguments are defined:
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
@@ -298,6 +323,11 @@ If `type` is of value `SchemaRegistry` the following additional arguments are de
 
 ### AWS
 * `role_arn` - Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account.
+
+### Azure
+* `service_principal_id` - (Required) UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account.
+* `storage_account_name` - (Required) Name of the Azure Storage account to use. Must be lowercase, 3-24 characters, and contain only letters and numbers.
+* `region` - (Optional) Azure region where the storage account is located.
 
 ### Schema Registry Authentication
 * `type` - Authentication type discriminator. Specifies the authentication mechanism for Confluent Schema Registry. Valid values are `USER_INFO` or `SASL_INHERIT`.

--- a/examples/mongodbatlas_stream_connection/README.md
+++ b/examples/mongodbatlas_stream_connection/README.md
@@ -14,5 +14,6 @@ You must set the following variables depending on connection type:
 - `cluster_project_id`: The project of the Cluster that will be used for creating a connection. Required if the project is different from the project of the stream instance.
 - `azure_service_principal_id`: UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account.
 - `azure_storage_account_name`: Name of the Azure Storage account to use for the Azure Blob Storage connection.
+- `azure_region`: (optional) Azure region where the storage account is located.
 
 To learn more, see the [Stream Instance Connection Registry Documentation](https://www.mongodb.com/docs/atlas/atlas-sp/manage-processing-instance/#view-connections-in-the-connection-registry).

--- a/examples/mongodbatlas_stream_connection/README.md
+++ b/examples/mongodbatlas_stream_connection/README.md
@@ -1,6 +1,6 @@
 # MongoDB Atlas Provider - Atlas Stream Instance defined in a Project
 
-This example shows how to create Atlas Stream Connections in Terraform. It also creates a stream instance, which is a prerequisite. Both Kafka and Cluster connections types are defined to showcase their usage.
+This example shows how to create Atlas Stream Connections in Terraform. It also creates a stream instance, which is a prerequisite. Kafka, Cluster, Azure Blob Storage, and other connection types are defined to showcase their usage.
 
 You must set the following variables depending on connection type:
 
@@ -12,5 +12,7 @@ You must set the following variables depending on connection type:
 - `kafka_ssl_cert`: String value of public x509 certificate for connecting to Kafka over SSL.
 - `cluster_name`: Name of Cluster that will be used for creating a connection.
 - `cluster_project_id`: The project of the Cluster that will be used for creating a connection. Required if the project is different from the project of the stream instance.
+- `azure_service_principal_id`: UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account.
+- `azure_storage_account_name`: Name of the Azure Storage account to use for the Azure Blob Storage connection.
 
 To learn more, see the [Stream Instance Connection Registry Documentation](https://www.mongodb.com/docs/atlas/atlas-sp/manage-processing-instance/#view-connections-in-the-connection-registry).

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -112,7 +112,7 @@ resource "mongodbatlas_stream_connection" "example-azure-blob-storage" {
   azure = {
     service_principal_id = var.azure_service_principal_id
     storage_account_name = var.azure_storage_account_name
-    region               = var.azure_region
+    region               = var.azure_region == "" ? null : var.azure_region
   }
   networking = {
     access = {

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -104,6 +104,23 @@ resource "mongodbatlas_stream_connection" "example-kafka-ssl" {
   }
 }
 
+resource "mongodbatlas_stream_connection" "example-azure-blob-storage" {
+  project_id      = var.project_id
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "AzureBlobStorageConnection"
+  type            = "AzureBlobStorage"
+  azure = {
+    service_principal_id = var.azure_service_principal_id
+    storage_account_name = var.azure_storage_account_name
+    region               = var.azure_region
+  }
+  networking = {
+    access = {
+      type = "PUBLIC"
+    }
+  }
+}
+
 resource "mongodbatlas_stream_connection" "example-sample" {
   project_id      = var.project_id
   workspace_name  = mongodbatlas_stream_instance.example.instance_name

--- a/examples/mongodbatlas_stream_connection/variables.tf
+++ b/examples/mongodbatlas_stream_connection/variables.tf
@@ -52,19 +52,16 @@ variable "other_cluster" {
 variable "azure_service_principal_id" {
   description = "UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account"
   type        = string
-  default     = ""
 }
 
 variable "azure_storage_account_name" {
   description = "Name of the Azure Storage account to use for the Azure Blob Storage connection"
   type        = string
-  default     = ""
 }
 
 variable "azure_region" {
   description = "Azure region where the storage account is located"
   type        = string
-  default     = ""
 }
 
 variable "schema_registry_username" {

--- a/examples/mongodbatlas_stream_connection/variables.tf
+++ b/examples/mongodbatlas_stream_connection/variables.tf
@@ -49,6 +49,24 @@ variable "other_cluster" {
   type        = string
 }
 
+variable "azure_service_principal_id" {
+  description = "UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account"
+  type        = string
+  default     = ""
+}
+
+variable "azure_storage_account_name" {
+  description = "Name of the Azure Storage account to use for the Azure Blob Storage connection"
+  type        = string
+  default     = ""
+}
+
+variable "azure_region" {
+  description = "Azure region where the storage account is located"
+  type        = string
+  default     = ""
+}
+
 variable "schema_registry_username" {
   description = "Username for connecting to your Schema Registry"
   type        = string

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -79,11 +79,26 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 		if diags := networkingModel.Access.As(ctx, networkingAccessModel, basetypes.ObjectAsOptions{}); diags.HasError() {
 			return nil, diags
 		}
-		streamConnection.Networking = &admin.StreamsKafkaNetworking{
-			Access: &admin.StreamsKafkaNetworkingAccess{
-				Type:         networkingAccessModel.Type.ValueStringPointer(),
-				ConnectionId: networkingAccessModel.ConnectionID.ValueStringPointer(),
-			},
+		switch plan.Type.ValueString() {
+		case ConnectionTypeAzureBlobStorage:
+			streamConnection.PublicPrivateNetworking = &admin.StreamsPublicPrivateLinkNetworking{
+				Access: &admin.StreamsPublicPrivateLinkNetworkingAccess{
+					Type:         networkingAccessModel.Type.ValueStringPointer(),
+					ConnectionId: networkingAccessModel.ConnectionID.ValueStringPointer(),
+				},
+			}
+		case ConnectionTypeKafka, ConnectionTypeAWSKinesisDataStreams, ConnectionTypeS3:
+			streamConnection.Networking = &admin.StreamsKafkaNetworking{
+				Access: &admin.StreamsKafkaNetworkingAccess{
+					Type:         networkingAccessModel.Type.ValueStringPointer(),
+					ConnectionId: networkingAccessModel.ConnectionID.ValueStringPointer(),
+				},
+			}
+		default:
+			return nil, diag.Diagnostics{diag.NewErrorDiagnostic(
+				"invalid connection type with networking",
+				fmt.Sprintf("connection type %q does not support networking configuration", plan.Type.ValueString()),
+			)}
 		}
 	}
 
@@ -94,6 +109,18 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 		}
 		streamConnection.Aws = &admin.StreamsAWSConnectionConfig{
 			RoleArn: awsModel.RoleArn.ValueStringPointer(),
+		}
+	}
+
+	if !plan.Azure.IsNull() {
+		azureModel := &TFAzureModel{}
+		if diags := plan.Azure.As(ctx, azureModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return nil, diags
+		}
+		streamConnection.Azure = &admin.AzureConnection{
+			ServicePrincipalId: azureModel.ServicePrincipalID.ValueStringPointer(),
+			StorageAccountName: azureModel.StorageAccountName.ValueStringPointer(),
+			Region:             azureModel.Region.ValueStringPointer(),
 		}
 	}
 
@@ -241,7 +268,7 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName, workspaceN
 	}
 
 	connectionModel.Networking = types.ObjectNull(NetworkingObjectType.AttrTypes)
-	if apiResp.Networking != nil {
+	if apiResp.Networking != nil && apiResp.Networking.Access != nil {
 		networkingAccessModel, diags := types.ObjectValueFrom(ctx, NetworkingAccessObjectType.AttrTypes, TFNetworkingAccessModel{
 			Type:         types.StringPointerValue(apiResp.Networking.Access.Type),
 			ConnectionID: types.StringPointerValue(apiResp.Networking.Access.ConnectionId),
@@ -256,6 +283,34 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName, workspaceN
 			return nil, diags
 		}
 		connectionModel.Networking = networkingModel
+	} else if apiResp.PublicPrivateNetworking != nil && apiResp.PublicPrivateNetworking.Access != nil {
+		networkingAccessModel, diags := types.ObjectValueFrom(ctx, NetworkingAccessObjectType.AttrTypes, TFNetworkingAccessModel{
+			Type:         types.StringPointerValue(apiResp.PublicPrivateNetworking.Access.Type),
+			ConnectionID: types.StringPointerValue(apiResp.PublicPrivateNetworking.Access.ConnectionId),
+		})
+		if diags.HasError() {
+			return nil, diags
+		}
+		networkingModel, diags := types.ObjectValueFrom(ctx, NetworkingObjectType.AttrTypes, TFNetworkingModel{
+			Access: networkingAccessModel,
+		})
+		if diags.HasError() {
+			return nil, diags
+		}
+		connectionModel.Networking = networkingModel
+	}
+
+	connectionModel.Azure = types.ObjectNull(AzureObjectType.AttrTypes)
+	if apiResp.Azure != nil {
+		azure, diags := types.ObjectValueFrom(ctx, AzureObjectType.AttrTypes, TFAzureModel{
+			ServicePrincipalID: types.StringPointerValue(apiResp.Azure.ServicePrincipalId),
+			StorageAccountName: types.StringPointerValue(apiResp.Azure.StorageAccountName),
+			Region:             types.StringPointerValue(apiResp.Azure.Region),
+		})
+		if diags.HasError() {
+			return nil, diags
+		}
+		connectionModel.Azure = azure
 	}
 
 	connectionModel.AWS = types.ObjectNull(AWSObjectType.AttrTypes)

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -37,6 +37,9 @@ const (
 	awslambdaConnectionName   = "aws_lambda_connection"
 	sampleRoleArn             = "rn:aws:iam::123456789123:role/sample"
 	httpsURL                  = "https://example.com"
+	azureServicePrincipalID   = "12345678-1234-1234-1234-123456789012"
+	azureStorageAccountName   = "mystorageaccount"
+	azureRegion               = "eastus2"
 )
 
 var (
@@ -58,11 +61,12 @@ type sdkToTFModelTestCase struct {
 	name                             string
 }
 
-func TestStreamConnectionSDKToTFModel(t *testing.T) {
+func sdkToTFModelTestCases(t *testing.T) []sdkToTFModelTestCase {
+	t.Helper()
 	var authConfigWithPasswordDefined = tfAuthenticationObject(t, authMechanism, authUsername, "raw password")
 	var authConfigWithOAuth = tfAuthenticationObjectForOAuth(t, authMechanism, clientID, clientSecret, tokenEndpointURL, scope, saslOauthbearerExtentions, method)
 
-	testCases := []sdkToTFModelTestCase{
+	return []sdkToTFModelTestCase{
 		{
 			name: "Cluster connection type SDK response",
 			SDKResp: &admin.StreamsConnection{
@@ -90,6 +94,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -125,6 +130,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -163,6 +169,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -205,6 +212,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -232,6 +240,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -270,6 +279,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -296,6 +306,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -323,6 +334,40 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                          tfAWSLambdaConfigObject(t, sampleRoleArn),
+					Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
+					Headers:                      types.MapNull(types.StringType),
+					SchemaRegistryURLs:           types.ListNull(types.StringType),
+					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
+				},
+			},
+		},
+		{
+			name: "AzureBlobStorage connection type with publicPrivateNetworking",
+			SDKResp: &admin.StreamsConnection{
+				Name:  new(connectionName),
+				Type:  new("AzureBlobStorage"),
+				Azure: &admin.AzureConnection{ServicePrincipalId: new(azureServicePrincipalID), StorageAccountName: new(azureStorageAccountName), Region: new(azureRegion)},
+				PublicPrivateNetworking: &admin.StreamsPublicPrivateLinkNetworking{
+					Access: &admin.StreamsPublicPrivateLinkNetworkingAccess{
+						Type: new(networkingType),
+					},
+				},
+			},
+			providedProjID:       dummyProjectID,
+			providedInstanceName: instanceName,
+			expectedTFModel: &streamconnection.TFStreamConnectionModel{
+				TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
+					ProjectID:                    types.StringValue(dummyProjectID),
+					WorkspaceName:                types.StringValue(instanceName),
+					ConnectionName:               types.StringValue(connectionName),
+					Type:                         types.StringValue("AzureBlobStorage"),
+					Authentication:               types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+					Config:                       types.MapNull(types.StringType),
+					Security:                     types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+					DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
+					Networking:                   tfNetworkingObject(t, networkingType, nil),
+					AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                        tfAzureConfigObject(t, azureServicePrincipalID, azureStorageAccountName, azureRegion),
 					Headers:                      types.MapNull(types.StringType),
 					SchemaRegistryURLs:           types.ListNull(types.StringType),
 					SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -359,6 +404,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					DBRoleToExecute:        types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					Networking:             types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 					AWS:                    types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+					Azure:                  types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 					Headers:                types.MapNull(types.StringType),
 					SchemaRegistryProvider: types.StringValue("CONFLUENT"),
 					SchemaRegistryURLs: types.ListValueMust(types.StringType, []attr.Value{
@@ -370,8 +416,10 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 			},
 		},
 	}
+}
 
-	for _, tc := range testCases {
+func TestStreamConnectionSDKToTFModel(t *testing.T) {
+	for _, tc := range sdkToTFModelTestCases(t) {
 		t.Run(tc.name, func(t *testing.T) {
 			resultModel, diags := streamconnection.NewTFStreamConnection(t.Context(), tc.providedProjID, "", tc.providedInstanceName, tc.providedAuthConfig, tc.providedSchemaRegistryAuthConfig, tc.SDKResp, nil)
 			if diags.HasError() {
@@ -546,6 +594,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   tfNetworkingObject(t, networkingType, nil),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -565,6 +614,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -584,6 +634,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -603,6 +654,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          tfAWSLambdaConfigObject(t, sampleRoleArn),
+							Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 							Headers:                      types.MapNull(types.StringType),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
 							SchemaRegistryAuthentication: types.ObjectNull(streamconnection.SchemaRegistryAuthenticationObjectType.AttrTypes),
@@ -622,6 +674,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:              types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:                   types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                          types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							Azure:                        types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 							Headers:                      tfConfigMap(t, headersMap),
 							URL:                          types.StringValue(httpsURL),
 							SchemaRegistryURLs:           types.ListNull(types.StringType),
@@ -642,6 +695,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							DBRoleToExecute:        types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 							Networking:             types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 							AWS:                    types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+							Azure:                  types.ObjectNull(streamconnection.AzureObjectType.AttrTypes),
 							Headers:                types.MapNull(types.StringType),
 							SchemaRegistryProvider: types.StringValue("CONFLUENT"),
 							SchemaRegistryURLs: types.ListValueMust(types.StringType, []attr.Value{
@@ -814,6 +868,33 @@ func TestStreamInstanceTFToSDKCreateModel(t *testing.T) {
 				Type: new("AWSLambda"),
 				Aws: &admin.StreamsAWSConnectionConfig{
 					RoleArn: new(sampleRoleArn),
+				},
+			},
+		},
+		{
+			name: "AzureBlobStorage type TF state",
+			tfModel: &streamconnection.TFStreamConnectionModel{
+				TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
+					ProjectID:      types.StringValue(dummyProjectID),
+					InstanceName:   types.StringValue(instanceName),
+					ConnectionName: types.StringValue(connectionName),
+					Type:           types.StringValue("AzureBlobStorage"),
+					Azure:          tfAzureConfigObject(t, azureServicePrincipalID, azureStorageAccountName, azureRegion),
+					Networking:     tfNetworkingObject(t, networkingType, nil),
+				},
+			},
+			expectedSDKReq: &admin.StreamsConnection{
+				Name: new(connectionName),
+				Type: new("AzureBlobStorage"),
+				Azure: &admin.AzureConnection{
+					ServicePrincipalId: new(azureServicePrincipalID),
+					StorageAccountName: new(azureStorageAccountName),
+					Region:             new(azureRegion),
+				},
+				PublicPrivateNetworking: &admin.StreamsPublicPrivateLinkNetworking{
+					Access: &admin.StreamsPublicPrivateLinkNetworkingAccess{
+						Type: new(networkingType),
+					},
 				},
 			},
 		},
@@ -1002,6 +1083,19 @@ func tfNetworkingObject(t *testing.T, networkingType string, connectionID *strin
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
 	}
 	return networking
+}
+
+func tfAzureConfigObject(t *testing.T, servicePrincipalID, storageAccountName, region string) types.Object {
+	t.Helper()
+	azure, diags := types.ObjectValueFrom(t.Context(), streamconnection.AzureObjectType.AttrTypes, streamconnection.TFAzureModel{
+		ServicePrincipalID: types.StringValue(servicePrincipalID),
+		StorageAccountName: types.StringValue(storageAccountName),
+		Region:             types.StringValue(region),
+	})
+	if diags.HasError() {
+		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
+	}
+	return azure
 }
 
 func tfAWSLambdaConfigObject(t *testing.T, roleArn string) types.Object {

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -66,6 +66,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						ConnectionTypeAWSKinesisDataStreams,
+						ConnectionTypeAWSLambda,
+						ConnectionTypeAzureBlobStorage,
+						ConnectionTypeCluster,
+						ConnectionTypeHTTPS,
+						ConnectionTypeKafka,
+						ConnectionTypeS3,
+						ConnectionTypeSample,
+						ConnectionTypeSchemaRegistry,
+					),
+				},
 			},
 
 			// cluster type specific
@@ -170,6 +183,23 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Attributes: map[string]schema.Attribute{
 					"role_arn": schema.StringAttribute{
 						Required: true,
+					},
+				},
+			},
+
+			// AzureBlobStorage type specific
+			"azure": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"service_principal_id": schema.StringAttribute{
+						Required: true,
+					},
+					"storage_account_name": schema.StringAttribute{
+						Required: true,
+					},
+					"region": schema.StringAttribute{
+						Computed: true,
+						Optional: true,
 					},
 				},
 			},

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -19,6 +19,19 @@ import (
 
 const streamConnectionName = "stream_connection"
 
+// Connection type constants used to differentiate API field mapping by connection type.
+const (
+	ConnectionTypeAWSKinesisDataStreams = "AWSKinesisDataStreams"
+	ConnectionTypeAWSLambda             = "AWSLambda"
+	ConnectionTypeAzureBlobStorage      = "AzureBlobStorage"
+	ConnectionTypeCluster               = "Cluster"
+	ConnectionTypeHTTPS                 = "Https"
+	ConnectionTypeKafka                 = "Kafka"
+	ConnectionTypeS3                    = "S3"
+	ConnectionTypeSample                = "Sample"
+	ConnectionTypeSchemaRegistry        = "SchemaRegistry"
+)
+
 var _ resource.ResourceWithConfigure = &streamConnectionRS{}
 var _ resource.ResourceWithImportState = &streamConnectionRS{}
 
@@ -51,6 +64,7 @@ type TFStreamConnectionCommonModel struct {
 	DBRoleToExecute  types.Object `tfsdk:"db_role_to_execute"`
 	Networking       types.Object `tfsdk:"networking"`
 	AWS              types.Object `tfsdk:"aws"`
+	Azure            types.Object `tfsdk:"azure"`
 	// https connection
 	Headers types.Map    `tfsdk:"headers"`
 	URL     types.String `tfsdk:"url"`
@@ -157,6 +171,18 @@ type TFAWSModel struct {
 
 var AWSObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"role_arn": types.StringType,
+}}
+
+type TFAzureModel struct {
+	ServicePrincipalID types.String `tfsdk:"service_principal_id"`
+	StorageAccountName types.String `tfsdk:"storage_account_name"`
+	Region             types.String `tfsdk:"region"`
+}
+
+var AzureObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"service_principal_id": types.StringType,
+	"storage_account_name": types.StringType,
+	"region":               types.StringType,
 }}
 
 func (r *streamConnectionRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -1124,6 +1124,72 @@ func checkAWSLambdaAttributes(resourceName, workspaceName, connectionName string
 	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }
 
+func TestAccStreamRSStreamConnection_AzureBlobStorage(t *testing.T) {
+	var (
+		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		connectionName          = acc.RandomName()
+		servicePrincipalID      = os.Getenv("AZURE_SERVICE_PRINCIPAL_ID")
+		storageAccountName      = os.Getenv("AZURE_BLOB_STORAGE_ACCOUNT_NAME")
+		region                  = os.Getenv("AZURE_REGION")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckStreamConnectionAzureBlobStorage(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: dataSourceConfig + configureAzureBlobStorage(projectID, instanceName, connectionName, servicePrincipalID, storageAccountName, region, networkingTypePublic),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkAzureBlobStorageAttributes(resourceName, instanceName, connectionName, servicePrincipalID, storageAccountName, region),
+					checkAzureBlobStorageAttributes(dataSourceName, instanceName, connectionName, servicePrincipalID, storageAccountName, region),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: checkStreamConnectionImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func configureAzureBlobStorage(projectID, workspaceName, connectionName, servicePrincipalID, storageAccountName, region, networkingType string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_stream_connection" "test" {
+		    project_id = %[1]q
+			workspace_name = %[2]q
+		 	connection_name = %[3]q
+		 	type = "AzureBlobStorage"
+			azure = {
+				service_principal_id = %[4]q
+				storage_account_name = %[5]q
+				region               = %[6]q
+			}
+			networking = {
+				access = {
+					type = %[7]q
+				}
+			}
+		}
+	`, projectID, workspaceName, connectionName, servicePrincipalID, storageAccountName, region, networkingType)
+}
+
+func checkAzureBlobStorageAttributes(resourceName, workspaceName, connectionName, servicePrincipalID, storageAccountName, region string) resource.TestCheckFunc {
+	resourceChecks := []resource.TestCheckFunc{
+		checkStreamConnectionExists(),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttr(resourceName, "workspace_name", workspaceName),
+		resource.TestCheckResourceAttr(resourceName, "connection_name", connectionName),
+		resource.TestCheckResourceAttr(resourceName, "type", "AzureBlobStorage"),
+		resource.TestCheckResourceAttr(resourceName, "azure.service_principal_id", servicePrincipalID),
+		resource.TestCheckResourceAttr(resourceName, "azure.storage_account_name", storageAccountName),
+		resource.TestCheckResourceAttr(resourceName, "azure.region", region),
+		resource.TestCheckResourceAttr(resourceName, "networking.access.type", networkingTypePublic),
+	}
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
+}
+
 func streamConnectionsAttributeChecks(resourceName string, pageNum, itemsPerPage *int) resource.TestCheckFunc {
 	resourceChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),

--- a/internal/serviceapi/streamconnectionapi/resource_schema.go
+++ b/internal/serviceapi/streamconnectionapi/resource_schema.go
@@ -91,6 +91,26 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
+			"azure": schema.SingleNestedAttribute{
+				Optional:            true,
+				MarkdownDescription: "Optional for type: AzureBlobStorage. Azure configurations for Azure Blob Storage connection types.",
+				CustomType:          customtypes.NewObjectType[TFAzureModel](ctx),
+				Attributes: map[string]schema.Attribute{
+					"service_principal_id": schema.StringAttribute{
+						Required:            true,
+						MarkdownDescription: "UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account.",
+					},
+					"storage_account_name": schema.StringAttribute{
+						Required:            true,
+						MarkdownDescription: "Name of the Azure Storage account to use. Must be lowercase, 3-24 characters, and contain only letters and numbers.",
+					},
+					"region": schema.StringAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Azure region where the storage account is located.",
+					},
+				},
+			},
 			"bootstrap_servers": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Optional for type: Kafka. Comma separated list of server addresses.",
@@ -141,7 +161,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"networking": schema.SingleNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Optional for type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.",
+				MarkdownDescription: "Optional for type: AWSKinesisDataStreams, AzureBlobStorage, Kafka, S3. Networking configuration for Streams connections.",
 				CustomType:          customtypes.NewObjectType[TFNetworkingModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"access": schema.SingleNestedAttribute{
@@ -251,6 +271,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							"AWSLambda": {
 								Allowed: []string{"aws"},
 							},
+							"AzureBlobStorage": {
+								Allowed: []string{"azure", "networking"},
+							},
 							"Cluster": {
 								Allowed: []string{"cluster_name", "cluster_project_id", "db_role_to_execute"},
 							},
@@ -295,6 +318,7 @@ type TFModel struct {
 	TFExpandedModel
 	Authentication               customtypes.ObjectValue[TFAuthenticationModel]               `tfsdk:"authentication"`
 	Aws                          customtypes.ObjectValue[TFAwsModel]                          `tfsdk:"aws"`
+	Azure                        customtypes.ObjectValue[TFAzureModel]                        `tfsdk:"azure"`
 	BootstrapServers             types.String                                                 `tfsdk:"bootstrap_servers"`
 	ClusterProjectId             types.String                                                 `tfsdk:"cluster_project_id" apiname:"clusterGroupId"`
 	ClusterName                  types.String                                                 `tfsdk:"cluster_name"`
@@ -333,6 +357,11 @@ type TFAuthenticationModel struct {
 type TFAwsModel struct {
 	RoleArn    types.String `tfsdk:"role_arn"`
 	TestBucket types.String `tfsdk:"test_bucket"`
+}
+type TFAzureModel struct {
+	ServicePrincipalId types.String `tfsdk:"service_principal_id"`
+	StorageAccountName types.String `tfsdk:"storage_account_name"`
+	Region             types.String `tfsdk:"region"`
 }
 type TFDbRoleToExecuteModel struct {
 	Role types.String `tfsdk:"role"`

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -398,3 +398,12 @@ func PreCheckAccessToken(tb testing.TB) {
 		tb.Fatal("`MONGODB_ATLAS_ACCESS_TOKEN` must be set for Atlas Access Token acceptance testing")
 	}
 }
+
+func PreCheckStreamConnectionAzureBlobStorage(tb testing.TB) {
+	tb.Helper()
+	PreCheckBasic(tb)
+	if os.Getenv("AZURE_SERVICE_PRINCIPAL_ID") == "" ||
+		os.Getenv("AZURE_BLOB_STORAGE_ACCOUNT_NAME") == "" {
+		tb.Fatal("`AZURE_SERVICE_PRINCIPAL_ID` and `AZURE_BLOB_STORAGE_ACCOUNT_NAME` must be set for Azure Blob Storage stream connection acceptance testing")
+	}
+}

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -403,7 +403,8 @@ func PreCheckStreamConnectionAzureBlobStorage(tb testing.TB) {
 	tb.Helper()
 	PreCheckBasic(tb)
 	if os.Getenv("AZURE_SERVICE_PRINCIPAL_ID") == "" ||
-		os.Getenv("AZURE_BLOB_STORAGE_ACCOUNT_NAME") == "" {
+		os.Getenv("AZURE_BLOB_STORAGE_ACCOUNT_NAME") == "" ||
+		os.Getenv("AZURE_REGION") == "" {
 		tb.Fatal("`AZURE_SERVICE_PRINCIPAL_ID` and `AZURE_BLOB_STORAGE_ACCOUNT_NAME` must be set for Azure Blob Storage stream connection acceptance testing")
 	}
 }

--- a/tools/codegen/models/stream_connection_api.yaml
+++ b/tools/codegen/models/stream_connection_api.yaml
@@ -12,6 +12,12 @@ schema:
                 allowed:
                     - api_name: aws
                       tf_schema_name: aws
+            AzureBlobStorage:
+                allowed:
+                    - api_name: azure
+                      tf_schema_name: azure
+                    - api_name: publicPrivateNetworking
+                      tf_schema_name: networking
             Cluster:
                 allowed:
                     - api_name: clusterName
@@ -255,6 +261,57 @@ schema:
           create_only: false
           present_in_any_response: true
           request_only_required_on_create: false
+        - single_nested:
+            nested_object:
+                attributes:
+                    - string: {}
+                      description: UUID that identifies the Azure Service Principal used to access the Azure Blob Storage account.
+                      computed_optional_required: required
+                      tf_schema_name: service_principal_id
+                      tf_model_name: ServicePrincipalId
+                      api_name: servicePrincipalId
+                      req_body_usage: all_request_bodies
+                      sensitive: false
+                      create_only: false
+                      present_in_any_response: true
+                      request_only_required_on_create: false
+                    - string: {}
+                      description: Name of the Azure Storage account to use. Must be lowercase, 3-24 characters, and contain only letters and numbers.
+                      computed_optional_required: required
+                      tf_schema_name: storage_account_name
+                      tf_model_name: StorageAccountName
+                      api_name: storageAccountName
+                      req_body_usage: all_request_bodies
+                      sensitive: false
+                      create_only: false
+                      present_in_any_response: true
+                      request_only_required_on_create: false
+                    - string: {}
+                      description: Azure region where the storage account is located.
+                      computed_optional_required: computed_optional
+                      tf_schema_name: region
+                      tf_model_name: Region
+                      api_name: region
+                      req_body_usage: all_request_bodies
+                      sensitive: false
+                      create_only: false
+                      present_in_any_response: true
+                      request_only_required_on_create: false
+          description: 'Optional for type: AzureBlobStorage. Azure configurations for Azure Blob Storage connection types.'
+          custom_type:
+            package: customtypes
+            name: Azure
+            model: customtypes.ObjectValue[TFAzureModel]
+            schema: customtypes.NewObjectType[TFAzureModel](ctx)
+          computed_optional_required: optional
+          tf_schema_name: azure
+          tf_model_name: Azure
+          api_name: azure
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
         - string: {}
           description: 'Optional for type: Kafka. Comma separated list of server addresses.'
           computed_optional_required: optional
@@ -447,7 +504,7 @@ schema:
                       create_only: false
                       present_in_any_response: true
                       request_only_required_on_create: false
-          description: 'Optional for type: AWSKinesisDataStreams, Kafka, S3. Networking configuration for Streams connections.'
+          description: 'Optional for type: AWSKinesisDataStreams, AzureBlobStorage, Kafka, S3. Networking configuration for Streams connections.'
           custom_type:
             package: customtypes
             name: Networking


### PR DESCRIPTION
## Description

Adds support for `AzureBlobStorage` as a connection type for stream processing in the `mongodbatlas_stream_connection` resource and data sources.  This allows users to create a connection with an Azure service principal and storage account
.  
Link to any related issue(s): [CLOUDP-383606](https://jira.mongodb.org/browse/CLOUDP-383606)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
For the acceptance tests, I need a storage account with write permissions on the Azure service principal ID, but I'm not sure where to configure that.