### PR TITLE
fix: Remove inconsistency issue in config_server_type when config_server_management_mode is updated

### DIFF
--- a/.changelog/4380.txt
+++ b/.changelog/4380.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Fixes `config_server_type` inconsistent result after apply when updating `config_server_management_mode`
+```

--- a/.changelog/4380.txt
+++ b/.changelog/4380.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_advanced_cluster: Fixes `config_server_type` inconsistent result after apply when updating `config_server_management_mode`
+resource/mongodbatlas_advanced_cluster: Fixes `config_server_type` inconsistent result after apply when `config_server_management_mode` is `ATLAS_MANAGED`
 ```

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -21,6 +21,7 @@ var (
 		"custom_openssl_cipher_config_tls12": {"custom_openssl_cipher_config_tls13"},
 		"custom_openssl_cipher_config_tls13": {"custom_openssl_cipher_config_tls12"},
 		"cluster_type":                       {"config_server_management_mode", "config_server_type"}, // computed values of config server change when REPLICA_SET changes to SHARDED
+		"config_server_management_mode":      {"config_server_type"},                                  // config_server_type changes when switching config server management mode
 	}
 )
 

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -21,7 +21,6 @@ var (
 		"custom_openssl_cipher_config_tls12": {"custom_openssl_cipher_config_tls13"},
 		"custom_openssl_cipher_config_tls13": {"custom_openssl_cipher_config_tls12"},
 		"cluster_type":                       {"config_server_management_mode", "config_server_type"}, // computed values of config server change when REPLICA_SET changes to SHARDED
-		"config_server_management_mode":      {"config_server_type"},                                  // config_server_type changes when switching config server management mode
 	}
 )
 
@@ -55,7 +54,7 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 		return
 	}
 	attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
-	keepUnknown := []string{"connection_strings", "state_name", "mongo_db_version"} // Volatile attributes, should not be copied from state
+	keepUnknown := []string{"connection_strings", "state_name", "mongo_db_version", "config_server_type"} // Volatile attributes, should not be copied from state
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)


### PR DESCRIPTION
## Description

Fixes `"Provider produced inconsistent result after apply"` error on `config_server_type` when updating `config_server_management_mode` for `mongodbatlas_advanced_cluster` resource.

When config_server_management_mode changes (e.g. from `ATLAS_MANAGED` to `FIXED_TO_DEDICATED`), the field `config_server_type` is also updated. However, the plan modifier was copying the previous state value of `config_server_type` into the plan, which after performing `tf`apply resulted in:

```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to mongodbatlas_advanced_cluster.test, provider "provider[\"registry.terraform.io/mongodb/mongodbatlas\"]" produced an
│ unexpected new value: .config_server_type: was cty.StringVal("EMBEDDED"), but now cty.StringVal("DEDICATED")
This fix keeps config_server_type as unknown in the plan when config_server_management_mode changes, so the value returned by the API after apply is accepted without causing an inconsistency error.
```


This fix keeps `config_server_type` as unknown in the plan when `config_server_management_mode` changes, so the value returned by the API after apply is accepted.

Link to any related issue(s): CLOUDP-396696

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fix and verified my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
