### PR TITLE
fix: Allows `timeouts` update to `mongodbatlas_encryption_at_rest_private_endpoint`

### DIFF
--- a/.changelog/4377.txt
+++ b/.changelog/4377.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_encryption_at_rest_private_endpoint: Fixes inconsistent state error when adding `timeouts` block to an existing resource
+```

--- a/internal/service/encryptionatrestprivateendpoint/resource.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource.go
@@ -124,6 +124,18 @@ func (r *encryptionAtRestPrivateEndpointRS) Read(ctx context.Context, req resour
 }
 
 func (r *encryptionAtRestPrivateEndpointRS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state TFEarPrivateEndpointModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var plan TFEarPrivateEndpointModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Timeouts = plan.Timeouts
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	resp.Diagnostics.AddWarning(warnUnsupportedOperation, "Updating the private endpoint for encryption at rest is not supported. To modify your infrastructure, please delete the existing mongodbatlas_encryption_at_rest_private_endpoint resource and create a new one with the necessary updates")
 }
 

--- a/internal/service/encryptionatrestprivateendpoint/resource.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource.go
@@ -138,6 +138,9 @@ func (r *encryptionAtRestPrivateEndpointRS) Update(ctx context.Context, req reso
 	// Writing the full plan would hide API-owned attribute drift from future plans.
 	state.Timeouts = plan.Timeouts
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.Diagnostics.AddWarning(warnUnsupportedOperation, "Updating the private endpoint for encryption at rest is not supported. To modify your infrastructure, please delete the existing mongodbatlas_encryption_at_rest_private_endpoint resource and create a new one with the necessary updates")
 }
 

--- a/internal/service/encryptionatrestprivateendpoint/resource.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource.go
@@ -134,6 +134,8 @@ func (r *encryptionAtRestPrivateEndpointRS) Update(ctx context.Context, req reso
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Only copy Terraform-managed fields (Timeouts) from plan into prior state.
+	// Writing the full plan would hide API-owned attribute drift from future plans.
 	state.Timeouts = plan.Timeouts
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	resp.Diagnostics.AddWarning(warnUnsupportedOperation, "Updating the private endpoint for encryption at rest is not supported. To modify your infrastructure, please delete the existing mongodbatlas_encryption_at_rest_private_endpoint resource and create a new one with the necessary updates")

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -35,7 +35,7 @@ func importStep(config string) resource.TestStep {
 		ImportStateIdFunc:       importStateIDFunc(resourceName),
 		ImportState:             true,
 		ImportStateVerify:       true,
-		ImportStateVerifyIgnore: []string{"delete_on_create_timeout"},
+		ImportStateVerifyIgnore: []string{"delete_on_create_timeout", "timeouts"},
 	}
 }
 
@@ -194,7 +194,9 @@ func basicTestCaseAWS(tb testing.TB) *resource.TestCase {
 			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RequirePrivateNetworking: new(true),
 		}
-		region = conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))
+		region         = conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))
+		createTimeout  = "45m"
+		timeoutsConfig = acc.TimeoutConfig(&createTimeout, nil, nil)
 	)
 
 	return &resource.TestCase{
@@ -212,6 +214,10 @@ func basicTestCaseAWS(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKmsPrivateNetworking),
+				Check:  checkBasic(projectID, "AWS", region, true),
+			},
+			{
+				Config: configAWSWithTimeouts(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKmsPrivateNetworking, timeoutsConfig),
 				Check:  checkBasic(projectID, "AWS", region, true),
 			},
 			importStep(configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKms)),
@@ -357,8 +363,12 @@ func checkBasic(projectID, cloudProvider, region string, expectApproved bool) re
 }
 
 func configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName string, awsKms *admin.AWSKMSConfiguration) string {
+	return configAWSWithTimeouts(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKms, "")
+}
+
+func configAWSWithTimeouts(projectID, awsIAMRoleName, awsIAMRolePolicyName string, awsKms *admin.AWSKMSConfiguration, timeoutConfig string) string {
 	encryptionAtRestConfig := acc.ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKms, false, true, false)
-	return configEARPrivateEndpoint(encryptionAtRestConfig, awsKms, "", nil)
+	return configEARPrivateEndpoint(encryptionAtRestConfig, awsKms, timeoutConfig, nil)
 }
 
 func configAWSProject(projectName, orgID, awsIAMRoleName, awsIAMRolePolicyName string, awsKms *admin.AWSKMSConfiguration, timeoutConfig string, deleteOnCreateTimeout *bool) string {


### PR DESCRIPTION
## Description

`Update` in `encryption_at_rest_private_endpoint` never called `resp.State.Set(...)`, so adding a `timeouts` block to an existing resource failed with "Provider produced inconsistent result after apply". The fix copies `Timeouts` from the plan into the prior state and writes it back.

Link to any related issue(s): CLOUDP-396562

## Reviewer notes

- Only `Timeouts` is copied from plan to state (not the full plan) to avoid masking API-sourced attribute drift.
- No API calls are made in `Update`. The existing unsupported-operation warning is preserved.
- Note did a quick check and couldn't find any other resources with the same problem.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments