### PR TITLE
fix: Validate email_enabled and sms_enabled are only set for supported notification types in alert_configuration

### DIFF
--- a/.changelog/4390.txt
+++ b/.changelog/4390.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`mongodbatlas_alert_configuration`: Fixed apply failure and drift when `email_enabled = true` or `sms_enabled = true` is set on a notification type other than `ORG`, `GROUP`, or `USER` (Atlas API does not support these fields for other types).
+```

--- a/.changelog/4390.txt
+++ b/.changelog/4390.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`mongodbatlas_alert_configuration`: Fixed apply failure and drift when `email_enabled = true` or `sms_enabled = true` is set on a notification type other than `ORG`, `GROUP`, or `USER` (Atlas API does not support these fields for other types).
+resource/mongodbatlas_alert_configuration: Fixes apply failure and drift when `email_enabled = true` or `sms_enabled = true` is set on a notification type other than `ORG`, `GROUP`, or `USER` (Atlas API does not support these fields for other types)
 ```

--- a/.changelog/4390.txt
+++ b/.changelog/4390.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_alert_configuration: Fixes apply failure and drift when `email_enabled = true` or `sms_enabled = true` is set on a notification type other than `ORG`, `GROUP`, or `USER` (Atlas API does not support these fields for other types)
+resource/mongodbatlas_alert_configuration: Fixes apply failure and plan drift when `email_enabled = true` or `sms_enabled = true` is set on a notification type other than `ORG`, `GROUP`, or `USER`
 ```

--- a/internal/service/alertconfiguration/resource.go
+++ b/internal/service/alertconfiguration/resource.go
@@ -272,6 +272,9 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"email_enabled": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
+							Validators: []validator.Bool{
+								ValidEmailEnabled(),
+							},
 						},
 						"interval_min": schema.Int64Attribute{
 							Optional: true,
@@ -300,6 +303,9 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"sms_enabled": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
+							Validators: []validator.Bool{
+								ValidSMSEnabled(),
+							},
 						},
 						"team_id": schema.StringAttribute{
 							Optional: true,

--- a/internal/service/alertconfiguration/resource.go
+++ b/internal/service/alertconfiguration/resource.go
@@ -273,7 +273,7 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 							Optional: true,
 							Computed: true,
 							Validators: []validator.Bool{
-								ValidEmailEnabled(),
+								validEmailEnabled(),
 							},
 						},
 						"interval_min": schema.Int64Attribute{
@@ -304,7 +304,7 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 							Optional: true,
 							Computed: true,
 							Validators: []validator.Bool{
-								ValidSMSEnabled(),
+								validSMSEnabled(),
 							},
 						},
 						"team_id": schema.StringAttribute{

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -332,7 +332,6 @@ func TestAccConfigRSAlertConfiguration_emailEnabledInvalidType(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				// email_enabled = true is only valid for ORG, GROUP, or USER (not EMAIL type).
 				Config:      configEmailEnabledNotification(projectID),
 				ExpectError: regexp.MustCompile(`(?s).*'email_enabled'.*only valid.*type_name.*ORG.*GROUP.*USER`),
 			},
@@ -1552,21 +1551,13 @@ func configEmailEnabledNotification(projectID string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_alert_configuration" "test" {
 			project_id = %[1]q
-			event_type = "CPS_SNAPSHOT_BEHIND"
 			enabled    = true
+			event_type = "NO_PRIMARY"
 
 			notification {
 				type_name     = "EMAIL"
 				email_address = "test@mongodb.com"
-				interval_min  = 5
-				delay_min     = 0
 				email_enabled = true
-			}
-
-			threshold_config {
-				operator  = "GREATER_THAN"
-				threshold = 48
-				units     = "HOURS"
 			}
 		}
 	`, projectID)

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -332,7 +332,7 @@ func TestAccConfigRSAlertConfiguration_emailEnabledInvalidType(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				// email_enabled = true is only valid for ORG, GROUP, or USER — not EMAIL type.
+				// email_enabled = true is only valid for ORG, GROUP, or USER (not EMAIL type).
 				Config:      configEmailEnabledNotification(projectID),
 				ExpectError: regexp.MustCompile(`(?s).*'email_enabled'.*only valid.*type_name.*ORG.*GROUP.*USER`),
 			},

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -324,6 +324,22 @@ func TestAccConfigRSAlertConfiguration_addNotification(t *testing.T) {
 	})
 }
 
+func TestAccConfigRSAlertConfiguration_emailEnabledInvalidType(t *testing.T) {
+	projectID := acc.ProjectIDExecution(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				// email_enabled = true is only valid for ORG, GROUP, or USER — not EMAIL type.
+				Config:      configEmailEnabledNotification(projectID),
+				ExpectError: regexp.MustCompile(`(?s).*'email_enabled'.*only valid.*type_name.*ORG.*GROUP.*USER`),
+			},
+		},
+	})
+}
+
 func TestAccConfigRSAlertConfiguration_withoutOptionalAttributes(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
@@ -1530,6 +1546,30 @@ func checkCount(resourceName string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func configEmailEnabledNotification(projectID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = %[1]q
+			event_type = "CPS_SNAPSHOT_BEHIND"
+			enabled    = true
+
+			notification {
+				type_name     = "EMAIL"
+				email_address = "test@mongodb.com"
+				interval_min  = 5
+				delay_min     = 0
+				email_enabled = true
+			}
+
+			threshold_config {
+				operator  = "GREATER_THAN"
+				threshold = 48
+				units     = "HOURS"
+			}
+		}
+	`, projectID)
 }
 
 func configAddNotification(projectID string, twoNotifications bool) string {

--- a/internal/service/alertconfiguration/validator_bool_enabled.go
+++ b/internal/service/alertconfiguration/validator_bool_enabled.go
@@ -33,6 +33,9 @@ func (v BoolEnabledValidator) ValidateBool(ctx context.Context, req validator.Bo
 	if diags.HasError() {
 		return
 	}
+	if notification.TypeName.IsNull() || notification.TypeName.IsUnknown() {
+		return
+	}
 	typeNameValue := notification.TypeName.ValueString()
 	for _, validType := range validEmailSMSEnabledTypes {
 		if strings.EqualFold(typeNameValue, validType) {

--- a/internal/service/alertconfiguration/validator_bool_enabled.go
+++ b/internal/service/alertconfiguration/validator_bool_enabled.go
@@ -11,19 +11,19 @@ import (
 
 var validEmailSMSEnabledTypes = []string{"ORG", "GROUP", "USER"}
 
-type BoolEnabledValidator struct {
+type boolEnabledValidator struct {
 	fieldName string
 }
 
-func (v BoolEnabledValidator) Description(_ context.Context) string {
+func (v boolEnabledValidator) Description(_ context.Context) string {
 	return fmt.Sprintf("'%s' is only valid if 'type_name' is set to 'ORG', 'GROUP', or 'USER'", v.fieldName)
 }
 
-func (v BoolEnabledValidator) MarkdownDescription(ctx context.Context) string {
+func (v boolEnabledValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v BoolEnabledValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+func (v boolEnabledValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || !req.ConfigValue.ValueBool() {
 		return
 	}
@@ -49,10 +49,10 @@ func (v BoolEnabledValidator) ValidateBool(ctx context.Context, req validator.Bo
 	))
 }
 
-func ValidEmailEnabled() validator.Bool {
-	return BoolEnabledValidator{fieldName: "email_enabled"}
+func validEmailEnabled() validator.Bool {
+	return boolEnabledValidator{fieldName: "email_enabled"}
 }
 
-func ValidSMSEnabled() validator.Bool {
-	return BoolEnabledValidator{fieldName: "sms_enabled"}
+func validSMSEnabled() validator.Bool {
+	return boolEnabledValidator{fieldName: "sms_enabled"}
 }

--- a/internal/service/alertconfiguration/validator_bool_enabled.go
+++ b/internal/service/alertconfiguration/validator_bool_enabled.go
@@ -1,0 +1,55 @@
+package alertconfiguration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var validEmailSMSEnabledTypes = []string{"ORG", "GROUP", "USER"}
+
+type BoolEnabledValidator struct {
+	fieldName string
+}
+
+func (v BoolEnabledValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("'%s' is only valid if 'type_name' is set to 'ORG', 'GROUP', or 'USER'", v.fieldName)
+}
+
+func (v BoolEnabledValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v BoolEnabledValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || !req.ConfigValue.ValueBool() {
+		return
+	}
+	notificationPath := req.Path.ParentPath()
+	var notification TfNotificationModel
+	diags := req.Config.GetAttribute(ctx, notificationPath, &notification)
+	if diags.HasError() {
+		return
+	}
+	typeNameValue := notification.TypeName.ValueString()
+	for _, validType := range validEmailSMSEnabledTypes {
+		if strings.EqualFold(typeNameValue, validType) {
+			return
+		}
+	}
+	resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+		req.Path,
+		v.Description(ctx),
+		"true",
+	))
+}
+
+func ValidEmailEnabled() validator.Bool {
+	return BoolEnabledValidator{fieldName: "email_enabled"}
+}
+
+func ValidSMSEnabled() validator.Bool {
+	return BoolEnabledValidator{fieldName: "sms_enabled"}
+}


### PR DESCRIPTION
## Description

Added a plan-time validator that rejects `email_enabled = true` or `sms_enabled = true` on `mongodbatlas_alert_configuration` notification blocks when `type_name` is not `ORG`, `GROUP`, or `USER`. Previously, setting these fields on other types (such as `EMAIL` or `SLACK`) was silently accepted but had no effect, because the Atlas API drops them and does not return them in the response. This caused an apply failure (v2.x) or an infinite drift loop (v1.x) when the field was set to `true`.

**Note: this is a breaking change.** Configs that set `email_enabled = true` or `sms_enabled = true` on an unsupported `type_name` will now fail at plan time with a clear error instead of causing apply failures or plan drift.

The validator follows the same pattern as the existing `IntervalMinValidator` in the same package.

Link to any related issue(s): CLOUDP-397410

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments