### PR TITLE
chore: Skip hc-install checksum verification due to expired HashiCorp PGP key

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -62,6 +62,10 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+        with:
+          terraform_version: '1.14.x'
+          terraform_wrapper: false
       - run: make tools generate-docs-all
       - name: Find mutations
         id: self_mutation

--- a/internal/testutil/hcl/common.go
+++ b/internal/testutil/hcl/common.go
@@ -33,8 +33,9 @@ func getTF() *tfexec.Terraform {
 		return tf
 	}
 	installer := &releases.ExactVersion{
-		Product: product.Terraform,
-		Version: version.Must(version.NewVersion("1.10.1")),
+		Product:                  product.Terraform,
+		Version:                  version.Must(version.NewVersion("1.10.1")),
+		SkipChecksumVerification: true,
 	}
 	execPath, err := installer.Install(context.Background())
 	if err != nil {

--- a/internal/testutil/hcl/common.go
+++ b/internal/testutil/hcl/common.go
@@ -32,6 +32,7 @@ func getTF() *tfexec.Terraform {
 	if tf != nil {
 		return tf
 	}
+	// TODO: revert SkipChecksumVerification once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
 	installer := &releases.ExactVersion{
 		Product:                  product.Terraform,
 		Version:                  version.Must(version.NewVersion("1.10.1")),

--- a/scripts/generate-doc.sh
+++ b/scripts/generate-doc.sh
@@ -78,8 +78,8 @@ fi
 
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
-# TODO: revert to --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
-tfplugindocs generate --tfpath "$(which terraform)" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out"
+# TODO: restore --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
+tfplugindocs generate --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out"
 
 if [ "${is_ephemeral}" = true ]; then
     if [ ! -f "docs-out/ephemeral-resources/${resource_name}.md" ]; then

--- a/scripts/generate-doc.sh
+++ b/scripts/generate-doc.sh
@@ -78,7 +78,8 @@ fi
 
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
-tfplugindocs generate --tf-version "${TF_VERSION}" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out"
+# TODO: revert to --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
+tfplugindocs generate --tfpath "$(which terraform)" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out"
 
 if [ "${is_ephemeral}" = true ]; then
     if [ ! -f "docs-out/ephemeral-resources/${resource_name}.md" ]; then

--- a/scripts/generate-doc.sh
+++ b/scripts/generate-doc.sh
@@ -34,7 +34,6 @@
 
 set -euo pipefail
 
-TF_VERSION="${TF_VERSION:-"1.14.8"}" # TF version to use when running tfplugindocs. Default: 1.14.8
 TEMPLATE_FOLDER_PATH="${TEMPLATE_FOLDER_PATH:-"templates"}" # PATH to the templates folder. Default: templates
 
 
@@ -78,7 +77,6 @@ fi
 
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
-# TODO: restore --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
 tfplugindocs generate --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out"
 
 if [ "${is_ephemeral}" = true ]; then

--- a/scripts/generate-docs-all.sh
+++ b/scripts/generate-docs-all.sh
@@ -30,7 +30,6 @@ TEMPLATE_FOLDER_PATH="${TEMPLATE_FOLDER_PATH:-"templates"}" # PATH to the templa
 
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
-# TODO: restore --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
 tfplugindocs generate --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out" --provider-name "mongodbatlas"
 
 printf "\nStarting file move\n\n"

--- a/scripts/generate-docs-all.sh
+++ b/scripts/generate-docs-all.sh
@@ -26,12 +26,12 @@
 
 set -euo pipefail
 
-TF_VERSION="${TF_VERSION:-"1.14.8"}" # TF version to use when running tfplugindocs. Default: 1.14.8
 TEMPLATE_FOLDER_PATH="${TEMPLATE_FOLDER_PATH:-"templates"}" # PATH to the templates folder. Default: templates
 
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
-tfplugindocs generate --tf-version "${TF_VERSION}" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out" --provider-name "mongodbatlas"
+# TODO: revert to --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
+tfplugindocs generate --tfpath "$(which terraform)" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out" --provider-name "mongodbatlas"
 
 printf "\nStarting file move\n\n"
 

--- a/scripts/generate-docs-all.sh
+++ b/scripts/generate-docs-all.sh
@@ -30,8 +30,8 @@ TEMPLATE_FOLDER_PATH="${TEMPLATE_FOLDER_PATH:-"templates"}" # PATH to the templa
 
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
-# TODO: revert to --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
-tfplugindocs generate --tfpath "$(which terraform)" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out" --provider-name "mongodbatlas"
+# TODO: restore --tf-version once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
+tfplugindocs generate --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out" --provider-name "mongodbatlas"
 
 printf "\nStarting file move\n\n"
 

--- a/scripts/update-tf-version-in-repository.sh
+++ b/scripts/update-tf-version-in-repository.sh
@@ -23,8 +23,6 @@ ACCEPTANCE_TESTS_YAML_FILE=".github/workflows/acceptance-tests.yml"
 CODE_HEALTH_YAML_FILE=".github/workflows/code-health.yml"
 EXAMPLES_YAML_FILE=".github/workflows/examples.yml"
 TOOL_VERSIONS_FILE=".tool-versions"
-DOC_SCRIPT="scripts/generate-doc.sh"
-DOC_ALL_SCRIPT="scripts/generate-docs-all.sh"
 
 LATEST_TF_VERSION=$(echo "$TF_VERSIONS_ARR" | sed -E 's/^\["([^"]+).*/\1/')
 
@@ -47,6 +45,3 @@ LATEST_TF_PATCH_VERSION=$(./scripts/get-terraform-supported-versions.sh "latest"
 # Update Terraform versions in .tool-versions
 sed -i.bak -E "s|^(terraform) [0-9]+\.[0-9]+\.[0-9]+|\1 $LATEST_TF_PATCH_VERSION|" "$TOOL_VERSIONS_FILE"
 
-# Update Terraform versions in generate-doc scripts
-sed -i.bak -E "/TF_VERSION=/ s/[0-9]+\.[0-9]+\.[0-9]+/$LATEST_TF_PATCH_VERSION/g" "$DOC_SCRIPT"
-sed -i.bak -E "/TF_VERSION=/ s/[0-9]+\.[0-9]+\.[0-9]+/$LATEST_TF_PATCH_VERSION/g" "$DOC_ALL_SCRIPT"


### PR DESCRIPTION
## Description

The HashiCorp PGP key embedded in `hc-install` v0.9.3 expired on 2026-04-18, causing failures in both MacT tests and doc generation. This is a confirmed upstream bug (hashicorp/hc-install#370).

**Temporary workaround** (to be reverted once hashicorp/hc-install#370 is fixed):

1. `internal/testutil/hcl/common.go`: sets `SkipChecksumVerification: true` on the `ExactVersion` installer. `getTF()` is only called by `PrettyHCL()`, which is called by `extractAndNormalizeConfig()` in `testutil/unit/http_mocker.go` and by `ConfigAddResourceStr()` in `testutil/acc/config_formatter.go`.

**Permanent improvements** (better approach regardless of the upstream fix):

2. `scripts/generate-docs-all.sh` and `scripts/generate-doc.sh`: drop `--tf-version` from `tfplugindocs generate`. The scripts now use whatever Terraform is in PATH, delegating version management to the caller.
3. `.github/workflows/code-health.yml`: add `hashicorp/setup-terraform` to the `generate-doc-check` job so CI explicitly controls the Terraform version, consistent with the other jobs in the same workflow.

All changes are in test/tooling infrastructure with no impact on production code.

Ran acceptance tests to verify the fix works:
- `advanced_cluster`: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/24653819639/job/72082418583
- `search_deployment`: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/24653879710/job/72082608881

Link to any related issue(s): CLOUDP-398527

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments