### PR TITLE
chore: Increase waiting time on TestAccFederatedDatabaseInstance_withPrivateEndpoint to reduce test flakiness

### DIFF
--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -629,7 +629,7 @@ data "mongodbatlas_federated_database_instance" "test" {
 }
 
 func waitForStatusUpdate() {
-	time.Sleep(2 * time.Minute)
+	time.Sleep(4 * time.Minute)
 }
 
 func configWithPrivateEndpoint(projectID, name string) string {


### PR DESCRIPTION
## Description

This PR reduces flakiness in `TestAccFederatedDatabaseInstance_withPrivateEndpoint` by increasing the stabilization wait used before validating `private_endpoint_hostnames`.

In this test flow, `private_endpoint_hostnames` is populated asynchronously and can take ~2–3 minutes to appear. The previous 2-minute wait was occasionally too short, causing intermittent failures.
This change increases the wait to 4 minutes 

Failure example: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/24754037586/job/72423490121#step:5:123

Link to any related issue(s): No CLOUDP ticket linked to this issue, it's an on-call task

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fix and verified my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
