### PR TITLE
doc: Remove mention of Public Preview for GCP note

### DIFF
--- a/docs/resources/online_archive.md
+++ b/docs/resources/online_archive.md
@@ -10,7 +10,6 @@ subcategory: "Online Archive"
 
 ~> **IMPORTANT:** There are fields that are immutable after creation, i.e if `date_field` value does not exist in the collection, the online archive state will be pending forever, and this field cannot be updated, that means a destroy is required, known error `ONLINE_ARCHIVE_CANNOT_MODIFY_FIELD`
 
-~> **IMPORTANT:** Support for Online Archive on `GCP` is available in Private Preview. To request access and participate in the Private Preview release of this feature, complete the [sign-up form](https://www.mongodb.com/products/platform/atlas-online-archive#promo).
 
 ## Example Usages
 ```terraform

--- a/docs/resources/online_archive.md
+++ b/docs/resources/online_archive.md
@@ -10,7 +10,6 @@ subcategory: "Online Archive"
 
 ~> **IMPORTANT:** There are fields that are immutable after creation, i.e if `date_field` value does not exist in the collection, the online archive state will be pending forever, and this field cannot be updated, that means a destroy is required, known error `ONLINE_ARCHIVE_CANNOT_MODIFY_FIELD`
 
-
 ## Example Usages
 ```terraform
 resource "mongodbatlas_online_archive" "test" {


### PR DESCRIPTION
## Description

The [documentation](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/online_archive) for the `mongodbatlas_online_archive` resource is showing a note mentioning the following:

> Support for Online Archive on GCP is available in Private Preview. To request access and participate in the Private Preview release of this feature, complete the [sign-up form](https://www.mongodb.com/products/platform/atlas-online-archive#promo).

This note is outdated, as Online Archive currently supports GCP on GA as the documentation points out: https://www.mongodb.com/docs/atlas/online-archive/configure-online-archive/

Therefore, this note needs to be removed.

Link to any related issue(s): CLOUDP-396559

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [X] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fix and verified my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
