### PR TITLE
fix: Preserve mongo_db_major_version state after out-of-band major version upgrade

### DIFF
--- a/.changelog/4400.txt
+++ b/.changelog/4400.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_advanced_cluster: Fixes perpetual plan drift on `mongo_db_major_version` after out-of-band major version upgrade
+resource/mongodbatlas_advanced_cluster: Enables drift detection in `mongo_db_major_version` after performing an upgrade outside of Terraform
 ```

--- a/.changelog/4400.txt
+++ b/.changelog/4400.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Fixes perpetual plan drift on `mongo_db_major_version` after out-of-band major version upgrade
+```

--- a/internal/service/advancedcluster/resource_compatibility_test.go
+++ b/internal/service/advancedcluster/resource_compatibility_test.go
@@ -26,6 +26,12 @@ func TestAdvancedCluster_ShouldUsePreviousMongoDBMajorVersion(t *testing.T) {
 			after:    "8.0",
 			expected: false,
 		},
+		{
+			name:     "keeps previous version when minor version differs within same major",
+			before:   "8.0",
+			after:    "8.2",
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/service/advancedcluster/resource_compatibility_test.go
+++ b/internal/service/advancedcluster/resource_compatibility_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAdvancedCluster_overrideMongoDBMajorVersion(t *testing.T) {
+func TestAdvancedCluster_ShouldUsePreviousMongoDBMajorVersion(t *testing.T) {
 	testCases := []struct {
 		name     string
 		before   string

--- a/internal/service/advancedcluster/resource_compatiblity.go
+++ b/internal/service/advancedcluster/resource_compatiblity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"go.mongodb.org/atlas-sdk/v20250312018/admin"
 
@@ -112,7 +113,15 @@ func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 }
 
 func ShouldUsePreviousMongoDBMajorVersion(beforeVersion, afterVersion string) bool {
-	return beforeVersion != afterVersion && FormatMongoDBMajorVersion(beforeVersion) == FormatMongoDBMajorVersion(afterVersion)
+	if beforeVersion == afterVersion {
+		return false
+	}
+	return majorComponent(beforeVersion) == majorComponent(afterVersion)
+}
+
+func majorComponent(version string) string {
+	major, _, _ := strings.Cut(FormatMongoDBMajorVersion(version), ".")
+	return major
 }
 
 func overrideMapStringWithPrevStateValue(mapIn, mapOut *types.Map) {

--- a/internal/service/advancedcluster/resource_compatiblity.go
+++ b/internal/service/advancedcluster/resource_compatiblity.go
@@ -94,7 +94,8 @@ func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 		return
 	}
 	beforeVersion := conversion.NilForUnknown(modelIn.MongoDBMajorVersion, modelIn.MongoDBMajorVersion.ValueStringPointer())
-	if beforeVersion != nil && !modelIn.MongoDBMajorVersion.Equal(modelOut.MongoDBMajorVersion) {
+	afterVersion := conversion.NilForUnknown(modelOut.MongoDBMajorVersion, modelOut.MongoDBMajorVersion.ValueStringPointer())
+	if beforeVersion != nil && afterVersion != nil && shouldUsePreviousMongoDBMajorVersion(*beforeVersion, *afterVersion) {
 		modelOut.MongoDBMajorVersion = types.StringPointerValue(beforeVersion)
 	}
 	overrideMapStringWithPrevStateValue(&modelIn.Labels, &modelOut.Labels)
@@ -107,6 +108,10 @@ func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 	modelOut.DeleteOnCreateTimeout = modelIn.DeleteOnCreateTimeout
 	modelOut.RetainBackupsEnabled = modelIn.RetainBackupsEnabled
 	modelOut.UseEffectiveFields = modelIn.UseEffectiveFields
+}
+
+func shouldUsePreviousMongoDBMajorVersion(beforeVersion, afterVersion string) bool {
+	return beforeVersion != afterVersion && FormatMongoDBMajorVersion(beforeVersion) == FormatMongoDBMajorVersion(afterVersion)
 }
 
 func overrideMapStringWithPrevStateValue(mapIn, mapOut *types.Map) {

--- a/internal/service/advancedcluster/resource_compatiblity.go
+++ b/internal/service/advancedcluster/resource_compatiblity.go
@@ -95,7 +95,8 @@ func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 	}
 	beforeVersion := conversion.NilForUnknown(modelIn.MongoDBMajorVersion, modelIn.MongoDBMajorVersion.ValueStringPointer())
 	afterVersion := conversion.NilForUnknown(modelOut.MongoDBMajorVersion, modelOut.MongoDBMajorVersion.ValueStringPointer())
-	if beforeVersion != nil && afterVersion != nil && shouldUsePreviousMongoDBMajorVersion(*beforeVersion, *afterVersion) {
+	// Only preserve prior state value for formatting differences (e.g. "8" vs "8.0"), not real version transitions.
+	if beforeVersion != nil && afterVersion != nil && ShouldUsePreviousMongoDBMajorVersion(*beforeVersion, *afterVersion) {
 		modelOut.MongoDBMajorVersion = types.StringPointerValue(beforeVersion)
 	}
 	overrideMapStringWithPrevStateValue(&modelIn.Labels, &modelOut.Labels)
@@ -110,7 +111,7 @@ func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 	modelOut.UseEffectiveFields = modelIn.UseEffectiveFields
 }
 
-func shouldUsePreviousMongoDBMajorVersion(beforeVersion, afterVersion string) bool {
+func ShouldUsePreviousMongoDBMajorVersion(beforeVersion, afterVersion string) bool {
 	return beforeVersion != afterVersion && FormatMongoDBMajorVersion(beforeVersion) == FormatMongoDBMajorVersion(afterVersion)
 }
 

--- a/internal/service/advancedcluster/resource_compatiblity_test.go
+++ b/internal/service/advancedcluster/resource_compatiblity_test.go
@@ -1,0 +1,50 @@
+package advancedcluster
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestOverrideAttributesWithPrevStateValueMongoDBMajorVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		before   string
+		after    string
+		expected string
+	}{
+		{
+			name:     "keeps previous version when only formatting differs",
+			before:   "8",
+			after:    "8.0",
+			expected: "8",
+		},
+		{
+			name:     "uses API value when major version actually changed",
+			before:   "7.0",
+			after:    "8.0",
+			expected: "8.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			modelIn := &TFModel{
+				MongoDBMajorVersion: types.StringValue(tc.before),
+				Labels:              types.MapNull(types.StringType),
+				Tags:                types.MapNull(types.StringType),
+			}
+			modelOut := &TFModel{
+				MongoDBMajorVersion: types.StringValue(tc.after),
+				Labels:              types.MapNull(types.StringType),
+				Tags:                types.MapNull(types.StringType),
+			}
+
+			overrideAttributesWithPrevStateValue(modelIn, modelOut)
+
+			if got := modelOut.MongoDBMajorVersion.ValueString(); got != tc.expected {
+				t.Fatalf("unexpected mongo_db_major_version: got %q want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/service/advancedcluster/resource_compatiblity_test.go
+++ b/internal/service/advancedcluster/resource_compatiblity_test.go
@@ -1,50 +1,36 @@
-package advancedcluster
+package advancedcluster_test
 
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestOverrideAttributesWithPrevStateValueMongoDBMajorVersion(t *testing.T) {
+func TestAdvancedCluster_overrideMongoDBMajorVersion(t *testing.T) {
 	testCases := []struct {
 		name     string
 		before   string
 		after    string
-		expected string
+		expected bool
 	}{
 		{
 			name:     "keeps previous version when only formatting differs",
 			before:   "8",
 			after:    "8.0",
-			expected: "8",
+			expected: true,
 		},
 		{
 			name:     "uses API value when major version actually changed",
 			before:   "7.0",
 			after:    "8.0",
-			expected: "8.0",
+			expected: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			modelIn := &TFModel{
-				MongoDBMajorVersion: types.StringValue(tc.before),
-				Labels:              types.MapNull(types.StringType),
-				Tags:                types.MapNull(types.StringType),
-			}
-			modelOut := &TFModel{
-				MongoDBMajorVersion: types.StringValue(tc.after),
-				Labels:              types.MapNull(types.StringType),
-				Tags:                types.MapNull(types.StringType),
-			}
-
-			overrideAttributesWithPrevStateValue(modelIn, modelOut)
-
-			if got := modelOut.MongoDBMajorVersion.ValueString(); got != tc.expected {
-				t.Fatalf("unexpected mongo_db_major_version: got %q want %q", got, tc.expected)
-			}
+			assert.Equal(t, tc.expected, advancedcluster.ShouldUsePreviousMongoDBMajorVersion(tc.before, tc.after))
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes a bug where `mongodbatlas_advanced_cluster` would retain a stale `mongo_db_major_version` in Terraform state after an out-of-band major version upgrade (e.g. upgrading from MongoDB 7.0 to 8.0 via Atlas UI and unpinning FCV). Even after updating the config to match the new version, the provider would perpetually show a diff.

The root cause was in `overrideAttributesWithPrevStateValue`: it unconditionally overwrote the API value with the prior state value whenever they differed, which was intended to suppress cosmetic formatting differences (e.g. `"8"` vs `"8.0"`) but also masked real version transitions.

The fix narrows the override to cases where the major component is the same, handling two scenarios: formatting differences (e.g. "8" vs "8.0") and minor version bumps from `version_release_system = "CONTINUOUS"` (e.g. "8.0" vs "8.2") where the version is no longer user-controlled.

Link to any related issue(s): [CLOUDP-399538](https://jira.mongodb.org/browse/CLOUDP-399538)

Closes #4398

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Related external PR: #4399 (opened by the issue reporter with the same fix — this PR adapts it to follow our internal conventions).