### PR TITLE
chore: Add make link-skills command to symlink AI agent skills directories

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-    "install": "make tools link-git-hooks"
+    "install": "make tools link-git-hooks link-skills"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin
 .windsurf
 CLAUDE.md
 .claude
+.cursor/skills
 *.env
 *.bak
 *.log

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,13 @@ link-git-hooks: ## Install Git hooks
 	find .git/hooks -type l -exec rm {} \;
 	find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
 
+.PHONY: link-skills
+link-skills: ## Create symlinks for AI agent skills
+	@echo "==> Linking skills directories..."
+	@mkdir -p .claude .cursor
+	@ln -sfn ../.agents/skills .claude/skills
+	@ln -sfn ../.agents/skills .cursor/skills
+
 .PHONY: update-atlas-sdk
 update-atlas-sdk: ## Update the Atlas SDK dependency
 	./scripts/update-sdk.sh

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,13 @@ link-git-hooks: ## Install Git hooks
 link-skills: ## Create symlinks for AI agent skills
 	@echo "==> Linking skills directories..."
 	@mkdir -p .claude .cursor
-	@ln -sfn ../.agents/skills .claude/skills
-	@ln -sfn ../.agents/skills .cursor/skills
+	@for dir in .claude/skills .cursor/skills; do \
+		if [ -d "$$dir" ] && [ ! -L "$$dir" ]; then \
+			echo "Error: $$dir is an existing directory. Remove it manually before running this command." >&2; \
+			exit 1; \
+		fi; \
+		ln -sfn ../.agents/skills "$$dir"; \
+	done
 
 .PHONY: update-atlas-sdk
 update-atlas-sdk: ## Update the Atlas SDK dependency

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -21,7 +21,8 @@
 ### Building
 - Enter the provider directory
 - Run `make tools` to install the needed tools for the provider
-- Run `make link-git-hooks` to install githooks 
+- Run `make link-git-hooks` to install githooks
+- Run `make link-skills` to set up AI agent skill symlinks
 - Run `make fix` to format (`gofmt`, `goimports`), lint, and build the binary in the `./bin` directory:
 - Use the local provider binary in the `./bin` folder:
   - Create the following `dev.trfc` file inside your directory 


### PR DESCRIPTION
## Description

Adds a `make link-skills` Makefile target that creates symlinks from `.claude/skills` and `.cursor/skills` to the versioned `.agents/skills` directory. This ensures all developers have consistent AI agent skill configurations across tools without having to keep symlinks commited (multiple root level directories) in the repo.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments