### PR TITLE
fix: Avoid plan churn when adding/removing role_assignments field on mongodbatlas_federated_settings_org_role_mapping

### DIFF
--- a/.changelog/4394.txt
+++ b/.changelog/4394.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_federated_settings_org_role_mapping: Fixes plan churn on `role_assignments` fields when adding/removing a new block
+```

--- a/internal/service/federatedsettingsorgrolemapping/model_federated_settings_org_role_mapping.go
+++ b/internal/service/federatedsettingsorgrolemapping/model_federated_settings_org_role_mapping.go
@@ -17,9 +17,13 @@ import (
 // to show as remove+add when the set size changes.
 // See CLOUDP-397797 for more details.
 func hashRoleAssignment(v any) int {
-	m := v.(map[string]any)
-	orgID := m["org_id"].(string)
-	groupID := m["group_id"].(string)
+	m, ok := v.(map[string]any)
+	if !ok {
+		return schema.HashString("")
+	}
+
+	orgID, _ := m["org_id"].(string)
+	groupID, _ := m["group_id"].(string)
 	var roles []string
 	if rolesSet, ok := m["roles"].(*schema.Set); ok {
 		for _, r := range rolesSet.List() {

--- a/internal/service/federatedsettingsorgrolemapping/model_federated_settings_org_role_mapping.go
+++ b/internal/service/federatedsettingsorgrolemapping/model_federated_settings_org_role_mapping.go
@@ -16,7 +16,7 @@ import (
 // serialization instability in SDKv2, which causes all outer elements
 // to show as remove+add when the set size changes.
 // See CLOUDP-397797 for more details.
-func hashRoleAssignment(v interface{}) int {
+func hashRoleAssignment(v any) int {
 	m := v.(map[string]any)
 	orgID := m["org_id"].(string)
 	groupID := m["group_id"].(string)

--- a/internal/service/federatedsettingsorgrolemapping/model_federated_settings_org_role_mapping.go
+++ b/internal/service/federatedsettingsorgrolemapping/model_federated_settings_org_role_mapping.go
@@ -3,11 +3,32 @@ package federatedsettingsorgrolemapping
 import (
 	"cmp"
 	"slices"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"go.mongodb.org/atlas-sdk/v20250312018/admin"
 )
+
+// hashRoleAssignment hashes a role_assignments element by org_id, group_id, and
+// sorted roles. Sorting the roles before hashing bypasses the nested TypeSet
+// serialization instability in SDKv2, which causes all outer elements
+// to show as remove+add when the set size changes.
+// See CLOUDP-397797 for more details.
+func hashRoleAssignment(v interface{}) int {
+	m := v.(map[string]any)
+	orgID := m["org_id"].(string)
+	groupID := m["group_id"].(string)
+	var roles []string
+	if rolesSet, ok := m["roles"].(*schema.Set); ok {
+		for _, r := range rolesSet.List() {
+			roles = append(roles, r.(string))
+		}
+	}
+	sort.Strings(roles)
+	return schema.HashString(orgID + "|" + groupID + "|" + strings.Join(roles, ","))
+}
 
 func compareRoleAssignment(a, b admin.ConnectedOrgConfigRoleAssignment) int {
 	if c := cmp.Compare(a.GetOrgId(), b.GetOrgId()); c != 0 {
@@ -72,7 +93,7 @@ func flattenRoleAssignmentsResource(roleAssignments []admin.ConnectedOrgConfigRo
 	var roleAssignment = map[string]any{
 		"group_id": roleAssignments[0].GetGroupId(),
 		"org_id":   roleAssignments[0].GetOrgId(),
-		"roles":    []string{},
+		"roles":    schema.NewSet(schema.HashString, nil),
 	}
 
 	for _, row := range roleAssignments {
@@ -83,11 +104,11 @@ func flattenRoleAssignmentsResource(roleAssignments []admin.ConnectedOrgConfigRo
 			roleAssignment = map[string]any{
 				"group_id": row.GetGroupId(),
 				"org_id":   row.GetOrgId(),
-				"roles":    []string{},
+				"roles":    schema.NewSet(schema.HashString, nil),
 			}
 		}
 
-		roleAssignment["roles"] = append(roleAssignment["roles"].([]string), row.GetRole())
+		roleAssignment["roles"].(*schema.Set).Add(row.GetRole())
 	}
 
 	flattenedRoleAssignments = append(flattenedRoleAssignments, roleAssignment)

--- a/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping.go
+++ b/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping.go
@@ -53,12 +53,14 @@ func Resource() *schema.Resource {
 						"group_id": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "",
+							// Default ensures SDKv2 uses "" instead of null for unset fields, matching state representation and preventing hash mismatches. See CLOUDP-397797.
+							Default: "",
 						},
 						"org_id": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "",
+							// Default ensures SDKv2 uses "" instead of null for unset fields, matching state representation and preventing hash mismatches. See CLOUDP-397797.
+							Default: "",
 						},
 						"roles": {
 							Type:     schema.TypeSet,

--- a/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping.go
+++ b/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping.go
@@ -47,15 +47,18 @@ func Resource() *schema.Resource {
 			"role_assignments": {
 				Type:     schema.TypeSet,
 				Required: true,
+				Set:      hashRoleAssignment,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"group_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"org_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"roles": {
 							Type:     schema.TypeSet,

--- a/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping_test.go
+++ b/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping_test.go
@@ -7,10 +7,54 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
+
+func TestAccFederatedSettingsOrgRoleMapping_NoDriftOnRoleAssignments(t *testing.T) {
+	acc.SkipTestForCI(t)
+
+	var (
+		resourceName         = "mongodbatlas_federated_settings_org_role_mapping.test"
+		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID                = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+		groupID              = os.Getenv("MONGODB_ATLAS_FEDERATED_GROUP_ID")
+		oneRoleConfig        = configOneRoleAssignment(federationSettingsID, orgID)
+		twoRolesConfig       = configTwoRoleAssignments(federationSettingsID, orgID, groupID)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckFederatedSettingsRoleMapping(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: oneRoleConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "role_assignments.#", "1"),
+				),
+			},
+			{
+				Config: twoRolesConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "role_assignments.#", "2"),
+				),
+			},
+			{
+				Config: twoRolesConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
 
 func TestAccFederatedSettingsOrgRoleMapping_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCase(t))
@@ -148,4 +192,36 @@ func configBasic(federationSettingsID, orgID, groupID, externalGroupName string)
 		items_per_page = 100
 	}
 	  `, federationSettingsID, orgID, groupID, externalGroupName)
+}
+
+func configOneRoleAssignment(federationSettingsID, orgID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_federated_settings_org_role_mapping" "test" {
+		federation_settings_id = %[1]q
+		org_id                 = %[2]q
+		external_group_name    = "testgroup"
+		role_assignments {
+			org_id = %[2]q
+			roles  = ["ORG_MEMBER"]
+		}
+	}
+	`, federationSettingsID, orgID)
+}
+
+func configTwoRoleAssignments(federationSettingsID, orgID, groupID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_federated_settings_org_role_mapping" "test" {
+		federation_settings_id = %[1]q
+		org_id                 = %[2]q
+		external_group_name    = "testgroup"
+		role_assignments {
+			org_id = %[2]q
+			roles  = ["ORG_MEMBER"]
+		}
+		role_assignments {
+			group_id = %[3]q
+			roles    = ["GROUP_OWNER"]
+		}
+	}
+	`, federationSettingsID, orgID, groupID)
 }

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -343,6 +343,14 @@ func PreCheckFederatedSettings(tb testing.TB) {
 	}
 }
 
+func PreCheckFederatedSettingsRoleMapping(tb testing.TB) {
+	tb.Helper()
+	PreCheckFederatedSettings(tb)
+	if os.Getenv("MONGODB_ATLAS_FEDERATED_GROUP_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_FEDERATED_GROUP_ID` must be set for federated settings role mapping acceptance testing")
+	}
+}
+
 func PreCheckFederatedSettingsIdentityProvider(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID") == "" ||


### PR DESCRIPTION
## Description

This PR fixes an issue for `mongodbatlas_federated_settings_org_role_mapping`, where performing a `terraform plan` showed all `role_assignments` elements as remove+add whenever the set size changed (adding or removing one block).

### Root cause & fix
There are two separate SDKv2 limitations:

1. **Hash instability from nested `TypeSet`**: `role_assignments` is a `TypeSet` whose elements contain a nested roles TypeSet. SDKv2's HashResource/SerializeValueForHash produces unstable hashes for the outer elements because the inner TypeSet serialization differs depending on whether the value came from state or config.
2. **`null` vs `""` mismatch**: `group_id` and `org_id` are mutually exclusive fields, one is always unset. The state stores unset fields as `""` (the flat map can't represent null), but Terraform's SDK proposed state has null for unset fields. normalizeNullValues in SDKv2 fixes this for lists and maps but explicitly skips sets during plan ([grpc_provider.go:2435](https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.40.0/helper/schema/grpc_provider.go#L2435-L2441)). This causes Terraform to see every element as different, even when the SDKv2 diff layer correctly identifies them as matching.

```
  # mongodbatlas_federated_settings_org_role_mapping.test will be updated in-place
  ~ resource "mongodbatlas_federated_settings_org_role_mapping" "test" {

      - role_assignments {
          - org_id   = "<ORG_ID>" -> null
          - roles    = [
              - "ORG_BILLING_READ_ONLY",
              - "ORG_MEMBER",
              - "ORG_READ_ONLY",
            ] -> null
        }
      - role_assignments {
          - group_id = "<GROUP_ID>" -> null
          - roles    = [
              - "GROUP_DATA_ACCESS_READ_ONLY",
              - "GROUP_READ_ONLY",
            ] -> null
        }
      + role_assignments {
          + group_id = "<GROUP_ID>"
          + roles    = [
              + "GROUP_DATA_ACCESS_READ_ONLY",
              + "GROUP_READ_ONLY",
            ]
        }
      + role_assignments {
          + group_id = "<GROUP_ID>"
          + roles    = [
              + "GROUP_READ_ONLY",
            ]
        }
      + role_assignments {
          + org_id = "<ORG_ID>"
          + roles  = [
              + "ORG_BILLING_READ_ONLY",
              + "ORG_MEMBER",
              + "ORG_READ_ONLY",
            ]
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### Proposed fix
1. Custom Set hash function (`hashRoleAssignment`) on `role_assignments`: sorts roles before hashing, bypassing the nested TypeSet serialization instability. 
2. Define `Default: ""` on `group_id` and `org_id`: makes Terraform use `""` instead of `null` for unset fields, matching the state representation.

**Important**: without `Default: ""`, the hash mismatch between config (null) and state ("") causes the full remove+add behaviour **even with the custom hash function**. This approach does not introduce breaking changes, as  SDKv2 already stores `""` for unset `Optional` string fields in state, so existing state is unaffected. 

After the fix: Only the field that is added/removed is present, avoiding plan churn. 

```
  # mongodbatlas_federated_settings_org_role_mapping.test will be updated in-place
  ~ resource "mongodbatlas_federated_settings_org_role_mapping" "test" {

      + role_assignments {
          + group_id = "<GROUP_ID>"
          + roles    = [
              + "GROUP_READ_ONLY",
            ]
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Acceptance test passing in local:

```
=== RUN   TestAccFederatedSettingsOrgRoleMapping_NoDriftOnRoleAssignments
=== PAUSE TestAccFederatedSettingsOrgRoleMapping_NoDriftOnRoleAssignments
=== CONT  TestAccFederatedSettingsOrgRoleMapping_NoDriftOnRoleAssignments
--- PASS: TestAccFederatedSettingsOrgRoleMapping_NoDriftOnRoleAssignments (7.49s)
PASS
ok  	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/federatedsettingsorgrolemapping	8.085s
```

Link to any related issue(s): [CLOUDP-397797](https://jira.mongodb.org/browse/CLOUDP-397797)

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fix and verified my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
