### PR TITLE
feat: Add privateEndpointHostnames field to Data Federation resource

### DIFF
--- a/.changelog/4358.txt
+++ b/.changelog/4358.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_federated_database_instance: Adds `private_endpoint_hostnames` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_federated_database_instance: Adds `private_endpoint_hostnames` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_federated_database_instances: Adds `private_endpoint_hostnames` attribute
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -1081,6 +1081,9 @@ jobs:
           AWS_REGION: ${{ inputs.aws_region_federation }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_VPC_ID: ${{ vars.AWS_VPC_ID }}
+          AWS_SUBNET_ID: ${{ vars.AWS_SUBNET_ID }}
+          AWS_SECURITY_GROUP_ID: ${{ vars.AWS_SECURITY_GROUP_ID }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/federateddatabaseinstance

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -1081,9 +1081,6 @@ jobs:
           AWS_REGION: ${{ inputs.aws_region_federation }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_VPC_ID: ${{ vars.AWS_VPC_ID }}
-          AWS_SUBNET_ID: ${{ vars.AWS_SUBNET_ID }}
-          AWS_SECURITY_GROUP_ID: ${{ vars.AWS_SECURITY_GROUP_ID }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/federateddatabaseinstance

--- a/docs/data-sources/federated_database_instance.md
+++ b/docs/data-sources/federated_database_instance.md
@@ -59,8 +59,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
 * `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
-  * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
-  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
+  * `private_endpoint_hostnames.#.hostname` -  Human-readable label that identifies the host.
+  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label that identifies the private endpoint.
 * `state` - Current state of the Federated Database Instance:
   * `ACTIVE` - The Federated Database Instance is active and verified. You can query the data stores associated with the Federated Database Instance.
   * `DELETED` - The Federated Database Instance was deleted.

--- a/docs/data-sources/federated_database_instance.md
+++ b/docs/data-sources/federated_database_instance.md
@@ -58,7 +58,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
-* `private_endpoint_hostnames` - The list of private endpoint hostnames assiged to the Federated Database Instance.
+* `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
   * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
   * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
 * `state` - Current state of the Federated Database Instance:

--- a/docs/data-sources/federated_database_instance.md
+++ b/docs/data-sources/federated_database_instance.md
@@ -58,6 +58,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
+* `private_endpoint_hostnames` - The list of private endpoint hostnames assiged to the Federated Database Instance.
+  * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
+  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
 * `state` - Current state of the Federated Database Instance:
   * `ACTIVE` - The Federated Database Instance is active and verified. You can query the data stores associated with the Federated Database Instance.
   * `DELETED` - The Federated Database Instance was deleted.

--- a/docs/data-sources/federated_database_instances.md
+++ b/docs/data-sources/federated_database_instances.md
@@ -34,7 +34,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
-* `private_endpoint_hostnames` - The list of private endpoint hostnames assiged to the Federated Database Instance.
+* `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
   * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
   * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
 * `state` - Current state of the Federated Database Instance:

--- a/docs/data-sources/federated_database_instances.md
+++ b/docs/data-sources/federated_database_instances.md
@@ -35,8 +35,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
 * `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
-  * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
-  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
+  * `private_endpoint_hostnames.#.hostname` -  Human-readable label that identifies the host.
+  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label that identifies the private endpoint.
 * `state` - Current state of the Federated Database Instance:
   * `ACTIVE` - The Federated Database Instance is active and verified. You can query the data stores associated with the Federated Database Instance.
   * `DELETED` - The Federated Database Instance was deleted.

--- a/docs/data-sources/federated_database_instances.md
+++ b/docs/data-sources/federated_database_instances.md
@@ -34,6 +34,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
+* `private_endpoint_hostnames` - The list of private endpoint hostnames assiged to the Federated Database Instance.
+  * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
+  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
 * `state` - Current state of the Federated Database Instance:
   * `ACTIVE` - The Federated Database Instance is active and verified. You can query the data stores associated with the Federated Database Instance.
   * `DELETED` - The Federated Database Instance was deleted.

--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -214,6 +214,9 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
 * `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
+
+  -> **NOTE:** This field is populated asynchronously by Atlas after the private endpoint is registered and may be empty immediately after `apply`. Use a [`time_sleep`](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) resource if you need to reference this value in downstream resources.
+
   * `private_endpoint_hostnames.#.hostname` -  Human-readable label that identifies the host.
   * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label that identifies the private endpoint.
 * `state` - Current state of the Federated Database Instance:

--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -213,7 +213,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
-* `private_endpoint_hostnames` - The list of private endpoint hostnames assiged to the Federated Database Instance.
+* `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
   * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
   * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
 * `state` - Current state of the Federated Database Instance:

--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -215,7 +215,7 @@ In addition to all arguments above, the following attributes are exported:
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
 * `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
 
-  -> **NOTE:** This field is populated asynchronously by Atlas after the private endpoint is registered and may be empty immediately after `apply`. Use a [`time_sleep`](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) resource if you need to reference this value in downstream resources.
+  -> **NOTE:** When the private endpoint and the federated database instance are created in the same `apply`, this field may be empty as Atlas populates it asynchronously. In that case, run `terraform apply -refresh-only` after the initial apply to update the state with the populated hostnames, then run `terraform apply` again if you have downstream resources that consume this value.
 
   * `private_endpoint_hostnames.#.hostname` -  Human-readable label that identifies the host.
   * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label that identifies the private endpoint.

--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -213,6 +213,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
+* `private_endpoint_hostnames` - The list of private endpoint hostnames assiged to the Federated Database Instance.
+  * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
+  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
 * `state` - Current state of the Federated Database Instance:
   * `ACTIVE` - The Federated Database Instance is active and verified. You can query the data stores associated with the Federated Database Instance.
   * `DELETED` - The Federated Database Instance was deleted.

--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -214,8 +214,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The Terraform's unique identifier used internally for state management.
 * `hostnames` - The list of hostnames assigned to the Federated Database Instance. Each string in the array is a hostname assigned to the Federated Database Instance.
 * `private_endpoint_hostnames` - The list of private endpoint hostnames assigned to the Federated Database Instance.
-  * `private_endpoint_hostnames.#.hostname` - Human-readable label identifying the hostname.
-  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label identifying the private endpoint.
+  * `private_endpoint_hostnames.#.hostname` -  Human-readable label that identifies the host.
+  * `private_endpoint_hostnames.#.private_endpoint` - Human-readable label that identifies the private endpoint.
 * `state` - Current state of the Federated Database Instance:
   * `ACTIVE` - The Federated Database Instance is active and verified. You can query the data stores associated with the Federated Database Instance.
   * `DELETED` - The Federated Database Instance was deleted.

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/README.md
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/README.md
@@ -1,0 +1,51 @@
+# Example - MongoDB Atlas Federated Database Instance with Private Endpoint - AWS
+
+This example shows how to configure a [MongoDB Atlas Federated Database Instance](https://www.mongodb.com/docs/atlas/data-federation/overview/) with an AWS Private Endpoint
+
+## Dependencies
+
+* Terraform >= 1.0
+* A MongoDB Atlas account
+* An AWS account
+
+## Usage
+
+**1\. Set up credentials.**
+
+```bash
+export MONGODB_ATLAS_CLIENT_ID="<ATLAS_CLIENT_ID>"
+export MONGODB_ATLAS_CLIENT_SECRET="<ATLAS_CLIENT_SECRET>"
+export AWS_ACCESS_KEY_ID="<AWS_ACCESS_KEY_ID>"
+export AWS_SECRET_ACCESS_KEY="<AWS_SECRET_ACCESS_KEY>"
+```
+
+**2\. Set required variables.**
+
+Create a `terraform.tfvars` file:
+
+```hcl
+project_id       = "<ATLAS_PROJECT_ID>"
+vpce_service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-<ID>"
+```
+
+You can find the `vpce_service_name` for your region in the [Atlas Data Federation private endpoint documentation](https://www.mongodb.com/docs/atlas/data-federation/tutorial/config-private-endpoint/?cloud-provider=aws&interface=atlas-ui#choose-a-cloud-provider-and-region.).
+
+**3\. Review the Terraform plan.**
+
+```bash
+terraform plan
+```
+
+**4\. Apply.**
+
+```bash
+terraform apply
+```
+
+> **Note:** `private_endpoint_hostnames` is populated asynchronously by Atlas and will be empty on the first apply if the private endpoint is created within the same `apply`. After the initial apply completes, run `terraform apply -refresh-only` to update the state with the populated hostnames. If you have downstream resources that consume this value, run `terraform apply` afterwards as well.
+
+**5\. Destroy the resources.**
+
+```bash
+terraform destroy
+```

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/main.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/main.tf
@@ -1,0 +1,44 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_subnet" "this" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.subnet_cidr
+  availability_zone = var.availability_zone
+}
+
+data "aws_security_group" "default" {
+  name   = "default"
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_vpc_endpoint" "this" {
+  vpc_id             = aws_vpc.this.id
+  service_name       = var.vpce_service_name
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = [aws_subnet.this.id]
+  security_group_ids = [data.aws_security_group.default.id]
+}
+
+resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "this" {
+  project_id                 = var.project_id
+  endpoint_id                = aws_vpc_endpoint.this.id
+  provider_name              = "AWS"
+  region                     = var.atlas_region
+  customer_endpoint_dns_name = aws_vpc_endpoint.this.dns_entry[0].dns_name
+}
+
+resource "mongodbatlas_federated_database_instance" "this" {
+  project_id = var.project_id
+  name       = var.federated_instance_name
+
+  data_process_region {
+    cloud_provider = "AWS"
+    region         = "VIRGINIA_USA"
+  }
+
+  depends_on = [mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.this]
+}

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/outputs.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/outputs.tf
@@ -2,7 +2,7 @@ output "private_endpoint_hostnames" {
   description = "Private endpoint hostnames assigned to the Federated Database Instance"
   value       = mongodbatlas_federated_database_instance.this.private_endpoint_hostnames
 }
-output "mongodbatlas_fdata_federation_instance_name" {
+output "mongodbatlas_data_federation_instance_name" {
   description = "Name of the MongoDB Atlas Federated Database Instance"
   value       = mongodbatlas_federated_database_instance.this.name
 }

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/outputs.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/outputs.tf
@@ -2,3 +2,12 @@ output "private_endpoint_hostnames" {
   description = "Private endpoint hostnames assigned to the Federated Database Instance"
   value       = mongodbatlas_federated_database_instance.this.private_endpoint_hostnames
 }
+output "mongodbatlas_fdata_federation_instance_name" {
+  description = "Name of the MongoDB Atlas Federated Database Instance"
+  value       = mongodbatlas_federated_database_instance.this.name
+}
+
+output "vpc_endpoint_id" {
+  description = "ID of the AWS VPC endpoint"
+  value       = aws_vpc_endpoint.this.id
+}

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/outputs.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/outputs.tf
@@ -1,0 +1,4 @@
+output "private_endpoint_hostnames" {
+  description = "Private endpoint hostnames assigned to the Federated Database Instance"
+  value       = mongodbatlas_federated_database_instance.this.private_endpoint_hostnames
+}

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/provider.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/provider.tf
@@ -1,7 +1,6 @@
 provider "mongodbatlas" {
   client_id     = var.atlas_client_id
   client_secret = var.atlas_client_secret
-  base_url      = "https://cloud-dev.mongodb.com"
 }
 
 provider "aws" {

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/provider.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/provider.tf
@@ -1,0 +1,9 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+  base_url      = "https://cloud-dev.mongodb.com"
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/variables.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/variables.tf
@@ -41,14 +41,17 @@ variable "vpce_service_name" {
 variable "vpc_cidr" {
   description = "CIDR block for the VPC"
   type        = string
+  default     = "10.0.0.0/16"
 }
 
 variable "subnet_cidr" {
   description = "CIDR block for the subnet"
   type        = string
+  default     = "10.0.1.0/24"
 }
 
 variable "availability_zone" {
   description = "Availability zone for the subnet"
   type        = string
+  default     = "us-east-1a"
 }

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/variables.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/variables.tf
@@ -29,7 +29,7 @@ variable "aws_region" {
 }
 
 variable "atlas_region" {
-  description = "Atlas region (e.g. US_EAST_1). Must match the AWS region."
+  description = "Atlas region for the private endpoint in uppercase underscore format (e.g. US_EAST_1). Must match the AWS region. See https://www.mongodb.com/docs/atlas/data-federation/adf-overview/regions/ for the mapping between AWS and Atlas regions."
   type        = string
 }
 

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/variables.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/variables.tf
@@ -1,0 +1,54 @@
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "project_id" {
+  description = "MongoDB Atlas Project ID"
+  type        = string
+}
+
+variable "federated_instance_name" {
+  description = "Name of the MongoDB Atlas Federated Database Instance"
+  type        = string
+  default     = "federated-instance-privatelink"
+}
+
+variable "aws_region" {
+  description = "AWS Region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "atlas_region" {
+  description = "Atlas region (e.g. US_EAST_1). Must match the AWS region."
+  type        = string
+}
+
+variable "vpce_service_name" {
+  description = "AWS PrivateLink service name for Atlas Data Federation in your region. See https://www.mongodb.com/docs/atlas/data-federation/tutorial/config-private-endpoint/ for the value for your region."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "CIDR block for the subnet"
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "Availability zone for the subnet"
+  type        = string
+}

--- a/examples/mongodbatlas_federated_database_instance/private-endpoint/versions.tf
+++ b/examples/mongodbatlas_federated_database_instance/private-endpoint/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
@@ -33,6 +33,22 @@ func DataSource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"private_endpoint_hostnames": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"cloud_provider_config": cloudProviderConfig(true),
 			"data_process_region": {
 				Type:     schema.TypeList,
@@ -318,6 +334,10 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstanceRead(ctx context.Context, d 
 
 	if err := d.Set("hostnames", dataFederationInstance.Hostnames); err != nil {
 		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "hostnames", name, err))
+	}
+
+	if err := d.Set("private_endpoint_hostnames", flattenPrivateEndpointHostnames(dataFederationInstance.GetPrivateEndpointHostnames())); err != nil {
+		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "private_endpoint_hostnames", name, err))
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance_test.go
@@ -39,6 +39,7 @@ func TestAccFederatedDatabaseInstanceDS_s3Bucket(t *testing.T) {
 					checkAttributes(&federatedInstance, name),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "private_endpoint_hostnames.#", "0"),
 				),
 			},
 		},

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
@@ -45,6 +45,22 @@ func PluralDataSource() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"private_endpoint_hostnames": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"hostname": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"private_endpoint": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"cloud_provider_config": cloudProviderConfig(true),
 						"data_process_region": {
 							Type:     schema.TypeList,
@@ -100,14 +116,15 @@ func flattenFederatedDatabaseInstances(d *schema.ResourceData, projectID string,
 
 		for i := range federatedDatabaseInstances {
 			federatedDatabaseInstancesMap[i] = map[string]any{
-				"project_id":            projectID,
-				"name":                  federatedDatabaseInstances[i].GetName(),
-				"state":                 federatedDatabaseInstances[i].GetState(),
-				"hostnames":             federatedDatabaseInstances[i].GetHostnames(),
-				"cloud_provider_config": flattenCloudProviderConfig(d, federatedDatabaseInstances[i].CloudProviderConfig),
-				"data_process_region":   flattenDataProcessRegion(federatedDatabaseInstances[i].DataProcessRegion),
-				"storage_databases":     flattenDataFederationDatabase(federatedDatabaseInstances[i].Storage.GetDatabases()),
-				"storage_stores":        flattenDataFederationStores(federatedDatabaseInstances[i].Storage.GetStores()),
+				"project_id":                 projectID,
+				"name":                       federatedDatabaseInstances[i].GetName(),
+				"state":                      federatedDatabaseInstances[i].GetState(),
+				"hostnames":                  federatedDatabaseInstances[i].GetHostnames(),
+				"cloud_provider_config":      flattenCloudProviderConfig(d, federatedDatabaseInstances[i].CloudProviderConfig),
+				"data_process_region":        flattenDataProcessRegion(federatedDatabaseInstances[i].DataProcessRegion),
+				"storage_databases":          flattenDataFederationDatabase(federatedDatabaseInstances[i].Storage.GetDatabases()),
+				"storage_stores":             flattenDataFederationStores(federatedDatabaseInstances[i].Storage.GetStores()),
+				"private_endpoint_hostnames": flattenPrivateEndpointHostnames(federatedDatabaseInstances[i].GetPrivateEndpointHostnames()),
 			}
 		}
 	}

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instances_test.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instances_test.go
@@ -32,6 +32,7 @@ func TestAccFederatedDatabaseInstanceDSPlural_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttr(resourceName, "results.0.private_endpoint_hostnames.#", "0"),
 				),
 			},
 		},

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -413,12 +413,8 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "hostnames", name, err))
 	}
 
-	if val, ok := dataFederationInstance.GetPrivateEndpointHostnamesOk(); ok {
-		if privateEndpointHostnamesField := flattenPrivateEndpointHostnames(*val); privateEndpointHostnamesField != nil {
-			if err := d.Set("private_endpoint_hostnames", privateEndpointHostnamesField); err != nil {
-				return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "private_endpoint_hostnames", name, err))
-			}
-		}
+	if err := d.Set("private_endpoint_hostnames", flattenPrivateEndpointHostnames(dataFederationInstance.GetPrivateEndpointHostnames())); err != nil {
+		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "private_endpoint_hostnames", name, err))
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
@@ -538,12 +534,8 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 		return nil, fmt.Errorf(errorFederatedDatabaseInstanceSetting, "hostnames", name, err)
 	}
 
-	if val, ok := dataFederationInstance.GetPrivateEndpointHostnamesOk(); ok {
-		if privateEndpointHostnamesField := flattenPrivateEndpointHostnames(*val); privateEndpointHostnamesField != nil {
-			if err := d.Set("private_endpoint_hostnames", privateEndpointHostnamesField); err != nil {
-				return nil, fmt.Errorf(errorFederatedDatabaseInstanceSetting, "private_endpoint_hostnames", name, err)
-			}
-		}
+	if err := d.Set("private_endpoint_hostnames", flattenPrivateEndpointHostnames(dataFederationInstance.GetPrivateEndpointHostnames())); err != nil {
+		return nil, fmt.Errorf(errorFederatedDatabaseInstanceSetting, "private_endpoint_hostnames", name, err)
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
@@ -896,10 +888,6 @@ func flattenDataFederationStores(stores []admin.DataLakeStoreSettings) []map[str
 }
 
 func flattenPrivateEndpointHostnames(privateEndpointHostnames []admin.PrivateEndpointHostname) []map[string]any {
-	if len(privateEndpointHostnames) == 0 {
-		return nil
-	}
-
 	result := make([]map[string]any, len(privateEndpointHostnames))
 	for i, h := range privateEndpointHostnames {
 		result[i] = map[string]any{

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -53,6 +53,22 @@ func Resource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"private_endpoint_hostnames": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			// Optional-only behavior from the API, but keeping O+C to avoid behavior changes.
 			"cloud_provider_config": cloudProviderConfig(false),
 			"data_process_region": {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -413,6 +413,14 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "hostnames", name, err))
 	}
 
+	if val, ok := dataFederationInstance.GetPrivateEndpointHostnamesOk(); ok {
+		if privateEndpointHostnamesField := flattenPrivateEndpointHostnames(*val); privateEndpointHostnamesField != nil {
+			if err := d.Set("private_endpoint_hostnames", privateEndpointHostnamesField); err != nil {
+				return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "private_endpoint_hostnames", name, err))
+			}
+		}
+	}
+
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id": projectID,
 		"name":       name,
@@ -528,6 +536,14 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 
 	if err := d.Set("hostnames", dataFederationInstance.GetHostnames()); err != nil {
 		return nil, fmt.Errorf(errorFederatedDatabaseInstanceSetting, "hostnames", name, err)
+	}
+
+	if val, ok := dataFederationInstance.GetPrivateEndpointHostnamesOk(); ok {
+		if privateEndpointHostnamesField := flattenPrivateEndpointHostnames(*val); privateEndpointHostnamesField != nil {
+			if err := d.Set("private_endpoint_hostnames", privateEndpointHostnamesField); err != nil {
+				return nil, fmt.Errorf(errorFederatedDatabaseInstanceSetting, "private_endpoint_hostnames", name, err)
+			}
+		}
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
@@ -877,6 +893,21 @@ func flattenDataFederationStores(stores []admin.DataLakeStoreSettings) []map[str
 	}
 
 	return store
+}
+
+func flattenPrivateEndpointHostnames(privateEndpointHostnames []admin.PrivateEndpointHostname) []map[string]any {
+	if len(privateEndpointHostnames) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]any, len(privateEndpointHostnames))
+	for i, h := range privateEndpointHostnames {
+		result[i] = map[string]any{
+			"hostname":         h.GetHostname(),
+			"private_endpoint": h.GetPrivateEndpoint(),
+		}
+	}
+	return result
 }
 
 func newReadPreferenceField(atlasReadPreference *admin.DataLakeAtlasStoreReadPreference) []map[string]any {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -599,21 +599,18 @@ data "mongodbatlas_federated_database_instance" "test" {
 
 func TestAccFederatedDatabaseInstance_withPrivateEndpoint(t *testing.T) {
 	var (
-		projectID       = acc.ProjectIDExecution(t)
-		name            = acc.RandomName()
-		vpcID           = os.Getenv("AWS_VPC_ID")
-		subnetID        = os.Getenv("AWS_SUBNET_ID")
-		securityGroupID = os.Getenv("AWS_SECURITY_GROUP_ID")
+		projectID = acc.ProjectIDExecution(t)
+		name      = acc.RandomName()
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckAwsEnvPrivateLinkEndpointService(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckAwsEnvBasic(t) },
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyFederatedDatabaseInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateEndpoint(projectID, name, vpcID, subnetID, securityGroupID),
+				Config: configWithPrivateEndpoint(projectID, name),
 			},
 			{
 				PreConfig:    waitForStatusUpdate,
@@ -632,14 +629,41 @@ func waitForStatusUpdate() {
 	time.Sleep(1 * time.Minute)
 }
 
-func configWithPrivateEndpoint(projectID, name, vpcID, subnetID, securityGroupID string) string {
+func configWithPrivateEndpoint(projectID, name string) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 resource "aws_vpc_endpoint" "test" {
-  vpc_id              = %[3]q
+  vpc_id              = aws_vpc.test.id
   service_name        = "com.amazonaws.vpce.us-east-1.vpce-svc-0a7247db33497082e"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [%[4]q]
-  security_group_ids  = [%[5]q]
+  subnet_ids          = [aws_subnet.test.id]
+  security_group_ids  = [aws_security_group.test.id]
   private_dns_enabled = true
 }
 
@@ -663,7 +687,7 @@ resource "mongodbatlas_federated_database_instance" "test" {
 
   depends_on = [mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.test]
 }
-`, projectID, name, vpcID, subnetID, securityGroupID)
+`, projectID, name)
 }
 
 func configFirstStepsUpdate(federatedInstanceName, projectName, orgID string) string {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -594,6 +595,75 @@ data "mongodbatlas_federated_database_instance" "test" {
 	name = mongodbatlas_federated_database_instance.test.name
 }
 	`, federatedInstanceName, projectName, orgID)
+}
+
+func TestAccFederatedDatabaseInstance_withPrivateEndpoint(t *testing.T) {
+	var (
+		projectID       = acc.ProjectIDExecution(t)
+		name            = acc.RandomName()
+		vpcID           = os.Getenv("AWS_VPC_ID")
+		subnetID        = os.Getenv("AWS_SUBNET_ID")
+		securityGroupID = os.Getenv("AWS_SECURITY_GROUP_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckAwsEnvPrivateLinkEndpointService(t) },
+		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyFederatedDatabaseInstance,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithPrivateEndpoint(projectID, name, vpcID, subnetID, securityGroupID),
+			},
+			{
+				PreConfig:    waitForStatusUpdate,
+				RefreshState: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "private_endpoint_hostnames.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_endpoint_hostnames.0.hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_endpoint_hostnames.0.private_endpoint"),
+				),
+			},
+		},
+	})
+}
+
+func waitForStatusUpdate() {
+	time.Sleep(1 * time.Minute)
+}
+
+func configWithPrivateEndpoint(projectID, name, vpcID, subnetID, securityGroupID string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc_endpoint" "test" {
+  vpc_id              = %[3]q
+  service_name        = "com.amazonaws.vpce.us-east-1.vpce-svc-0a7247db33497082e"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [%[4]q]
+  security_group_ids  = [%[5]q]
+  private_dns_enabled = true
+}
+
+resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
+  project_id                 = %[1]q
+  endpoint_id                = aws_vpc_endpoint.test.id
+  provider_name              = "AWS"
+  comment                    = "Terraform Acceptance Test"
+  customer_endpoint_dns_name = aws_vpc_endpoint.test.dns_entry[0].dns_name
+  region                     = "US_EAST_1"
+}
+
+resource "mongodbatlas_federated_database_instance" "test" {
+  project_id = %[1]q
+  name       = %[2]q
+
+  data_process_region {
+    cloud_provider = "AWS"
+    region         = "VIRGINIA_USA"
+  }
+
+  depends_on = [mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.test]
+}
+`, projectID, name, vpcID, subnetID, securityGroupID)
 }
 
 func configFirstStepsUpdate(federatedInstanceName, projectName, orgID string) string {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -31,6 +31,7 @@ func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
 		"storage_stores.0.read_preference.0.tag_sets.#":             "2",
 		"storage_stores.0.read_preference.0.tag_sets.0.tags.#":      "2",
 		"storage_databases.0.collections.0.data_sources.0.database": "sample_airbnb",
+		"private_endpoint_hostnames.#":                              "0",
 	}
 	setChecks := []string{"project_id", "storage_stores.0.read_preference.0.tag_sets.#"}
 	firstStepChecks := acc.AddAttrChecks(resourceName, nil, valueChecks)

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -203,6 +203,9 @@ func TestAccFederatedDatabaseInstance_withPrivateEndpoint(t *testing.T) {
 				Config: configWithPrivateEndpoint(projectID, name),
 			},
 			{
+				// privateEndpointHostnames is populated asynchronously after the endpoint is registered.
+				// PreConfig waits for Atlas to finish, and RefreshState is needed so the Check runs against
+				// the latest API state instead of the cached state (hostnames were empty).
 				PreConfig:    waitForStatusUpdate,
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -626,7 +626,7 @@ func TestAccFederatedDatabaseInstance_withPrivateEndpoint(t *testing.T) {
 }
 
 func waitForStatusUpdate() {
-	time.Sleep(1 * time.Minute)
+	time.Sleep(2 * time.Minute)
 }
 
 func configWithPrivateEndpoint(projectID, name string) string {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -187,6 +187,34 @@ func TestAccFederatedDatabaseInstance_atlasCluster(t *testing.T) {
 	})
 }
 
+func TestAccFederatedDatabaseInstance_withPrivateEndpoint(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+		name      = acc.RandomName()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckAwsEnvBasic(t) },
+		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyFederatedDatabaseInstance,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithPrivateEndpoint(projectID, name),
+			},
+			{
+				PreConfig:    waitForStatusUpdate,
+				RefreshState: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "private_endpoint_hostnames.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_endpoint_hostnames.0.hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_endpoint_hostnames.0.private_endpoint"),
+				),
+			},
+		},
+	})
+}
+
 func configWithCluster(terraformStr, projectID, cluster1ResourceName, cluster2ResourceName, name string) string {
 	return fmt.Sprintf(`
 	  %[1]s
@@ -595,34 +623,6 @@ data "mongodbatlas_federated_database_instance" "test" {
 	name = mongodbatlas_federated_database_instance.test.name
 }
 	`, federatedInstanceName, projectName, orgID)
-}
-
-func TestAccFederatedDatabaseInstance_withPrivateEndpoint(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		name      = acc.RandomName()
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckAwsEnvBasic(t) },
-		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyFederatedDatabaseInstance,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithPrivateEndpoint(projectID, name),
-			},
-			{
-				PreConfig:    waitForStatusUpdate,
-				RefreshState: true,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "private_endpoint_hostnames.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "private_endpoint_hostnames.0.hostname"),
-					resource.TestCheckResourceAttrSet(resourceName, "private_endpoint_hostnames.0.private_endpoint"),
-				),
-			},
-		},
-	})
 }
 
 func waitForStatusUpdate() {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -647,15 +647,9 @@ resource "aws_subnet" "test" {
   availability_zone = "us-east-1a"
 }
 
-resource "aws_security_group" "test" {
+data "aws_security_group" "default" {
+  name   = "default"
   vpc_id = aws_vpc.test.id
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 resource "aws_vpc_endpoint" "test" {
@@ -663,8 +657,7 @@ resource "aws_vpc_endpoint" "test" {
   service_name        = "com.amazonaws.vpce.us-east-1.vpce-svc-0a7247db33497082e"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = [aws_subnet.test.id]
-  security_group_ids  = [aws_security_group.test.id]
-  private_dns_enabled = true
+  security_group_ids  = [data.aws_security_group.default.id]
 }
 
 resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -631,10 +631,6 @@ func waitForStatusUpdate() {
 
 func configWithPrivateEndpoint(projectID, name string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true


### PR DESCRIPTION
## Description

This PR adds the computed attribute `private_endpoint_hostnames` to `mongodbatlas_federated_database_instance` resource, and corresponding data sources `mongodbatlas_federated_database_instance` and `mongodbatlas_federated_database_instances`.

Link to any related issue(s): [CLOUDP-391245](https://jira.mongodb.org/browse/CLOUDP-391245)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [X] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fix and verified my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
