### PR TITLE
fix: preserve api mongo_db_major_version on real upgrades

### DIFF
--- a/internal/service/advancedcluster/resource_compatiblity.go
+++ b/internal/service/advancedcluster/resource_compatiblity.go
@@ -94,7 +94,8 @@ func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 		return
 	}
 	beforeVersion := conversion.NilForUnknown(modelIn.MongoDBMajorVersion, modelIn.MongoDBMajorVersion.ValueStringPointer())
-	if beforeVersion != nil && !modelIn.MongoDBMajorVersion.Equal(modelOut.MongoDBMajorVersion) {
+	afterVersion := conversion.NilForUnknown(modelOut.MongoDBMajorVersion, modelOut.MongoDBMajorVersion.ValueStringPointer())
+	if beforeVersion != nil && afterVersion != nil && shouldUsePreviousMongoDBMajorVersion(*beforeVersion, *afterVersion) {
 		modelOut.MongoDBMajorVersion = types.StringPointerValue(beforeVersion)
 	}
 	overrideMapStringWithPrevStateValue(&modelIn.Labels, &modelOut.Labels)
@@ -107,6 +108,10 @@ func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 	modelOut.DeleteOnCreateTimeout = modelIn.DeleteOnCreateTimeout
 	modelOut.RetainBackupsEnabled = modelIn.RetainBackupsEnabled
 	modelOut.UseEffectiveFields = modelIn.UseEffectiveFields
+}
+
+func shouldUsePreviousMongoDBMajorVersion(beforeVersion, afterVersion string) bool {
+	return beforeVersion != afterVersion && FormatMongoDBMajorVersion(beforeVersion) == FormatMongoDBMajorVersion(afterVersion)
 }
 
 func overrideMapStringWithPrevStateValue(mapIn, mapOut *types.Map) {

--- a/internal/service/advancedcluster/resource_compatiblity_test.go
+++ b/internal/service/advancedcluster/resource_compatiblity_test.go
@@ -1,0 +1,50 @@
+package advancedcluster
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestOverrideAttributesWithPrevStateValueMongoDBMajorVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		before   string
+		after    string
+		expected string
+	}{
+		{
+			name:     "keeps previous version when only formatting differs",
+			before:   "8",
+			after:    "8.0",
+			expected: "8",
+		},
+		{
+			name:     "uses API value when major version actually changed",
+			before:   "7.0",
+			after:    "8.0",
+			expected: "8.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			modelIn := &TFModel{
+				MongoDBMajorVersion: types.StringValue(tc.before),
+				Labels:              types.MapNull(types.StringType),
+				Tags:                types.MapNull(types.StringType),
+			}
+			modelOut := &TFModel{
+				MongoDBMajorVersion: types.StringValue(tc.after),
+				Labels:              types.MapNull(types.StringType),
+				Tags:                types.MapNull(types.StringType),
+			}
+
+			overrideAttributesWithPrevStateValue(modelIn, modelOut)
+
+			if got := modelOut.MongoDBMajorVersion.ValueString(); got != tc.expected {
+				t.Fatalf("unexpected mongo_db_major_version: got %q want %q", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This narrows the `mongo_db_major_version` compatibility workaround in `mongodbatlas_advanced_cluster` so it only preserves the previous state value when the difference is formatting-only, for example `8` vs `8.0`.

When Atlas API returns a genuinely different major version, such as `7.0 -> 8.0` after an out-of-band upgrade and FCV unpin, the provider now keeps the API value instead of forcing the previous state value back into state.

This preserves the original intent of avoiding unnecessary diffs from version normalization while allowing real major-version transitions to converge.

Link to any related issue(s):
- https://github.com/mongodb/terraform-provider-mongodbatlas/issues/4398

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Added a unit test that covers both:

- formatting-only normalization: previous state `8`, API value `8.0`
- real version transition: previous state `7.0`, API value `8.0`

Validation run:

- `go test ./internal/service/advancedcluster -run '^TestOverrideAttributesWithPrevStateValueMongoDBMajorVersion$'`
- `go test ./internal/service/advancedcluster -run 'TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs'`
