### PR TITLE
fix: Suppress perpetual plan drift on post_auth_role_grants and data_access_identity_provider_ids for mongodbatlas_federated_settings_org_config

### DIFF
--- a/.changelog/4384.txt
+++ b/.changelog/4384.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_federated_settings_org_config: Fixes perpetual plan drift on `post_auth_role_grants` and `data_access_identity_provider_ids` caused by non-deterministic API response ordering
+```

--- a/internal/common/schemafunc/string_list.go
+++ b/internal/common/schemafunc/string_list.go
@@ -23,6 +23,6 @@ func StringSlicesEqualIgnoringOrder(a, b []string) bool {
 // DiffSuppressFunc that suppresses diffs on a TypeList of strings when the only difference is element order.
 func EqualStringListsIgnoringOrder(k, oldValue, newValue string, d *schema.ResourceData) bool {
 	baseKey := k[:strings.LastIndex(k, ".")]
-	old, new := d.GetChange(baseKey)
-	return StringSlicesEqualIgnoringOrder(cast.ToStringSlice(old), cast.ToStringSlice(new))
+	oldVal, newVal := d.GetChange(baseKey)
+	return StringSlicesEqualIgnoringOrder(cast.ToStringSlice(oldVal), cast.ToStringSlice(newVal))
 }

--- a/internal/common/schemafunc/string_list.go
+++ b/internal/common/schemafunc/string_list.go
@@ -1,0 +1,28 @@
+package schemafunc
+
+import (
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spf13/cast"
+)
+
+// Returns true if both slices contain the same elements regardless of order.
+func StringSlicesEqualIgnoringOrder(a, b []string) bool {
+	sortedA := make([]string, len(a))
+	copy(sortedA, a)
+	sort.Strings(sortedA)
+	sortedB := make([]string, len(b))
+	copy(sortedB, b)
+	sort.Strings(sortedB)
+	return slices.Equal(sortedA, sortedB)
+}
+
+// DiffSuppressFunc that suppresses diffs on a TypeList of strings when the only difference is element order.
+func EqualStringListsIgnoringOrder(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	baseKey := k[:strings.LastIndex(k, ".")]
+	old, new := d.GetChange(baseKey)
+	return StringSlicesEqualIgnoringOrder(cast.ToStringSlice(old), cast.ToStringSlice(new))
+}

--- a/internal/common/schemafunc/string_list.go
+++ b/internal/common/schemafunc/string_list.go
@@ -11,6 +11,9 @@ import (
 
 // Returns true if both slices contain the same elements regardless of order.
 func StringSlicesEqualIgnoringOrder(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
 	sortedA := make([]string, len(a))
 	copy(sortedA, a)
 	sort.Strings(sortedA)

--- a/internal/common/schemafunc/string_list_test.go
+++ b/internal/common/schemafunc/string_list_test.go
@@ -1,0 +1,31 @@
+package schemafunc_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+)
+
+func Test_StringSlicesEqualIgnoringOrder(t *testing.T) {
+	testCases := map[string]struct {
+		a        []string
+		b        []string
+		expected bool
+	}{
+		"same order":        {[]string{"a", "b", "c"}, []string{"a", "b", "c"}, true},
+		"different order":   {[]string{"a", "b", "c"}, []string{"c", "a", "b"}, true},
+		"different values":  {[]string{"a", "b"}, []string{"a", "c"}, false},
+		"different lengths": {[]string{"a", "b", "c"}, []string{"a", "b"}, false},
+		"empty lists":       {[]string{}, []string{}, true},
+		"single element":    {[]string{"a"}, []string{"a"}, true},
+		"nil slices":        {nil, nil, true},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := schemafunc.StringSlicesEqualIgnoringOrder(tc.a, tc.b)
+			if actual != tc.expected {
+				t.Errorf("Expected: %v, got: %v", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/spf13/cast"
@@ -44,15 +45,17 @@ func Resource() *schema.Resource {
 				},
 			},
 			"data_access_identity_provider_ids": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: schemafunc.EqualStringListsIgnoringOrder,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			"post_auth_role_grants": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: schemafunc.EqualStringListsIgnoringOrder,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org.go
@@ -45,6 +45,7 @@ func Resource() *schema.Resource {
 				},
 			},
 			"data_access_identity_provider_ids": {
+				// CLOUDP-398552 will deal with update to TypeSet for this field
 				Type:             schema.TypeList,
 				Optional:         true,
 				DiffSuppressFunc: schemafunc.EqualStringListsIgnoringOrder,
@@ -53,6 +54,7 @@ func Resource() *schema.Resource {
 				},
 			},
 			"post_auth_role_grants": {
+				// CLOUDP-398552 will deal with update to TypeSet for this field
 				Type:             schema.TypeList,
 				Optional:         true,
 				DiffSuppressFunc: schemafunc.EqualStringListsIgnoringOrder,

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
@@ -112,7 +112,7 @@ func TestAccFederatedSettingsOrg_noDriftOnListFields(t *testing.T) {
 	config := configNoDrift(federationSettingsID, orgID, associatedDomain, idpID, oidcIDP1, oidcIDP2)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckFederatedSettingsIdentityProvider(t) },
+		PreCheck:                 func() { acc.PreCheckFederatedSettingsOIDCWorkloadIDPs(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/federatedsettingsidentityprovider"
@@ -97,6 +98,51 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 	}
 }
 
+func TestAccFederatedSettingsOrg_noDriftOnListFields(t *testing.T) {
+	acc.SkipTestForCI(t)
+	var (
+		resourceName         = "mongodbatlas_federated_settings_org_config.test"
+		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID                = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+		idpID                = os.Getenv("MONGODB_ATLAS_FEDERATED_IDP_ID")
+		associatedDomain     = os.Getenv("MONGODB_ATLAS_FEDERATED_SETTINGS_ASSOCIATED_DOMAIN")
+		oidcIDP1             = os.Getenv("MONGODB_ATLAS_FEDERATED_OIDC_IDP_ID_1")
+		oidcIDP2             = os.Getenv("MONGODB_ATLAS_FEDERATED_OIDC_IDP_ID_2")
+	)
+	config := configNoDrift(federationSettingsID, orgID, associatedDomain, idpID, oidcIDP1, oidcIDP2)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckFederatedSettingsIdentityProvider(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				ResourceName:       resourceName,
+				ImportStateIdFunc:  importStateIDFunc(federationSettingsID, orgID),
+				ImportState:        true,
+				ImportStateVerify:  false,
+				ImportStatePersist: true,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "post_auth_role_grants.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "data_access_identity_provider_ids.#", "2"),
+				),
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -126,6 +172,19 @@ func importStateIDFunc(federationSettingsID, orgID string) resource.ImportStateI
 		ids := conversion.DecodeStateID(ID)
 		return fmt.Sprintf("%s-%s", ids["federation_settings_id"], ids["org_id"]), nil
 	}
+}
+
+func configNoDrift(federationSettingsID, orgID, associatedDomain, idpID, oidcIDP1, oidcIDP2 string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_federated_settings_org_config" "test" {
+			federation_settings_id            = %[1]q
+			org_id                            = %[2]q
+			domain_restriction_enabled        = false
+			domain_allow_list                 = [%[3]q]
+			identity_provider_id              = %[4]q
+			post_auth_role_grants             = ["ORG_MEMBER", "ORG_READ_ONLY", "ORG_BILLING_READ_ONLY", "ORG_GROUP_CREATOR"]
+			data_access_identity_provider_ids = [%[5]q, %[6]q]
+		}`, federationSettingsID, orgID, associatedDomain, idpID, oidcIDP1, oidcIDP2)
 }
 
 func configBasic(federationSettingsID, orgID, associatedDomain string, identityProviderID *string, createIdpWorkload, attachIdpWorkload, domainRestrictionEnabled bool) string {

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -352,6 +352,16 @@ func PreCheckFederatedSettingsIdentityProvider(tb testing.TB) {
 	}
 }
 
+func PreCheckFederatedSettingsOIDCWorkloadIDPs(tb testing.TB) {
+	tb.Helper()
+	PreCheckFederatedSettingsIdentityProvider(tb)
+	if os.Getenv("MONGODB_ATLAS_FEDERATED_IDP_ID") == "" ||
+		os.Getenv("MONGODB_ATLAS_FEDERATED_OIDC_IDP_ID_1") == "" ||
+		os.Getenv("MONGODB_ATLAS_FEDERATED_OIDC_IDP_ID_2") == "" {
+		tb.Fatal("`MONGODB_ATLAS_FEDERATED_IDP_ID`, `MONGODB_ATLAS_FEDERATED_OIDC_IDP_ID_1`, and `MONGODB_ATLAS_FEDERATED_OIDC_IDP_ID_2` must be set for federated settings OIDC drift testing")
+	}
+}
+
 func PreCheckPrivateEndpoint(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID") == "" ||


### PR DESCRIPTION
## Description

Fixes perpetual plan drift on `post_auth_role_grants` and `data_access_identity_provider_ids` fields in `mongodbatlas_federated_settings_org_config`.

These fields are defined as `TypeList`, while the API returns these fields in a non-deterministic order (they're of `Set` type). This causes that each read produces a different order than what's in state, causing an in-place update diff on every plan even when nothing changed.

For example, applying a config with post_auth_role_grants and immediately running terraform plan would show:

```
~ post_auth_role_grants = [
    - "ORG_BILLING_READ_ONLY",
    - "ORG_GROUP_CREATOR",
      "ORG_MEMBER",
      "ORG_READ_ONLY",
    + "ORG_BILLING_READ_ONLY",
    + "ORG_GROUP_CREATOR",
  ]
```

This PR aims to fix that behaviour by adding a `DiffSuppressFunc` to those fields: that compares both lists as sets, suppressing diffs when the only difference is element order. Real changes (additions, removals, value changes) are still detected.

### Testing:

* Unit test for `StringSlicesEqualIgnoringOrder` covering same order, different order, different values, different lengths, empty lists, and nil slices. 
* Acceptance test `TestAccFederatedSettingsOrg_noDriftOnListFields` that checks the no-drift behaviour for both fields. These tests are skipped in CI, but they are currently passing locally:

```
go test ./internal/service/federatedsettingsorgconfig/ -run TestAccFederatedSettingsOrg_noDriftOnListFields -v -timeout 30m

=== RUN   TestAccFederatedSettingsOrg_noDriftOnListFields
=== PAUSE TestAccFederatedSettingsOrg_noDriftOnListFields
=== CONT  TestAccFederatedSettingsOrg_noDriftOnListFields
--- PASS: TestAccFederatedSettingsOrg_noDriftOnListFields (7.52s)
PASS
ok  	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/federatedsettingsorgconfig	8.460s
```

Link to any related issue(s): [CLOUDP-397484](https://jira.mongodb.org/browse/CLOUDP-397484)

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fix and verified my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
