### PR TITLE
chore: Rename api_spec_url to spec_source in autogen make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,10 +158,12 @@ scaffold: ## Create scaffolding for a new resource
 	@echo "Reminder: configure the new $(type) in provider.go"
 
 # Generate flattened API spec used by codegen
-# api_spec_url (optional) - URL to the OpenAPI spec (default: https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml).
+# spec_source (optional) - URL or local file path to the OpenAPI spec (default: https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml).
+# e.g. make autogen-update-api-spec spec_source=https://raw.githubusercontent.com/mongodb/openapi/dev/openapi/v2.yaml
+# e.g. make autogen-update-api-spec spec_source=/tmp/mms-spec.json
 .PHONY: autogen-update-api-spec
 autogen-update-api-spec:
-	@scripts/generate-autogen-api-spec.sh $(api_spec_url)
+	@scripts/generate-autogen-api-spec.sh $(spec_source)
 
 # Generate resources using API spec present in tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
 # resource_name (optional) - If not provided all configured resource models will be generated.
@@ -173,7 +175,7 @@ autogen-generate-resources:
 	@go run ./tools/codegen/main.go $(if $(resource_name),--resource-name $(resource_name),) $(if $(resource_tier),--resource-tier $(resource_tier),) $(if $(step),--step $(step),)
 
 # Complete generation pipeline: Fetch latest API Spec -> update resource models -> generate resource code
-# api_spec_url (optional) - URL to the OpenAPI spec (default: https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml).
+# spec_source (optional) - URL or local file path to the OpenAPI spec (default: https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml).
 # resource_name (optional) - If not provided all configured resources code will be generated
 # resource_tier (optional) - Valid values: `prod`, `internal` (default: all)
 # step (optional) - Valid values: `model-gen`, `code-gen` (default: both).

--- a/scripts/generate-autogen-api-spec.sh
+++ b/scripts/generate-autogen-api-spec.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_SPEC_URL="${1:-https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml}"
+# Accepts a URL or a local file path to an OpenAPI spec.
+# If a local file is provided, it is copied directly; otherwise, it is downloaded from the given URL.
+SPEC_SOURCE="${1:-https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml}"
 SPEC_PATH="tools/codegen/atlasapispec/raw-multi-version-api-spec.yml"
 FLATTENED_SPEC_PATH="tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml"
 
 mkdir -p "$(dirname "${SPEC_PATH}")"
 
-echo "Downloading OpenAPI spec from ${SOURCE_SPEC_URL}..."
-curl -fsSL "${SOURCE_SPEC_URL}" -o "${SPEC_PATH}"
+if [[ -f "${SPEC_SOURCE}" ]]; then
+  echo "Copying local spec from ${SPEC_SOURCE}..."
+  cp "${SPEC_SOURCE}" "${SPEC_PATH}"
+else
+  echo "Downloading OpenAPI spec from ${SPEC_SOURCE}..."
+  curl -fsSL "${SPEC_SOURCE}" -o "${SPEC_PATH}"
+fi
 
 echo "Saved spec to ${SPEC_PATH}"
 


### PR DESCRIPTION
## Description

Adjust `autogen-update-api-spec` and `autogen-pipeline` Makefile targets to support both URLs and local file paths for target API Spec. This is useful when using an API spec that has been fetched from a private source (e.g., an internal repo) and is made available locally.

Link to any related issue(s): CLOUDP-393164

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.