### PR TITLE
fix: Emit warning when use_effective_fields and auto-scaling are enabled and spec fields change

### DIFF
--- a/.agents/skills/pr-and-documentation-standards/SKILL.md
+++ b/.agents/skills/pr-and-documentation-standards/SKILL.md
@@ -7,6 +7,17 @@ description: Standards for pull requests, documentation, and code review in this
 
 ## Pull Request Structure
 
+### PR Title Format
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/): `fix:`, `feat:`, `chore:`, `doc:`, `test:`, `refactor:`, `ci:`, etc. The subject after the colon must start with an uppercase letter.
+
+```text
+fix: Emit warning when use_effective_fields and auto-scaling are enabled
+feat: Add search deployment resource
+```
+
+Do **not** include a scope in parentheses (e.g. `fix(resource/mongodbatlas_advanced_cluster): ...`). The repo convention uses the bare prefix without a scope.
+
 ### Separate Refactoring from Feature Changes
 
 Avoid mixing refactoring with functional changes in the same PR. Reviewers need to clearly distinguish which changed lines are behavioral vs structural.

--- a/.changelog/4405.txt
+++ b/.changelog/4405.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Emits a warning during plan when `use_effective_fields` is true, auto-scaling is enabled, and `instance_size`, `disk_size_gb`, or `disk_iops` is modified, as Atlas silently ignores these changes in that combination
+```

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -65,16 +65,16 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
-	WarnIgnoredSpecChange(ctx, diags, state, plan)
+	WarnIgnoredSpecChange(ctx, diags, attributeChanges, plan)
 }
 
 // WarnIgnoredSpecChange warns when use_effective_fields=true and auto-scaling is enabled but the user
 // changed instance_size, disk_size_gb, or disk_iops
-func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) {
+func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, attributeChanges schemafunc.AttributeChanges, plan *TFModel) {
 	if !plan.UseEffectiveFields.ValueBool() {
 		return
 	}
-	ignoredFields := collectIgnoredSpecChanges(ctx, diags, state, plan)
+	ignoredFields := collectIgnoredSpecChanges(ctx, diags, attributeChanges, plan)
 	if len(ignoredFields) == 0 {
 		return
 	}
@@ -89,21 +89,20 @@ func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, state, 
 }
 
 // collectIgnoredSpecChanges returns sorted field names changed in plan but ignored by Atlas due to auto-scaling.
-func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) []string {
-	stateRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, state.ReplicationSpecs)
+func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, attributeChanges schemafunc.AttributeChanges, plan *TFModel) []string {
 	planRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, plan.ReplicationSpecs)
 	if diags.HasError() {
 		return nil
 	}
 	ignoredSet := map[string]struct{}{}
-	for i := range minLen(planRepSpecs, stateRepSpecs) {
-		stateRegionConfigs := TFModelList[TFRegionConfigsModel](ctx, diags, stateRepSpecs[i].RegionConfigs)
+	for i := range planRepSpecs {
 		planRegionConfigs := TFModelList[TFRegionConfigsModel](ctx, diags, planRepSpecs[i].RegionConfigs)
 		if diags.HasError() {
 			return nil
 		}
-		for j := range minLen(planRegionConfigs, stateRegionConfigs) {
-			addIgnoredSpecChangesForRegionConfig(ctx, &stateRegionConfigs[j], &planRegionConfigs[j], ignoredSet)
+		for j := range planRegionConfigs {
+			rcPrefix := fmt.Sprintf("replication_specs[%d].region_configs[%d]", i, j)
+			addIgnoredSpecChangesForRegionConfig(ctx, &planRegionConfigs[j], attributeChanges, rcPrefix, ignoredSet)
 		}
 	}
 	if len(ignoredSet) == 0 {
@@ -113,48 +112,31 @@ func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, sta
 }
 
 // addIgnoredSpecChangesForRegionConfig adds field names that will be silently ignored by Atlas.
-// auto_scaling and analytics_auto_scaling are independent in the Atlas API, so each block only governs its own tier.
-func addIgnoredSpecChangesForRegionConfig(ctx context.Context, stateRC, planRC *TFRegionConfigsModel, ignored map[string]struct{}) {
-	planAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AutoScaling)
-	planAnalyticsAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AnalyticsAutoScaling)
+// Per Atlas docs: when compute OR disk auto-scaling is enabled, Atlas ignores instanceSize, diskSizeGB, and diskIOPS
+// for electable and read-only nodes. For analytics nodes, only instanceSize is ignored.
+// https://www.mongodb.com/docs/atlas/cluster-autoscaling/#enhance-auto-scaling-with-effective-fields-in-terraform
+func addIgnoredSpecChangesForRegionConfig(ctx context.Context, planRC *TFRegionConfigsModel, attributeChanges schemafunc.AttributeChanges, rcPrefix string, ignored map[string]struct{}) {
+	autoScalingActive := isAutoScalingActive(ctx, planRC.AutoScaling)
+	analyticsAutoScalingActive := isAutoScalingActive(ctx, planRC.AnalyticsAutoScaling)
 
-	stateElectable := TFModelObject[TFSpecsModel](ctx, stateRC.ElectableSpecs)
-	planElectable := TFModelObject[TFSpecsModel](ctx, planRC.ElectableSpecs)
-	stateReadOnly := TFModelObject[TFSpecsModel](ctx, stateRC.ReadOnlySpecs)
-	planReadOnly := TFModelObject[TFSpecsModel](ctx, planRC.ReadOnlySpecs)
-	stateAnalytics := TFModelObject[TFSpecsModel](ctx, stateRC.AnalyticsSpecs)
-	planAnalytics := TFModelObject[TFSpecsModel](ctx, planRC.AnalyticsSpecs)
-
-	// Per Atlas docs: when compute OR disk auto-scaling is enabled, Atlas ignores instanceSize, diskSizeGB, and diskIOPS
-	// for electable and read-only nodes. For analytics nodes, only instanceSize is ignored.
-	// https://www.mongodb.com/docs/atlas/cluster-autoscaling/#enhance-auto-scaling-with-effective-fields-in-terraform
-	if planAutoScaling != nil && (planAutoScaling.ComputeEnabled.ValueBool() || planAutoScaling.DiskGBEnabled.ValueBool()) {
-		checkInstanceSizeDiff(stateElectable, planElectable, ignored)
-		checkInstanceSizeDiff(stateReadOnly, planReadOnly, ignored)
-		checkDiskDiff(stateElectable, planElectable, ignored)
-		checkDiskDiff(stateReadOnly, planReadOnly, ignored)
-	}
-	if planAnalyticsAutoScaling != nil && (planAnalyticsAutoScaling.ComputeEnabled.ValueBool() || planAnalyticsAutoScaling.DiskGBEnabled.ValueBool()) {
-		checkInstanceSizeDiff(stateAnalytics, planAnalytics, ignored)
+	electablePrefix := rcPrefix + ".electable_specs."
+	readOnlyPrefix := rcPrefix + ".read_only_specs."
+	analyticsPrefix := rcPrefix + ".analytics_specs."
+	for _, change := range attributeChanges {
+		switch {
+		case autoScalingActive && strings.HasPrefix(change, electablePrefix):
+			ignored[strings.TrimPrefix(change, electablePrefix)] = struct{}{}
+		case autoScalingActive && strings.HasPrefix(change, readOnlyPrefix):
+			ignored[strings.TrimPrefix(change, readOnlyPrefix)] = struct{}{}
+		case analyticsAutoScalingActive && change == analyticsPrefix+"instance_size":
+			ignored["instance_size"] = struct{}{}
+		}
 	}
 }
 
-func checkInstanceSizeDiff(state, plan *TFSpecsModel, ignored map[string]struct{}) {
-	if state != nil && plan != nil && !plan.InstanceSize.IsUnknown() && !state.InstanceSize.Equal(plan.InstanceSize) {
-		ignored["instance_size"] = struct{}{}
-	}
-}
-
-func checkDiskDiff(state, plan *TFSpecsModel, ignored map[string]struct{}) {
-	if state == nil || plan == nil {
-		return
-	}
-	if !plan.DiskSizeGb.IsUnknown() && !state.DiskSizeGb.Equal(plan.DiskSizeGb) {
-		ignored["disk_size_gb"] = struct{}{}
-	}
-	if !plan.DiskIops.IsUnknown() && !state.DiskIops.Equal(plan.DiskIops) {
-		ignored["disk_iops"] = struct{}{}
-	}
+func isAutoScalingActive(ctx context.Context, autoScalingObj basetypes.ObjectValue) bool {
+	autoScaling := TFModelObject[TFAutoScalingModel](ctx, autoScalingObj)
+	return autoScaling != nil && (autoScaling.ComputeEnabled.ValueBool() || autoScaling.DiskGBEnabled.ValueBool())
 }
 
 // adjustRegionConfigsChildren modifies the planned values of region configs based on the current state.

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -60,18 +60,18 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	autoScalingFields := determineKeepUnknownsAutoScaling(ctx, diags, state, plan)
 	keepUnknown = append(keepUnknown, autoScalingFields...)
-	emitWarningIfSpecChangedWithAutoScaling(diags, plan, attributeChanges, autoScalingFields)
+	emitWarningIfSpecChangedWithAutoScaling(ctx, diags, plan, attributeChanges)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
 }
 
 // emitWarningIfSpecChangedWithAutoScaling warns when use_effective_fields=true and auto-scaling is enabled but the user
-// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination.
-func emitWarningIfSpecChangedWithAutoScaling(diags *diag.Diagnostics, plan *TFModel, attributeChanges schemafunc.AttributeChanges, autoScalingFields []string) {
-	if !plan.UseEffectiveFields.ValueBool() || len(autoScalingFields) == 0 {
+// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination
+func emitWarningIfSpecChangedWithAutoScaling(ctx context.Context, diags *diag.Diagnostics, plan *TFModel, attributeChanges schemafunc.AttributeChanges) {
+	if !plan.UseEffectiveFields.ValueBool() || !autoScalingUsed(ctx, diags, plan) {
 		return
 	}
 	var changedFields []string
-	for _, field := range autoScalingFields {
+	for _, field := range []string{"instance_size", "disk_size_gb", "disk_iops"} {
 		if attributeChanges.AttributeChanged(field) {
 			changedFields = append(changedFields, field)
 		}
@@ -193,28 +193,26 @@ func findDefinedElectableSpecInReplicationSpec(ctx context.Context, regionConfig
 }
 
 func determineKeepUnknownsAutoScaling(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) []string {
-	if !autoScalingUsed(ctx, diags, state, plan) {
+	if !autoScalingUsed(ctx, diags, state) && !autoScalingUsed(ctx, diags, plan) {
 		return nil
 	}
 	// When either compute or disk auto-scaling is enabled, all three fields may be adjusted by Atlas
 	return []string{"instance_size", "disk_size_gb", "disk_iops"}
 }
 
-// autoScalingUsed checks if auto-scaling was enabled (state) or will be enabled (plan).
-func autoScalingUsed(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) bool {
-	for _, model := range []*TFModel{state, plan} {
-		repSpecsTF := TFModelList[TFReplicationSpecsModel](ctx, diags, model.ReplicationSpecs)
-		for i := range repSpecsTF {
-			regiongConfigsTF := TFModelList[TFRegionConfigsModel](ctx, diags, repSpecsTF[i].RegionConfigs)
-			for j := range regiongConfigsTF {
-				for _, autoScalingTF := range []types.Object{regiongConfigsTF[j].AutoScaling, regiongConfigsTF[j].AnalyticsAutoScaling} {
-					autoscaling := TFModelObject[TFAutoScalingModel](ctx, autoScalingTF)
-					if autoscaling == nil {
-						continue
-					}
-					if autoscaling.ComputeEnabled.ValueBool() || autoscaling.DiskGBEnabled.ValueBool() {
-						return true
-					}
+// autoScalingUsed checks if auto-scaling is enabled in the given cluster model.
+func autoScalingUsed(ctx context.Context, diags *diag.Diagnostics, model *TFModel) bool {
+	repSpecsTF := TFModelList[TFReplicationSpecsModel](ctx, diags, model.ReplicationSpecs)
+	for i := range repSpecsTF {
+		regiongConfigsTF := TFModelList[TFRegionConfigsModel](ctx, diags, repSpecsTF[i].RegionConfigs)
+		for j := range regiongConfigsTF {
+			for _, autoScalingTF := range []types.Object{regiongConfigsTF[j].AutoScaling, regiongConfigsTF[j].AnalyticsAutoScaling} {
+				autoscaling := TFModelObject[TFAutoScalingModel](ctx, autoScalingTF)
+				if autoscaling == nil {
+					continue
+				}
+				if autoscaling.ComputeEnabled.ValueBool() || autoscaling.DiskGBEnabled.ValueBool() {
+					return true
 				}
 			}
 		}

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -63,13 +63,13 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	autoScalingFields := determineKeepUnknownsAutoScaling(ctx, diags, state, plan)
 	keepUnknown = append(keepUnknown, autoScalingFields...)
-	emitWarningIfSpecChangedWithAutoScaling(ctx, diags, plan, attributeChanges)
+	WarnIgnoredSpecChange(ctx, diags, plan, attributeChanges)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
 }
 
-// emitWarningIfSpecChangedWithAutoScaling warns when use_effective_fields=true and auto-scaling is enabled but the user
+// WarnIgnoredSpecChange warns when use_effective_fields=true and auto-scaling is enabled but the user
 // changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination
-func emitWarningIfSpecChangedWithAutoScaling(ctx context.Context, diags *diag.Diagnostics, plan *TFModel, attributeChanges schemafunc.AttributeChanges) {
+func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, plan *TFModel, attributeChanges schemafunc.AttributeChanges) {
 	if !plan.UseEffectiveFields.ValueBool() || !autoScalingUsed(ctx, diags, plan) {
 		return
 	}

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -69,10 +69,9 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 }
 
 // WarnIgnoredSpecChange warns when use_effective_fields=true and auto-scaling is enabled but the user
-// changed instance_size, disk_size_gb, or disk_iops — Atlas silently ignores these in that combination.
-// Per-tier scoping is implemented in addIgnoredSpecChangesForRegionConfig.
+// changed instance_size, disk_size_gb, or disk_iops
 func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) {
-	if !state.UseEffectiveFields.ValueBool() || !plan.UseEffectiveFields.ValueBool() {
+	if !plan.UseEffectiveFields.ValueBool() {
 		return
 	}
 	ignoredFields := collectIgnoredSpecChanges(ctx, diags, state, plan)

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -2,6 +2,8 @@ package advancedcluster
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -56,8 +58,36 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 	keepUnknown := []string{"connection_strings", "state_name", "mongo_db_version", "config_server_type"} // Volatile attributes, should not be copied from state
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
-	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
+	autoScalingFields := determineKeepUnknownsAutoScaling(ctx, diags, state, plan)
+	keepUnknown = append(keepUnknown, autoScalingFields...)
+	emitWarningIfSpecChangedWithAutoScaling(diags, plan, attributeChanges, autoScalingFields)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
+}
+
+// emitWarningIfSpecChangedWithAutoScaling warns when use_effective_fields=true and auto-scaling is enabled but the user
+// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination —
+// the new values are stored in state but the cluster is not modified, producing a false "1 changed" result with no feedback.
+func emitWarningIfSpecChangedWithAutoScaling(diags *diag.Diagnostics, plan *TFModel, attributeChanges schemafunc.AttributeChanges, autoScalingFields []string) {
+	if !plan.UseEffectiveFields.ValueBool() || len(autoScalingFields) == 0 {
+		return
+	}
+	var changedFields []string
+	for _, field := range autoScalingFields {
+		if attributeChanges.AttributeChanged(field) {
+			changedFields = append(changedFields, field)
+		}
+	}
+	if len(changedFields) == 0 {
+		return
+	}
+	diags.AddWarning(
+		"Spec change ignored due to auto-scaling",
+		fmt.Sprintf("The change to %s will be stored in Terraform state but will not modify the actual cluster in Atlas. "+
+			"When use_effective_fields is true and auto-scaling is enabled, Atlas controls instance_size, disk_size_gb, and disk_iops values. "+
+			"To apply this change, temporarily disable auto-scaling. "+
+			"See: https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster#manually-updating-specs-with-use_effective_fields",
+			strings.Join(changedFields, ", ")),
+	)
 }
 
 // adjustRegionConfigsChildren modifies the planned values of region configs based on the current state.

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -61,10 +61,9 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 	keepUnknown := []string{"connection_strings", "state_name", "mongo_db_version", "config_server_type"} // Volatile attributes, should not be copied from state
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
-	autoScalingFields := determineKeepUnknownsAutoScaling(ctx, diags, state, plan)
-	keepUnknown = append(keepUnknown, autoScalingFields...)
-	WarnIgnoredSpecChange(ctx, diags, plan, attributeChanges)
+	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
+	WarnIgnoredSpecChange(ctx, diags, plan, attributeChanges)
 }
 
 // WarnIgnoredSpecChange warns when use_effective_fields=true and auto-scaling is enabled but the user

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -117,7 +117,10 @@ func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, att
 // https://www.mongodb.com/docs/atlas/cluster-autoscaling/#enhance-auto-scaling-with-effective-fields-in-terraform
 func addIgnoredSpecChangesForRegionConfig(ctx context.Context, planRC *TFRegionConfigsModel, attributeChanges schemafunc.AttributeChanges, rcPrefix string, ignored map[string]struct{}) {
 	autoScalingActive := isAutoScalingActive(ctx, planRC.AutoScaling)
-	analyticsAutoScalingActive := isAutoScalingActive(ctx, planRC.AnalyticsAutoScaling)
+	// For analytics nodes, only compute_enabled causes instance_size to be ignored by Atlas.
+	// disk_gb_enabled alone does not affect analytics instance_size.
+	analyticsAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AnalyticsAutoScaling)
+	analyticsAutoScalingActive := analyticsAutoScaling != nil && analyticsAutoScaling.ComputeEnabled.ValueBool()
 
 	electablePrefix := rcPrefix + ".electable_specs."
 	readOnlyPrefix := rcPrefix + ".read_only_specs."

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -82,10 +82,10 @@ func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, plan *T
 		return
 	}
 	diags.AddWarning(
-		"Spec change ignored due to auto-scaling",
-		fmt.Sprintf("The change to %s will be stored in Terraform state but will not modify the actual cluster in Atlas. "+
+		"Spec change ignored when use_effective_fields is true and auto-scaling is enabled",
+		fmt.Sprintf("Your changes to %s will be stored in Terraform state but will not modify the actual cluster in Atlas. "+
 			"When use_effective_fields is true and auto-scaling is enabled, Atlas controls instance_size, disk_size_gb, and disk_iops values. "+
-			"To apply this change, temporarily disable auto-scaling. "+
+			"To apply your changes, disable auto-scaling and apply, then re-enable auto-scaling in a separate apply. "+
 			"See: https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster#manually-updating-specs-with-use_effective_fields",
 			strings.Join(changedFields, ", ")),
 	)

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -65,8 +65,7 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 }
 
 // emitWarningIfSpecChangedWithAutoScaling warns when use_effective_fields=true and auto-scaling is enabled but the user
-// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination —
-// the new values are stored in state but the cluster is not modified, producing a false "1 changed" result with no feedback.
+// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination.
 func emitWarningIfSpecChangedWithAutoScaling(diags *diag.Diagnostics, plan *TFModel, attributeChanges schemafunc.AttributeChanges, autoScalingFields []string) {
 	if !plan.UseEffectiveFields.ValueBool() || len(autoScalingFields) == 0 {
 		return

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -15,6 +15,13 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 )
 
+type RegionAutoScaling struct {
+	RCPrefix                string
+	ComputeEnabled          bool
+	DiskGBEnabled           bool
+	AnalyticsComputeEnabled bool
+}
+
 var (
 	// Spec fields that Atlas controls when auto-scaling is active.
 	autoScalingManagedSpecFields = []string{"instance_size", "disk_size_gb", "disk_iops"}
@@ -65,16 +72,19 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
-	WarnIgnoredSpecChange(ctx, diags, attributeChanges, plan)
+	configs := extractAutoScalingConfigs(ctx, diags, plan)
+	if !diags.HasError() {
+		WarnIgnoredSpecChange(diags, plan.UseEffectiveFields.ValueBool(), attributeChanges, configs)
+	}
 }
 
-// WarnIgnoredSpecChange warns when use_effective_fields=true and auto-scaling is enabled but the user
-// changed instance_size, disk_size_gb, or disk_iops
-func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, attributeChanges schemafunc.AttributeChanges, plan *TFModel) {
-	if !plan.UseEffectiveFields.ValueBool() {
+// WarnIgnoredSpecChange warns when use_effective_fields=true, auto-scaling is enabled, and the user
+// changed instance_size, disk_size_gb, or disk_iops — fields Atlas silently ignores in that case.
+func WarnIgnoredSpecChange(diags *diag.Diagnostics, useEffectiveFields bool, attributeChanges schemafunc.AttributeChanges, configs []RegionAutoScaling) {
+	if !useEffectiveFields {
 		return
 	}
-	ignoredFields := collectIgnoredSpecChanges(ctx, diags, attributeChanges, plan)
+	ignoredFields := collectIgnoredSpecChanges(attributeChanges, configs)
 	if len(ignoredFields) == 0 {
 		return
 	}
@@ -88,22 +98,10 @@ func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, attribu
 	)
 }
 
-// collectIgnoredSpecChanges returns sorted field names changed in plan but ignored by Atlas due to auto-scaling.
-func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, attributeChanges schemafunc.AttributeChanges, plan *TFModel) []string {
-	planRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, plan.ReplicationSpecs)
-	if diags.HasError() {
-		return nil
-	}
+func collectIgnoredSpecChanges(attributeChanges schemafunc.AttributeChanges, configs []RegionAutoScaling) []string {
 	ignoredSet := map[string]struct{}{}
-	for i := range planRepSpecs {
-		planRegionConfigs := TFModelList[TFRegionConfigsModel](ctx, diags, planRepSpecs[i].RegionConfigs)
-		if diags.HasError() {
-			return nil
-		}
-		for j := range planRegionConfigs {
-			rcPrefix := fmt.Sprintf("replication_specs[%d].region_configs[%d]", i, j)
-			addIgnoredSpecChangesForRegionConfig(ctx, &planRegionConfigs[j], attributeChanges, rcPrefix, ignoredSet)
-		}
+	for _, cfg := range configs {
+		addIgnoredSpecChangesForRegionConfig(cfg, attributeChanges, ignoredSet)
 	}
 	if len(ignoredSet) == 0 {
 		return nil
@@ -113,18 +111,13 @@ func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, att
 
 // addIgnoredSpecChangesForRegionConfig adds field names that will be silently ignored by Atlas.
 // Per Atlas docs: when compute OR disk auto-scaling is enabled, Atlas ignores instanceSize, diskSizeGB, and diskIOPS
-// for electable and read-only nodes. For analytics nodes, only instanceSize is ignored.
+// for electable and read-only nodes. For analytics nodes, only instanceSize is ignored (and only when compute is enabled).
 // https://www.mongodb.com/docs/atlas/cluster-autoscaling/#enhance-auto-scaling-with-effective-fields-in-terraform
-func addIgnoredSpecChangesForRegionConfig(ctx context.Context, planRC *TFRegionConfigsModel, attributeChanges schemafunc.AttributeChanges, rcPrefix string, ignored map[string]struct{}) {
-	autoScalingActive := isAutoScalingActive(ctx, planRC.AutoScaling)
-	// For analytics nodes, only compute_enabled causes instance_size to be ignored by Atlas.
-	// disk_gb_enabled alone does not affect analytics instance_size.
-	analyticsAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AnalyticsAutoScaling)
-	analyticsAutoScalingActive := analyticsAutoScaling != nil && analyticsAutoScaling.ComputeEnabled.ValueBool()
-
-	electablePrefix := rcPrefix + ".electable_specs."
-	readOnlyPrefix := rcPrefix + ".read_only_specs."
-	analyticsPrefix := rcPrefix + ".analytics_specs."
+func addIgnoredSpecChangesForRegionConfig(cfg RegionAutoScaling, attributeChanges schemafunc.AttributeChanges, ignored map[string]struct{}) {
+	autoScalingActive := cfg.ComputeEnabled || cfg.DiskGBEnabled
+	electablePrefix := cfg.RCPrefix + ".electable_specs."
+	readOnlyPrefix := cfg.RCPrefix + ".read_only_specs."
+	analyticsPrefix := cfg.RCPrefix + ".analytics_specs."
 	for _, change := range attributeChanges {
 		switch {
 		case autoScalingActive && strings.HasPrefix(change, electablePrefix):
@@ -135,15 +128,42 @@ func addIgnoredSpecChangesForRegionConfig(ctx context.Context, planRC *TFRegionC
 			if field := strings.TrimPrefix(change, readOnlyPrefix); slices.Contains(autoScalingManagedSpecFields, field) {
 				ignored[field] = struct{}{}
 			}
-		case analyticsAutoScalingActive && change == analyticsPrefix+"instance_size":
+		case cfg.AnalyticsComputeEnabled && change == analyticsPrefix+"instance_size":
 			ignored["instance_size"] = struct{}{}
 		}
 	}
 }
 
-func isAutoScalingActive(ctx context.Context, autoScalingObj basetypes.ObjectValue) bool {
-	autoScaling := TFModelObject[TFAutoScalingModel](ctx, autoScalingObj)
-	return autoScaling != nil && (autoScaling.ComputeEnabled.ValueBool() || autoScaling.DiskGBEnabled.ValueBool())
+// extractAutoScalingConfigs reads per-region-config auto-scaling flags from the plan model.
+func extractAutoScalingConfigs(ctx context.Context, diags *diag.Diagnostics, plan *TFModel) []RegionAutoScaling {
+	planRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, plan.ReplicationSpecs)
+	if diags.HasError() {
+		return nil
+	}
+	var configs []RegionAutoScaling
+	for i := range planRepSpecs {
+		planRegionConfigs := TFModelList[TFRegionConfigsModel](ctx, diags, planRepSpecs[i].RegionConfigs)
+		if diags.HasError() {
+			return nil
+		}
+		for j := range planRegionConfigs {
+			regionConfig := &planRegionConfigs[j]
+			autoScaling := TFModelObject[TFAutoScalingModel](ctx, regionConfig.AutoScaling)
+			analyticsAutoScaling := TFModelObject[TFAutoScalingModel](ctx, regionConfig.AnalyticsAutoScaling)
+			cfg := RegionAutoScaling{
+				RCPrefix: fmt.Sprintf("replication_specs[%d].region_configs[%d]", i, j),
+			}
+			if autoScaling != nil {
+				cfg.ComputeEnabled = autoScaling.ComputeEnabled.ValueBool()
+				cfg.DiskGBEnabled = autoScaling.DiskGBEnabled.ValueBool()
+			}
+			if analyticsAutoScaling != nil {
+				cfg.AnalyticsComputeEnabled = analyticsAutoScaling.ComputeEnabled.ValueBool()
+			}
+			configs = append(configs, cfg)
+		}
+	}
+	return configs
 }
 
 // adjustRegionConfigsChildren modifies the planned values of region configs based on the current state.

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -125,19 +125,17 @@ func addIgnoredSpecChangesForRegionConfig(ctx context.Context, stateRC, planRC *
 	stateAnalytics := TFModelObject[TFSpecsModel](ctx, stateRC.AnalyticsSpecs)
 	planAnalytics := TFModelObject[TFSpecsModel](ctx, planRC.AnalyticsSpecs)
 
-	if planAutoScaling != nil && planAutoScaling.ComputeEnabled.ValueBool() {
+	// Per Atlas docs: when compute OR disk auto-scaling is enabled, Atlas ignores instanceSize, diskSizeGB, and diskIOPS
+	// for electable and read-only nodes. For analytics nodes, only instanceSize is ignored.
+	// https://www.mongodb.com/docs/atlas/cluster-autoscaling/#enhance-auto-scaling-with-effective-fields-in-terraform
+	if planAutoScaling != nil && (planAutoScaling.ComputeEnabled.ValueBool() || planAutoScaling.DiskGBEnabled.ValueBool()) {
 		checkInstanceSizeDiff(stateElectable, planElectable, ignored)
 		checkInstanceSizeDiff(stateReadOnly, planReadOnly, ignored)
-	}
-	if planAnalyticsAutoScaling != nil && planAnalyticsAutoScaling.ComputeEnabled.ValueBool() {
-		checkInstanceSizeDiff(stateAnalytics, planAnalytics, ignored)
-	}
-	if planAutoScaling != nil && planAutoScaling.DiskGBEnabled.ValueBool() {
 		checkDiskDiff(stateElectable, planElectable, ignored)
 		checkDiskDiff(stateReadOnly, planReadOnly, ignored)
 	}
-	if planAnalyticsAutoScaling != nil && planAnalyticsAutoScaling.DiskGBEnabled.ValueBool() {
-		checkDiskDiff(stateAnalytics, planAnalytics, ignored)
+	if planAnalyticsAutoScaling != nil && (planAnalyticsAutoScaling.ComputeEnabled.ValueBool() || planAnalyticsAutoScaling.DiskGBEnabled.ValueBool()) {
+		checkInstanceSizeDiff(stateAnalytics, planAnalytics, ignored)
 	}
 }
 

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -125,9 +125,13 @@ func addIgnoredSpecChangesForRegionConfig(ctx context.Context, planRC *TFRegionC
 	for _, change := range attributeChanges {
 		switch {
 		case autoScalingActive && strings.HasPrefix(change, electablePrefix):
-			ignored[strings.TrimPrefix(change, electablePrefix)] = struct{}{}
+			if field := strings.TrimPrefix(change, electablePrefix); slices.Contains(autoScalingManagedSpecFields, field) {
+				ignored[field] = struct{}{}
+			}
 		case autoScalingActive && strings.HasPrefix(change, readOnlyPrefix):
-			ignored[strings.TrimPrefix(change, readOnlyPrefix)] = struct{}{}
+			if field := strings.TrimPrefix(change, readOnlyPrefix); slices.Contains(autoScalingManagedSpecFields, field) {
+				ignored[field] = struct{}{}
+			}
 		case analyticsAutoScalingActive && change == analyticsPrefix+"instance_size":
 			ignored["instance_size"] = struct{}{}
 		}

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -3,6 +3,8 @@ package advancedcluster
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -63,25 +65,19 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
-	WarnIgnoredSpecChange(ctx, diags, plan, attributeChanges)
+	WarnIgnoredSpecChange(ctx, diags, state, plan)
 }
 
 // WarnIgnoredSpecChange warns when use_effective_fields=true and auto-scaling is enabled but the user
-// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination
-func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, plan *TFModel, attributeChanges schemafunc.AttributeChanges) {
-	if !plan.UseEffectiveFields.ValueBool() || !autoScalingUsed(ctx, diags, plan) {
+// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination.
+// The check is scoped per region config: compute_enabled governs electable/read_only instance_size,
+// analytics_auto_scaling.compute_enabled governs analytics instance_size, and disk_gb_enabled governs disk fields for all specs.
+func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) {
+	if !plan.UseEffectiveFields.ValueBool() {
 		return
 	}
-	if attributeChanges.ListLenChanges("replication_specs") || attributeChanges.ListLenChanges("region_configs") {
-		return
-	}
-	var changedFields []string
-	for _, field := range autoScalingManagedSpecFields {
-		if attributeChanges.AttributeChanged(field) {
-			changedFields = append(changedFields, field)
-		}
-	}
-	if len(changedFields) == 0 {
+	ignoredFields := collectIgnoredSpecChanges(ctx, diags, state, plan)
+	if len(ignoredFields) == 0 {
 		return
 	}
 	diags.AddWarning(
@@ -90,8 +86,76 @@ func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, plan *T
 			"When use_effective_fields is true and auto-scaling is enabled, Atlas controls instance_size, disk_size_gb, and disk_iops values. "+
 			"To apply your changes, disable auto-scaling and apply, then re-enable auto-scaling in a separate apply. "+
 			"See: https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster#manually-updating-specs-with-use_effective_fields",
-			strings.Join(changedFields, ", ")),
+			strings.Join(ignoredFields, ", ")),
 	)
+}
+
+// collectIgnoredSpecChanges returns sorted field names that changed in plan vs state but will be ignored by Atlas due to auto-scaling.
+// New replication specs or region configs added in plan (no state counterpart) are naturally skipped via minLen iteration.
+func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) []string {
+	stateRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, state.ReplicationSpecs)
+	planRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, plan.ReplicationSpecs)
+	if diags.HasError() {
+		return nil
+	}
+	ignoredSet := map[string]struct{}{}
+	for i := range minLen(planRepSpecs, stateRepSpecs) {
+		stateRegionConfigs := TFModelList[TFRegionConfigsModel](ctx, diags, stateRepSpecs[i].RegionConfigs)
+		planRegionConfigs := TFModelList[TFRegionConfigsModel](ctx, diags, planRepSpecs[i].RegionConfigs)
+		if diags.HasError() {
+			return nil
+		}
+		for j := range minLen(planRegionConfigs, stateRegionConfigs) {
+			addIgnoredSpecChangesForRegionConfig(ctx, &stateRegionConfigs[j], &planRegionConfigs[j], ignoredSet)
+		}
+	}
+	if len(ignoredSet) == 0 {
+		return nil
+	}
+	return slices.Sorted(maps.Keys(ignoredSet))
+}
+
+func addIgnoredSpecChangesForRegionConfig(ctx context.Context, stateRC, planRC *TFRegionConfigsModel, ignored map[string]struct{}) {
+	planAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AutoScaling)
+	planAnalyticsAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AnalyticsAutoScaling)
+
+	stateElectable := TFModelObject[TFSpecsModel](ctx, stateRC.ElectableSpecs)
+	planElectable := TFModelObject[TFSpecsModel](ctx, planRC.ElectableSpecs)
+	stateReadOnly := TFModelObject[TFSpecsModel](ctx, stateRC.ReadOnlySpecs)
+	planReadOnly := TFModelObject[TFSpecsModel](ctx, planRC.ReadOnlySpecs)
+	stateAnalytics := TFModelObject[TFSpecsModel](ctx, stateRC.AnalyticsSpecs)
+	planAnalytics := TFModelObject[TFSpecsModel](ctx, planRC.AnalyticsSpecs)
+
+	if planAutoScaling != nil && planAutoScaling.ComputeEnabled.ValueBool() {
+		checkInstanceSizeDiff(stateElectable, planElectable, ignored)
+		checkInstanceSizeDiff(stateReadOnly, planReadOnly, ignored)
+	}
+	if planAnalyticsAutoScaling != nil && planAnalyticsAutoScaling.ComputeEnabled.ValueBool() {
+		checkInstanceSizeDiff(stateAnalytics, planAnalytics, ignored)
+	}
+	if planAutoScaling != nil && planAutoScaling.DiskGBEnabled.ValueBool() {
+		checkDiskDiff(stateElectable, planElectable, ignored)
+		checkDiskDiff(stateReadOnly, planReadOnly, ignored)
+		checkDiskDiff(stateAnalytics, planAnalytics, ignored)
+	}
+}
+
+func checkInstanceSizeDiff(state, plan *TFSpecsModel, ignored map[string]struct{}) {
+	if state != nil && plan != nil && !state.InstanceSize.Equal(plan.InstanceSize) {
+		ignored["instance_size"] = struct{}{}
+	}
+}
+
+func checkDiskDiff(state, plan *TFSpecsModel, ignored map[string]struct{}) {
+	if state == nil || plan == nil {
+		return
+	}
+	if !state.DiskSizeGb.Equal(plan.DiskSizeGb) {
+		ignored["disk_size_gb"] = struct{}{}
+	}
+	if !state.DiskIops.Equal(plan.DiskIops) {
+		ignored["disk_iops"] = struct{}{}
+	}
 }
 
 // adjustRegionConfigsChildren modifies the planned values of region configs based on the current state.

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -14,6 +14,9 @@ import (
 )
 
 var (
+	// Spec fields that Atlas controls when auto-scaling is active.
+	autoScalingManagedSpecFields = []string{"instance_size", "disk_size_gb", "disk_iops"}
+
 	// Change mappings uses `attribute_name`, it doesn't care about the nested level.
 	attributeRootChangeMapping = map[string][]string{
 		"replication_specs":      {},
@@ -71,7 +74,7 @@ func emitWarningIfSpecChangedWithAutoScaling(ctx context.Context, diags *diag.Di
 		return
 	}
 	var changedFields []string
-	for _, field := range []string{"instance_size", "disk_size_gb", "disk_iops"} {
+	for _, field := range autoScalingManagedSpecFields {
 		if attributeChanges.AttributeChanged(field) {
 			changedFields = append(changedFields, field)
 		}
@@ -197,7 +200,7 @@ func determineKeepUnknownsAutoScaling(ctx context.Context, diags *diag.Diagnosti
 		return nil
 	}
 	// When either compute or disk auto-scaling is enabled, all three fields may be adjusted by Atlas
-	return []string{"instance_size", "disk_size_gb", "disk_iops"}
+	return autoScalingManagedSpecFields
 }
 
 // autoScalingUsed checks if auto-scaling is enabled in the given cluster model.

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -69,11 +69,10 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 }
 
 // WarnIgnoredSpecChange warns when use_effective_fields=true and auto-scaling is enabled but the user
-// changed instance_size, disk_size_gb, or disk_iops. Atlas silently ignores these changes in that combination.
-// The check is scoped per region config: compute_enabled governs electable/read_only instance_size,
-// analytics_auto_scaling.compute_enabled governs analytics instance_size, and disk_gb_enabled governs disk fields for all specs.
+// changed instance_size, disk_size_gb, or disk_iops — Atlas silently ignores these in that combination.
+// Per-tier scoping is implemented in addIgnoredSpecChangesForRegionConfig.
 func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) {
-	if !plan.UseEffectiveFields.ValueBool() {
+	if !state.UseEffectiveFields.ValueBool() || !plan.UseEffectiveFields.ValueBool() {
 		return
 	}
 	ignoredFields := collectIgnoredSpecChanges(ctx, diags, state, plan)
@@ -90,8 +89,7 @@ func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, state, 
 	)
 }
 
-// collectIgnoredSpecChanges returns sorted field names that changed in plan vs state but will be ignored by Atlas due to auto-scaling.
-// New replication specs or region configs added in plan (no state counterpart) are naturally skipped via minLen iteration.
+// collectIgnoredSpecChanges returns sorted field names changed in plan but ignored by Atlas due to auto-scaling.
 func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) []string {
 	stateRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, state.ReplicationSpecs)
 	planRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, plan.ReplicationSpecs)
@@ -115,6 +113,8 @@ func collectIgnoredSpecChanges(ctx context.Context, diags *diag.Diagnostics, sta
 	return slices.Sorted(maps.Keys(ignoredSet))
 }
 
+// addIgnoredSpecChangesForRegionConfig adds field names that will be silently ignored by Atlas.
+// auto_scaling and analytics_auto_scaling are independent in the Atlas API, so each block only governs its own tier.
 func addIgnoredSpecChangesForRegionConfig(ctx context.Context, stateRC, planRC *TFRegionConfigsModel, ignored map[string]struct{}) {
 	planAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AutoScaling)
 	planAnalyticsAutoScaling := TFModelObject[TFAutoScalingModel](ctx, planRC.AnalyticsAutoScaling)
@@ -136,12 +136,14 @@ func addIgnoredSpecChangesForRegionConfig(ctx context.Context, stateRC, planRC *
 	if planAutoScaling != nil && planAutoScaling.DiskGBEnabled.ValueBool() {
 		checkDiskDiff(stateElectable, planElectable, ignored)
 		checkDiskDiff(stateReadOnly, planReadOnly, ignored)
+	}
+	if planAnalyticsAutoScaling != nil && planAnalyticsAutoScaling.DiskGBEnabled.ValueBool() {
 		checkDiskDiff(stateAnalytics, planAnalytics, ignored)
 	}
 }
 
 func checkInstanceSizeDiff(state, plan *TFSpecsModel, ignored map[string]struct{}) {
-	if state != nil && plan != nil && !state.InstanceSize.Equal(plan.InstanceSize) {
+	if state != nil && plan != nil && !plan.InstanceSize.IsUnknown() && !state.InstanceSize.Equal(plan.InstanceSize) {
 		ignored["instance_size"] = struct{}{}
 	}
 }
@@ -150,10 +152,10 @@ func checkDiskDiff(state, plan *TFSpecsModel, ignored map[string]struct{}) {
 	if state == nil || plan == nil {
 		return
 	}
-	if !state.DiskSizeGb.Equal(plan.DiskSizeGb) {
+	if !plan.DiskSizeGb.IsUnknown() && !state.DiskSizeGb.Equal(plan.DiskSizeGb) {
 		ignored["disk_size_gb"] = struct{}{}
 	}
-	if !state.DiskIops.Equal(plan.DiskIops) {
+	if !plan.DiskIops.IsUnknown() && !state.DiskIops.Equal(plan.DiskIops) {
 		ignored["disk_iops"] = struct{}{}
 	}
 }
@@ -266,7 +268,7 @@ func determineKeepUnknownsAutoScaling(ctx context.Context, diags *diag.Diagnosti
 		return nil
 	}
 	// When either compute or disk auto-scaling is enabled, all three fields may be adjusted by Atlas
-	return autoScalingManagedSpecFields
+	return slices.Clone(autoScalingManagedSpecFields)
 }
 
 // autoScalingUsed checks if auto-scaling is enabled in the given cluster model.

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -72,6 +72,9 @@ func WarnIgnoredSpecChange(ctx context.Context, diags *diag.Diagnostics, plan *T
 	if !plan.UseEffectiveFields.ValueBool() || !autoScalingUsed(ctx, diags, plan) {
 		return
 	}
+	if attributeChanges.ListLenChanges("replication_specs") || attributeChanges.ListLenChanges("region_configs") {
+		return
+	}
 	var changedFields []string
 	for _, field := range autoScalingManagedSpecFields {
 		if attributeChanges.AttributeChanged(field) {

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -132,6 +132,7 @@ type regionConfigTestParams struct {
 	analyticsDiskSizeGb     float64
 	readOnlyDiskSizeGb      float64
 	diskIops                int64
+	electableNodeCount      int64
 	computeEnabled          bool
 	analyticsComputeEnabled bool
 	diskGBEnabled           bool
@@ -180,7 +181,7 @@ func buildRegionConfig(t *testing.T, rcParams *regionConfigTestParams) advancedc
 	return advancedcluster.TFRegionConfigsModel{
 		AutoScaling:          buildAutoScaling(t, rcParams.computeEnabled, rcParams.diskGBEnabled),
 		AnalyticsAutoScaling: buildAutoScaling(t, rcParams.analyticsComputeEnabled, rcParams.analyticsDiskGBEnabled),
-		ElectableSpecs:       buildSpecs(t, rcParams.electableInstanceSize, 3, rcParams.diskSizeGb, rcParams.diskIops),
+		ElectableSpecs:       buildSpecs(t, rcParams.electableInstanceSize, max(rcParams.electableNodeCount, 3), rcParams.diskSizeGb, rcParams.diskIops),
 		AnalyticsSpecs:       buildSpecs(t, rcParams.analyticsInstanceSize, 1, analyticsDiskSizeGb, rcParams.diskIops),
 		ReadOnlySpecs:        buildSpecs(t, rcParams.readOnlyInstanceSize, 2, readOnlyDiskSizeGb, rcParams.diskIops),
 		ProviderName:         types.StringValue("AWS"),
@@ -250,6 +251,11 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 		"no warning when auto-scaling is on but no managed spec fields changed": {
 			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
 			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
+			expectWarning: false,
+		},
+		"no warning when auto-scaling is on but only node_count changed": {
+			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", electableNodeCount: 3},
+			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", electableNodeCount: 5},
 			expectWarning: false,
 		},
 		"no warning when only analytics compute auto-scaling on but electable instance_size changed": {

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -124,90 +124,94 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 }
 
 type regionConfigTestParams struct {
-	electableInstanceSize   string // empty = null analytics_specs
-	analyticsInstanceSize   string
-	diskSizeGb              float64
+	electableInstanceSize   string  // empty = null electable_specs
+	analyticsInstanceSize   string  // empty = null analytics_specs
+	diskSizeGb              float64 // applied to both electable and analytics specs unless analyticsDiskSizeGb is set
+	analyticsDiskSizeGb     float64 // when non-zero, overrides diskSizeGb for analytics_specs
 	diskIops                int64
 	computeEnabled          bool
 	analyticsComputeEnabled bool
 	diskGBEnabled           bool
+	analyticsDiskGBEnabled  bool
 }
 
-func buildModelForWarnTest(t *testing.T, useEffectiveFields bool, rcParams regionConfigTestParams) *advancedcluster.TFModel {
+func buildAutoScaling(t *testing.T, computeEnabled, diskGBEnabled bool) types.Object {
 	t.Helper()
-	ctx := context.Background()
-
-	autoScaling, diags := types.ObjectValueFrom(ctx, autoScalingAttrTypes, advancedcluster.TFAutoScalingModel{
-		ComputeEnabled:          types.BoolValue(rcParams.computeEnabled),
-		DiskGBEnabled:           types.BoolValue(rcParams.diskGBEnabled),
+	obj, diags := types.ObjectValueFrom(context.Background(), autoScalingAttrTypes, advancedcluster.TFAutoScalingModel{
+		ComputeEnabled:          types.BoolValue(computeEnabled),
+		DiskGBEnabled:           types.BoolValue(diskGBEnabled),
 		ComputeScaleDownEnabled: types.BoolValue(false),
 		ComputeMinInstanceSize:  types.StringValue("M10"),
 		ComputeMaxInstanceSize:  types.StringValue("M40"),
 	})
 	require.Empty(t, diags)
+	return obj
+}
 
-	analyticsAutoScaling, diags := types.ObjectValueFrom(ctx, autoScalingAttrTypes, advancedcluster.TFAutoScalingModel{
-		ComputeEnabled:          types.BoolValue(rcParams.analyticsComputeEnabled),
-		DiskGBEnabled:           types.BoolValue(false),
-		ComputeScaleDownEnabled: types.BoolValue(false),
-		ComputeMinInstanceSize:  types.StringValue("M10"),
-		ComputeMaxInstanceSize:  types.StringValue("M40"),
-	})
-	require.Empty(t, diags)
-
-	electableSpecs, diags := types.ObjectValueFrom(ctx, specsAttrTypes, advancedcluster.TFSpecsModel{
-		InstanceSize:  types.StringValue(rcParams.electableInstanceSize),
-		NodeCount:     types.Int64Value(3),
-		DiskSizeGb:    types.Float64Value(rcParams.diskSizeGb),
-		DiskIops:      types.Int64Value(rcParams.diskIops),
+func buildSpecs(t *testing.T, instanceSize string, nodeCount int64, diskSizeGb float64, diskIops int64) types.Object {
+	t.Helper()
+	if instanceSize == "" {
+		return types.ObjectNull(specsAttrTypes)
+	}
+	obj, diags := types.ObjectValueFrom(context.Background(), specsAttrTypes, advancedcluster.TFSpecsModel{
+		InstanceSize:  types.StringValue(instanceSize),
+		NodeCount:     types.Int64Value(nodeCount),
+		DiskSizeGb:    types.Float64Value(diskSizeGb),
+		DiskIops:      types.Int64Value(diskIops),
 		EbsVolumeType: types.StringNull(),
 	})
 	require.Empty(t, diags)
+	return obj
+}
 
-	var analyticsSpecs types.Object
-	if rcParams.analyticsInstanceSize != "" {
-		analyticsSpecs, diags = types.ObjectValueFrom(ctx, specsAttrTypes, advancedcluster.TFSpecsModel{
-			InstanceSize:  types.StringValue(rcParams.analyticsInstanceSize),
-			NodeCount:     types.Int64Value(1),
-			DiskSizeGb:    types.Float64Value(rcParams.diskSizeGb),
-			DiskIops:      types.Int64Value(rcParams.diskIops),
-			EbsVolumeType: types.StringNull(),
-		})
-		require.Empty(t, diags)
-	} else {
-		analyticsSpecs = types.ObjectNull(specsAttrTypes)
+func buildRegionConfig(t *testing.T, rcParams regionConfigTestParams) advancedcluster.TFRegionConfigsModel {
+	t.Helper()
+	analyticsDiskSizeGb := rcParams.diskSizeGb
+	if rcParams.analyticsDiskSizeGb != 0 {
+		analyticsDiskSizeGb = rcParams.analyticsDiskSizeGb
 	}
-
-	regionConfig := advancedcluster.TFRegionConfigsModel{
-		AutoScaling:          autoScaling,
-		AnalyticsAutoScaling: analyticsAutoScaling,
-		AnalyticsSpecs:       analyticsSpecs,
-		ElectableSpecs:       electableSpecs,
+	return advancedcluster.TFRegionConfigsModel{
+		AutoScaling:          buildAutoScaling(t, rcParams.computeEnabled, rcParams.diskGBEnabled),
+		AnalyticsAutoScaling: buildAutoScaling(t, rcParams.analyticsComputeEnabled, rcParams.analyticsDiskGBEnabled),
+		ElectableSpecs:       buildSpecs(t, rcParams.electableInstanceSize, 3, rcParams.diskSizeGb, rcParams.diskIops),
+		AnalyticsSpecs:       buildSpecs(t, rcParams.analyticsInstanceSize, 1, analyticsDiskSizeGb, rcParams.diskIops),
 		ReadOnlySpecs:        types.ObjectNull(specsAttrTypes),
 		ProviderName:         types.StringValue("AWS"),
 		RegionName:           types.StringValue("US_EAST_1"),
 		Priority:             types.Int64Value(7),
 		BackingProviderName:  types.StringNull(),
 	}
-	regionConfigs, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: regionConfigAttrTypes}, []advancedcluster.TFRegionConfigsModel{regionConfig})
-	require.Empty(t, diags)
+}
 
-	repSpec := advancedcluster.TFReplicationSpecsModel{
-		RegionConfigs: regionConfigs,
+func buildRepSpec(t *testing.T, regionConfigs ...advancedcluster.TFRegionConfigsModel) advancedcluster.TFReplicationSpecsModel {
+	t.Helper()
+	rcList, diags := types.ListValueFrom(context.Background(), types.ObjectType{AttrTypes: regionConfigAttrTypes}, regionConfigs)
+	require.Empty(t, diags)
+	return advancedcluster.TFReplicationSpecsModel{
+		RegionConfigs: rcList,
 		ContainerId:   types.MapNull(types.StringType),
 		ExternalId:    types.StringNull(),
 		ZoneId:        types.StringNull(),
 		ZoneName:      types.StringNull(),
 	}
-	repSpecs, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: replicationSpecAttrTypes}, []advancedcluster.TFReplicationSpecsModel{repSpec})
-	require.Empty(t, diags)
+}
 
+func buildModel(t *testing.T, useEffectiveFields bool, repSpecs ...advancedcluster.TFReplicationSpecsModel) *advancedcluster.TFModel {
+	t.Helper()
+	repSpecsList, diags := types.ListValueFrom(context.Background(), types.ObjectType{AttrTypes: replicationSpecAttrTypes}, repSpecs)
+	require.Empty(t, diags)
 	return &advancedcluster.TFModel{
 		UseEffectiveFields: types.BoolValue(useEffectiveFields),
-		ReplicationSpecs:   repSpecs,
+		ReplicationSpecs:   repSpecsList,
 		Labels:             types.MapNull(types.StringType),
 		Tags:               types.MapNull(types.StringType),
 	}
+}
+
+// buildModelForWarnTest builds a TFModel with a single replication spec containing a single region config.
+func buildModelForWarnTest(t *testing.T, useEffectiveFields bool, rcParams regionConfigTestParams) *advancedcluster.TFModel {
+	t.Helper()
+	return buildModel(t, useEffectiveFields, buildRepSpec(t, buildRegionConfig(t, rcParams)))
 }
 
 func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
@@ -226,17 +230,10 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			expectWarning:      true,
 		},
 		{
-			name:               "warns when disk auto-scaling on and disk_size_gb changed",
+			name:               "warns when disk auto-scaling on and disk fields changed",
 			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
-			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20},
-			expectWarning:      true,
-		},
-		{
-			name:               "warns when disk auto-scaling on and disk_iops changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskIops: 3000},
-			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskIops: 4000},
+			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10, diskIops: 3000},
+			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20, diskIops: 4000},
 			expectWarning:      true,
 		},
 		{
@@ -275,10 +272,24 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			expectWarning:      false,
 		},
 		{
-			name:               "no warning when only compute auto-scaling on but analytics instance_size changed",
+			name:               "warns when analytics disk auto-scaling on and analytics disk fields changed",
 			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
-			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
+			stateRC:            regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10},
+			planRC:             regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20},
+			expectWarning:      true,
+		},
+		{
+			name:               "no warning when only electable disk auto-scaling on but analytics disk_size_gb changed",
+			useEffectiveFields: true,
+			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
+			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 20},
+			expectWarning:      false, // auto_scaling.disk_gb_enabled only governs electable/read_only disk
+		},
+		{
+			name:               "no warning when only analytics disk auto-scaling on but electable disk_size_gb changed",
+			useEffectiveFields: true,
+			stateRC:            regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
+			planRC:             regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20, analyticsDiskSizeGb: 10},
 			expectWarning:      false,
 		},
 	}
@@ -295,89 +306,45 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			assert.False(t, diags.HasError())
 			if tc.expectWarning {
 				assert.Equal(t, 1, diags.WarningsCount())
+				assert.Contains(t, diags[0].Summary(), "Spec change ignored")
 			} else {
 				assert.Equal(t, 0, diags.WarningsCount())
 			}
 		})
 	}
 
-	// List length changes: new specs/region_configs added in plan have no state counterpart,
-	// so minLen iteration naturally skips them — no false positive warning.
+	// List length changes: new entries added in plan have no state counterpart, so minLen iteration skips them.
 	t.Run("no warning when replication_specs list length changes", func(t *testing.T) {
-		ctx := context.Background()
-		state := buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		// plan has 2 rep specs; first is unchanged, second is new (no state counterpart)
-		plan := addExtraRepSpec(t, buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"}),
-			regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		rc1 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		rc2 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		state := buildModel(t, true, buildRepSpec(t, rc1))
+		plan := buildModel(t, true, buildRepSpec(t, rc1), buildRepSpec(t, rc2))
 		var diags diag.Diagnostics
-		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, state, plan)
+		advancedcluster.WarnIgnoredSpecChange(context.Background(), &diags, state, plan)
 		assert.False(t, diags.HasError())
 		assert.Equal(t, 0, diags.WarningsCount())
 	})
 
 	t.Run("no warning when region_configs list length changes", func(t *testing.T) {
+		rc1 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		rc2 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		state := buildModel(t, true, buildRepSpec(t, rc1))
+		plan := buildModel(t, true, buildRepSpec(t, rc1, rc2))
+		var diags diag.Diagnostics
+		advancedcluster.WarnIgnoredSpecChange(context.Background(), &diags, state, plan)
+		assert.False(t, diags.HasError())
+		assert.Equal(t, 0, diags.WarningsCount())
+	})
+
+	// Toggle case: state=false, plan=true. handleModifyPlan returns early on toggle so WarnIgnoredSpecChange
+	// is never reached from production, but the dual use_effective_fields guard makes it safe independently.
+	t.Run("no warning when toggling use_effective_fields from false to true", func(t *testing.T) {
 		ctx := context.Background()
-		state := buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		// plan has 2 region configs; first is unchanged, second is new (no state counterpart)
-		plan := addExtraRegionConfig(t, buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"}),
-			regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		state := buildModelForWarnTest(t, false, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		plan := buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
 		var diags diag.Diagnostics
 		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, state, plan)
 		assert.False(t, diags.HasError())
 		assert.Equal(t, 0, diags.WarningsCount())
 	})
-}
-
-// addExtraRepSpec appends a new replication spec to the model's ReplicationSpecs list.
-func addExtraRepSpec(t *testing.T, model *advancedcluster.TFModel, rcParams regionConfigTestParams) *advancedcluster.TFModel {
-	t.Helper()
-	extra := buildModelForWarnTest(t, model.UseEffectiveFields.ValueBool(), rcParams)
-	ctx := context.Background()
-
-	existing := make([]advancedcluster.TFReplicationSpecsModel, 0)
-	diags := model.ReplicationSpecs.ElementsAs(ctx, &existing, false)
-	require.Empty(t, diags)
-
-	extra1 := make([]advancedcluster.TFReplicationSpecsModel, 0)
-	diags = extra.ReplicationSpecs.ElementsAs(ctx, &extra1, false)
-	require.Empty(t, diags)
-
-	combined, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: replicationSpecAttrTypes}, append(existing, extra1...))
-	require.Empty(t, diags)
-
-	model.ReplicationSpecs = combined
-	return model
-}
-
-// addExtraRegionConfig appends a new region config to the first replication spec of the model.
-func addExtraRegionConfig(t *testing.T, model *advancedcluster.TFModel, rcParams regionConfigTestParams) *advancedcluster.TFModel {
-	t.Helper()
-	extra := buildModelForWarnTest(t, model.UseEffectiveFields.ValueBool(), rcParams)
-	ctx := context.Background()
-
-	repSpecs := make([]advancedcluster.TFReplicationSpecsModel, 0)
-	diags := model.ReplicationSpecs.ElementsAs(ctx, &repSpecs, false)
-	require.Empty(t, diags)
-
-	existingRCs := make([]advancedcluster.TFRegionConfigsModel, 0)
-	diags = repSpecs[0].RegionConfigs.ElementsAs(ctx, &existingRCs, false)
-	require.Empty(t, diags)
-
-	extraRepSpecs := make([]advancedcluster.TFReplicationSpecsModel, 0)
-	diags = extra.ReplicationSpecs.ElementsAs(ctx, &extraRepSpecs, false)
-	require.Empty(t, diags)
-
-	extraRCs := make([]advancedcluster.TFRegionConfigsModel, 0)
-	diags = extraRepSpecs[0].RegionConfigs.ElementsAs(ctx, &extraRCs, false)
-	require.Empty(t, diags)
-
-	combined, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: regionConfigAttrTypes}, append(existingRCs, extraRCs...))
-	require.Empty(t, diags)
-
-	repSpecs[0].RegionConfigs = combined
-	repSpecsList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: replicationSpecAttrTypes}, repSpecs)
-	require.Empty(t, diags)
-
-	model.ReplicationSpecs = repSpecsList
-	return model
 }

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -335,16 +335,4 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 		assert.False(t, diags.HasError())
 		assert.Equal(t, 0, diags.WarningsCount())
 	})
-
-	// Toggle case: state=false, plan=true. handleModifyPlan returns early on toggle so WarnIgnoredSpecChange
-	// is never reached from production, but the dual use_effective_fields guard makes it safe independently.
-	t.Run("no warning when toggling use_effective_fields from false to true", func(t *testing.T) {
-		ctx := context.Background()
-		state := buildModelForWarnTest(t, false, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		plan := buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
-		var diags diag.Diagnostics
-		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, state, plan)
-		assert.False(t, diags.HasError())
-		assert.Equal(t, 0, diags.WarningsCount())
-	})
 }

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -1,13 +1,59 @@
 package advancedcluster_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
+)
+
+// Attr type maps mirrors the unexported vars in schema.go to avoid uppercasing them.
+// They are redeclared here because this package is advancedcluster_test and cannot access package-private symbols.
+// Done in order to be able to add unit tests for WarnIgnoredSpecChange function, as they allow to test the function without depending on acceptance tests
+var (
+	autoScalingAttrTypes = map[string]attr.Type{
+		"compute_enabled":            types.BoolType,
+		"compute_max_instance_size":  types.StringType,
+		"compute_min_instance_size":  types.StringType,
+		"compute_scale_down_enabled": types.BoolType,
+		"disk_gb_enabled":            types.BoolType,
+	}
+	specsAttrTypes = map[string]attr.Type{
+		"disk_iops":       types.Int64Type,
+		"disk_size_gb":    types.Float64Type,
+		"ebs_volume_type": types.StringType,
+		"instance_size":   types.StringType,
+		"node_count":      types.Int64Type,
+	}
+	regionConfigAttrTypes = map[string]attr.Type{
+		"analytics_auto_scaling": types.ObjectType{AttrTypes: autoScalingAttrTypes},
+		"analytics_specs":        types.ObjectType{AttrTypes: specsAttrTypes},
+		"auto_scaling":           types.ObjectType{AttrTypes: autoScalingAttrTypes},
+		"backing_provider_name":  types.StringType,
+		"electable_specs":        types.ObjectType{AttrTypes: specsAttrTypes},
+		"priority":               types.Int64Type,
+		"provider_name":          types.StringType,
+		"read_only_specs":        types.ObjectType{AttrTypes: specsAttrTypes},
+		"region_name":            types.StringType,
+	}
+	replicationSpecAttrTypes = map[string]attr.Type{
+		"container_id":   types.MapType{ElemType: types.StringType},
+		"external_id":    types.StringType,
+		"region_configs": types.ListType{ElemType: types.ObjectType{AttrTypes: regionConfigAttrTypes}},
+		"zone_id":        types.StringType,
+		"zone_name":      types.StringType,
+	}
 )
 
 var (
@@ -77,6 +123,137 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.ConfigFilename, func(t *testing.T) {
 			unit.MockPlanChecksAndRun(t, baseConfig.WithPlanCheckTest(testCase))
+		})
+	}
+}
+
+func buildPlanWithAutoScaling(t *testing.T, useEffectiveFields, computeEnabled, diskGBEnabled bool) *advancedcluster.TFModel {
+	t.Helper()
+	ctx := context.Background()
+
+	autoScaling, diags := types.ObjectValueFrom(ctx, autoScalingAttrTypes, advancedcluster.TFAutoScalingModel{
+		ComputeEnabled:          types.BoolValue(computeEnabled),
+		DiskGBEnabled:           types.BoolValue(diskGBEnabled),
+		ComputeScaleDownEnabled: types.BoolValue(false),
+		ComputeMinInstanceSize:  types.StringValue("M10"),
+		ComputeMaxInstanceSize:  types.StringValue("M40"),
+	})
+	require.Empty(t, diags)
+
+	regionConfig := advancedcluster.TFRegionConfigsModel{
+		AutoScaling:          autoScaling,
+		AnalyticsAutoScaling: types.ObjectNull(autoScalingAttrTypes),
+		AnalyticsSpecs:       types.ObjectNull(specsAttrTypes),
+		ElectableSpecs:       types.ObjectNull(specsAttrTypes),
+		ReadOnlySpecs:        types.ObjectNull(specsAttrTypes),
+		ProviderName:         types.StringValue("AWS"),
+		RegionName:           types.StringValue("US_EAST_1"),
+		Priority:             types.Int64Value(7),
+		BackingProviderName:  types.StringNull(),
+	}
+	regionConfigs, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: regionConfigAttrTypes}, []advancedcluster.TFRegionConfigsModel{regionConfig})
+	require.Empty(t, diags)
+
+	repSpec := advancedcluster.TFReplicationSpecsModel{
+		RegionConfigs: regionConfigs,
+		ContainerId:   types.MapNull(types.StringType),
+		ExternalId:    types.StringNull(),
+		ZoneId:        types.StringNull(),
+		ZoneName:      types.StringNull(),
+	}
+	repSpecs, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: replicationSpecAttrTypes}, []advancedcluster.TFReplicationSpecsModel{repSpec})
+	require.Empty(t, diags)
+
+	return &advancedcluster.TFModel{
+		UseEffectiveFields: types.BoolValue(useEffectiveFields),
+		ReplicationSpecs:   repSpecs,
+		Labels:             types.MapNull(types.StringType),
+		Tags:               types.MapNull(types.StringType),
+	}
+}
+
+func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
+	testCases := []struct {
+		name               string
+		changedFields      schemafunc.AttributeChanges
+		useEffectiveFields bool
+		computeEnabled     bool
+		diskGBEnabled      bool
+		expectWarning      bool
+	}{
+		{
+			name:               "warns when compute auto-scaling on and instance_size changed",
+			useEffectiveFields: true,
+			computeEnabled:     true,
+			changedFields:      schemafunc.AttributeChanges{"instance_size"},
+			expectWarning:      true,
+		},
+		{
+			name:               "warns when disk auto-scaling on and disk_size_gb changed",
+			useEffectiveFields: true,
+			diskGBEnabled:      true,
+			changedFields:      schemafunc.AttributeChanges{"disk_size_gb"},
+			expectWarning:      true,
+		},
+		{
+			name:               "warns when compute auto-scaling on and disk_iops changed",
+			useEffectiveFields: true,
+			computeEnabled:     true,
+			changedFields:      schemafunc.AttributeChanges{"disk_iops"},
+			expectWarning:      true,
+		},
+		{
+			name:               "no warning when use_effective_fields is false",
+			useEffectiveFields: false,
+			computeEnabled:     true,
+			changedFields:      schemafunc.AttributeChanges{"instance_size"},
+			expectWarning:      false,
+		},
+		{
+			name:               "no warning when auto-scaling is disabled",
+			useEffectiveFields: true,
+			computeEnabled:     false,
+			diskGBEnabled:      false,
+			changedFields:      schemafunc.AttributeChanges{"instance_size"},
+			expectWarning:      false,
+		},
+		{
+			name:               "no warning when auto-scaling is on but no managed spec fields changed",
+			useEffectiveFields: true,
+			computeEnabled:     true,
+			changedFields:      schemafunc.AttributeChanges{"node_count"},
+			expectWarning:      false,
+		},
+		{
+			name:               "no warning when replication_specs list length changes (avoid false positive on new spec)",
+			useEffectiveFields: true,
+			computeEnabled:     true,
+			changedFields:      schemafunc.AttributeChanges{"replication_specs[+1]", "replication_specs[1].region_configs[0].instance_size", "instance_size"},
+			expectWarning:      false,
+		},
+		{
+			name:               "no warning when region_configs list length changes (avoid false positive on new region config)",
+			useEffectiveFields: true,
+			computeEnabled:     true,
+			changedFields:      schemafunc.AttributeChanges{"replication_specs[0].region_configs[+1]", "replication_specs[0].region_configs[1].instance_size", "instance_size"},
+			expectWarning:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			plan := buildPlanWithAutoScaling(t, tc.useEffectiveFields, tc.computeEnabled, tc.diskGBEnabled)
+			var diags diag.Diagnostics
+
+			advancedcluster.WarnIgnoredSpecChange(ctx, &diags, plan, tc.changedFields)
+
+			assert.False(t, diags.HasError())
+			if tc.expectWarning {
+				assert.Equal(t, 1, diags.WarningsCount())
+			} else {
+				assert.Equal(t, 0, diags.WarningsCount())
+			}
 		})
 	}
 }

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -1,56 +1,16 @@
 package advancedcluster_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
-)
-
-var (
-	autoScalingAttrTypes = map[string]attr.Type{
-		"compute_enabled":            types.BoolType,
-		"compute_max_instance_size":  types.StringType,
-		"compute_min_instance_size":  types.StringType,
-		"compute_scale_down_enabled": types.BoolType,
-		"disk_gb_enabled":            types.BoolType,
-	}
-	specsAttrTypes = map[string]attr.Type{
-		"disk_iops":       types.Int64Type,
-		"disk_size_gb":    types.Float64Type,
-		"ebs_volume_type": types.StringType,
-		"instance_size":   types.StringType,
-		"node_count":      types.Int64Type,
-	}
-	regionConfigAttrTypes = map[string]attr.Type{
-		"analytics_auto_scaling": types.ObjectType{AttrTypes: autoScalingAttrTypes},
-		"analytics_specs":        types.ObjectType{AttrTypes: specsAttrTypes},
-		"auto_scaling":           types.ObjectType{AttrTypes: autoScalingAttrTypes},
-		"backing_provider_name":  types.StringType,
-		"electable_specs":        types.ObjectType{AttrTypes: specsAttrTypes},
-		"priority":               types.Int64Type,
-		"provider_name":          types.StringType,
-		"read_only_specs":        types.ObjectType{AttrTypes: specsAttrTypes},
-		"region_name":            types.StringType,
-	}
-	replicationSpecAttrTypes = map[string]attr.Type{
-		"container_id":   types.MapType{ElemType: types.StringType},
-		"external_id":    types.StringType,
-		"region_configs": types.ListType{ElemType: types.ObjectType{AttrTypes: regionConfigAttrTypes}},
-		"zone_id":        types.StringType,
-		"zone_name":      types.StringType,
-	}
 )
 
 var (
@@ -124,197 +84,91 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 	}
 }
 
-type regionConfigTestParams struct {
-	electableInstanceSize   string
-	analyticsInstanceSize   string
-	readOnlyInstanceSize    string
-	diskSizeGb              float64
-	analyticsDiskSizeGb     float64
-	readOnlyDiskSizeGb      float64
-	diskIops                int64
-	electableNodeCount      int64
-	computeEnabled          bool
-	analyticsComputeEnabled bool
-	diskGBEnabled           bool
-	analyticsDiskGBEnabled  bool
-}
-
-func buildAutoScaling(t *testing.T, computeEnabled, diskGBEnabled bool) types.Object {
-	t.Helper()
-	obj, diags := types.ObjectValueFrom(context.Background(), autoScalingAttrTypes, advancedcluster.TFAutoScalingModel{
-		ComputeEnabled:          types.BoolValue(computeEnabled),
-		DiskGBEnabled:           types.BoolValue(diskGBEnabled),
-		ComputeScaleDownEnabled: types.BoolValue(false),
-		ComputeMinInstanceSize:  types.StringValue("M10"),
-		ComputeMaxInstanceSize:  types.StringValue("M40"),
-	})
-	require.Empty(t, diags)
-	return obj
-}
-
-func buildSpecs(t *testing.T, instanceSize string, nodeCount int64, diskSizeGb float64, diskIops int64) types.Object {
-	t.Helper()
-	if instanceSize == "" {
-		return types.ObjectNull(specsAttrTypes)
-	}
-	obj, diags := types.ObjectValueFrom(context.Background(), specsAttrTypes, advancedcluster.TFSpecsModel{
-		InstanceSize:  types.StringValue(instanceSize),
-		NodeCount:     types.Int64Value(nodeCount),
-		DiskSizeGb:    types.Float64Value(diskSizeGb),
-		DiskIops:      types.Int64Value(diskIops),
-		EbsVolumeType: types.StringNull(),
-	})
-	require.Empty(t, diags)
-	return obj
-}
-
-func buildRegionConfig(t *testing.T, rcParams *regionConfigTestParams) advancedcluster.TFRegionConfigsModel {
-	t.Helper()
-	analyticsDiskSizeGb := rcParams.diskSizeGb
-	if rcParams.analyticsDiskSizeGb != 0 {
-		analyticsDiskSizeGb = rcParams.analyticsDiskSizeGb
-	}
-	readOnlyDiskSizeGb := rcParams.diskSizeGb
-	if rcParams.readOnlyDiskSizeGb != 0 {
-		readOnlyDiskSizeGb = rcParams.readOnlyDiskSizeGb
-	}
-	return advancedcluster.TFRegionConfigsModel{
-		AutoScaling:          buildAutoScaling(t, rcParams.computeEnabled, rcParams.diskGBEnabled),
-		AnalyticsAutoScaling: buildAutoScaling(t, rcParams.analyticsComputeEnabled, rcParams.analyticsDiskGBEnabled),
-		ElectableSpecs:       buildSpecs(t, rcParams.electableInstanceSize, max(rcParams.electableNodeCount, 3), rcParams.diskSizeGb, rcParams.diskIops),
-		AnalyticsSpecs:       buildSpecs(t, rcParams.analyticsInstanceSize, 1, analyticsDiskSizeGb, rcParams.diskIops),
-		ReadOnlySpecs:        buildSpecs(t, rcParams.readOnlyInstanceSize, 2, readOnlyDiskSizeGb, rcParams.diskIops),
-		ProviderName:         types.StringValue("AWS"),
-		RegionName:           types.StringValue("US_EAST_1"),
-		Priority:             types.Int64Value(7),
-		BackingProviderName:  types.StringNull(),
-	}
-}
-
-func buildRepSpec(t *testing.T, regionConfigs ...advancedcluster.TFRegionConfigsModel) advancedcluster.TFReplicationSpecsModel {
-	t.Helper()
-	rcList, diags := types.ListValueFrom(context.Background(), types.ObjectType{AttrTypes: regionConfigAttrTypes}, regionConfigs)
-	require.Empty(t, diags)
-	return advancedcluster.TFReplicationSpecsModel{
-		RegionConfigs: rcList,
-		ContainerId:   types.MapNull(types.StringType),
-		ExternalId:    types.StringNull(),
-		ZoneId:        types.StringNull(),
-		ZoneName:      types.StringNull(),
-	}
-}
-
-func buildModel(t *testing.T, useEffectiveFields bool, repSpecs ...advancedcluster.TFReplicationSpecsModel) *advancedcluster.TFModel {
-	t.Helper()
-	repSpecsList, diags := types.ListValueFrom(context.Background(), types.ObjectType{AttrTypes: replicationSpecAttrTypes}, repSpecs)
-	require.Empty(t, diags)
-	return &advancedcluster.TFModel{
-		UseEffectiveFields: types.BoolValue(useEffectiveFields),
-		ReplicationSpecs:   repSpecsList,
-		Labels:             types.MapNull(types.StringType),
-		Tags:               types.MapNull(types.StringType),
-	}
-}
-
-// buildModelForWarnTest builds a TFModel with a single replication spec containing a single region config.
-func buildModelForWarnTest(t *testing.T, useEffectiveFields bool, rcParams *regionConfigTestParams) *advancedcluster.TFModel {
-	t.Helper()
-	return buildModel(t, useEffectiveFields, buildRepSpec(t, buildRegionConfig(t, rcParams)))
-}
-
 func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
+	const rc00 = "replication_specs[0].region_configs[0]"
+
 	testCases := map[string]struct {
-		stateRC       regionConfigTestParams
-		planRC        regionConfigTestParams
-		expectWarning bool
+		attributeChanges []string
+		configs          []advancedcluster.RegionAutoScaling
+		expectWarning    bool
 	}{
 		"warns when compute auto-scaling on and electable instance_size changed": {
-			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
-			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"},
-			expectWarning: true,
+			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
+			expectWarning:    true,
 		},
-		"warns when disk auto-scaling on and disk fields changed": {
-			stateRC:       regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10, diskIops: 3000},
-			planRC:        regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20, diskIops: 4000},
-			expectWarning: true,
-		},
-		"warns when analytics compute auto-scaling on and analytics instance_size changed": {
-			stateRC:       regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
-			planRC:        regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
-			expectWarning: true,
-		},
-		"no warning when auto-scaling is disabled": {
-			stateRC:       regionConfigTestParams{electableInstanceSize: "M10"},
-			planRC:        regionConfigTestParams{electableInstanceSize: "M20"},
-			expectWarning: false,
-		},
-		"no warning when auto-scaling is on but no managed spec fields changed": {
-			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
-			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
-			expectWarning: false,
-		},
-		"no warning when auto-scaling is on but only node_count changed": {
-			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", electableNodeCount: 3},
-			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", electableNodeCount: 5},
-			expectWarning: false,
-		},
-		"no warning when only analytics compute auto-scaling on but electable instance_size changed": {
-			stateRC:       regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10"},
-			planRC:        regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M20"},
-			expectWarning: false,
-		},
-		"no warning when analytics disk auto-scaling on but electable disk_size_gb changed": {
-			stateRC:       regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10},
-			planRC:        regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20},
-			expectWarning: false,
-		},
-		"no warning when only electable disk auto-scaling on but analytics disk_size_gb changed": {
-			stateRC:       regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
-			planRC:        regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 20},
-			expectWarning: false,
-		},
-		"no warning when only analytics disk auto-scaling on but electable disk_size_gb changed": {
-			stateRC:       regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
-			planRC:        regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20, analyticsDiskSizeGb: 10},
-			expectWarning: false,
+		"warns when disk auto-scaling on and electable disk fields changed": {
+			attributeChanges: []string{rc00 + ".electable_specs.disk_size_gb", rc00 + ".electable_specs.disk_iops"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, DiskGBEnabled: true}},
+			expectWarning:    true,
 		},
 		"warns when compute auto-scaling on and electable disk_size_gb changed": {
-			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
-			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20},
-			expectWarning: true,
-		},
-		"no warning when analytics compute auto-scaling on and analytics disk_size_gb changed": {
-			stateRC:       regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 10},
-			planRC:        regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 20},
-			expectWarning: false,
+			attributeChanges: []string{rc00 + ".electable_specs.disk_size_gb"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
+			expectWarning:    true,
 		},
 		"warns when disk auto-scaling on and electable instance_size changed": {
-			stateRC:       regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
-			planRC:        regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M20", diskSizeGb: 10},
-			expectWarning: true,
+			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, DiskGBEnabled: true}},
+			expectWarning:    true,
 		},
 		"warns when compute auto-scaling on and read_only instance_size changed": {
-			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", readOnlyInstanceSize: "M10"},
-			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", readOnlyInstanceSize: "M20"},
-			expectWarning: true,
+			attributeChanges: []string{rc00 + ".read_only_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
+			expectWarning:    true,
 		},
-		"no warning when only analytics disk auto-scaling on and analytics instance_size changed": {
-			stateRC:       regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
-			planRC:        regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
-			expectWarning: false,
+		"warns when analytics compute auto-scaling on and analytics instance_size changed": {
+			attributeChanges: []string{rc00 + ".analytics_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, AnalyticsComputeEnabled: true}},
+			expectWarning:    true,
+		},
+		"no warning when auto-scaling is disabled": {
+			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00}},
+			expectWarning:    false,
+		},
+		"no warning when auto-scaling is on but no managed spec fields changed": {
+			attributeChanges: nil,
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
+			expectWarning:    false,
+		},
+		"no warning when auto-scaling is on but only node_count changed": {
+			attributeChanges: []string{rc00 + ".electable_specs.node_count"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
+			expectWarning:    false,
+		},
+		"no warning when only analytics compute auto-scaling on but electable instance_size changed": {
+			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, AnalyticsComputeEnabled: true}},
+			expectWarning:    false,
+		},
+		"no warning when only electable auto-scaling on but analytics instance_size changed": {
+			attributeChanges: []string{rc00 + ".analytics_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
+			expectWarning:    false,
+		},
+		"no warning when only electable auto-scaling on but analytics disk_size_gb changed": {
+			attributeChanges: []string{rc00 + ".analytics_specs.disk_size_gb"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, DiskGBEnabled: true}},
+			expectWarning:    false,
+		},
+		"no warning when analytics compute auto-scaling on and analytics disk_size_gb changed": {
+			attributeChanges: []string{rc00 + ".analytics_specs.disk_size_gb"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, AnalyticsComputeEnabled: true}},
+			expectWarning:    false,
+		},
+		"no warning when analytics instance_size changed without analytics compute auto-scaling": {
+			// Confirmed via repro: analytics disk_gb_enabled alone does not cause Atlas to ignore instance_size.
+			attributeChanges: []string{rc00 + ".analytics_specs.instance_size"},
+			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00}},
+			expectWarning:    false,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
-			state := buildModelForWarnTest(t, true, &tc.stateRC)
-			plan := buildModelForWarnTest(t, true, &tc.planRC)
-			attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 			var diags diag.Diagnostics
-
-			advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
-
+			advancedcluster.WarnIgnoredSpecChange(&diags, true, tc.attributeChanges, tc.configs)
 			assert.False(t, diags.HasError())
 			if tc.expectWarning {
 				assert.Equal(t, 1, diags.WarningsCount())
@@ -326,39 +180,9 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 	}
 
 	t.Run("no warning when use_effective_fields is false", func(t *testing.T) {
-		ctx := context.Background()
-		state := buildModelForWarnTest(t, false, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		plan := buildModelForWarnTest(t, false, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
-		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 		var diags diag.Diagnostics
-		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
-		assert.False(t, diags.HasError())
-		assert.Equal(t, 0, diags.WarningsCount())
-	})
-
-	// List length changes: new entries added in plan have no state counterpart, so attributeChanges marks them as added and skips them.
-	t.Run("no warning when replication_specs list length changes", func(t *testing.T) {
-		ctx := context.Background()
-		rc1 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		rc2 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
-		state := buildModel(t, true, buildRepSpec(t, rc1))
-		plan := buildModel(t, true, buildRepSpec(t, rc1), buildRepSpec(t, rc2))
-		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
-		var diags diag.Diagnostics
-		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
-		assert.False(t, diags.HasError())
-		assert.Equal(t, 0, diags.WarningsCount())
-	})
-
-	t.Run("no warning when region_configs list length changes", func(t *testing.T) {
-		ctx := context.Background()
-		rc1 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		rc2 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
-		state := buildModel(t, true, buildRepSpec(t, rc1))
-		plan := buildModel(t, true, buildRepSpec(t, rc1, rc2))
-		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
-		var diags diag.Diagnostics
-		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
+		configs := []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}}
+		advancedcluster.WarnIgnoredSpecChange(&diags, false, []string{rc00 + ".electable_specs.instance_size"}, configs)
 		assert.False(t, diags.HasError())
 		assert.Equal(t, 0, diags.WarningsCount())
 	})

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -298,10 +298,10 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", readOnlyInstanceSize: "M20"},
 			expectWarning: true,
 		},
-		"warns when analytics disk auto-scaling on and analytics instance_size changed": {
+		"no warning when only analytics disk auto-scaling on and analytics instance_size changed": {
 			stateRC:       regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
 			planRC:        regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
-			expectWarning: true,
+			expectWarning: false,
 		},
 	}
 

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -125,10 +125,12 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 }
 
 type regionConfigTestParams struct {
-	electableInstanceSize   string  // empty = null electable_specs
-	analyticsInstanceSize   string  // empty = null analytics_specs
-	diskSizeGb              float64 // applied to both electable and analytics specs unless analyticsDiskSizeGb is set
-	analyticsDiskSizeGb     float64 // when non-zero, overrides diskSizeGb for analytics_specs
+	electableInstanceSize   string
+	analyticsInstanceSize   string
+	readOnlyInstanceSize    string
+	diskSizeGb              float64
+	analyticsDiskSizeGb     float64
+	readOnlyDiskSizeGb      float64
 	diskIops                int64
 	computeEnabled          bool
 	analyticsComputeEnabled bool
@@ -165,18 +167,22 @@ func buildSpecs(t *testing.T, instanceSize string, nodeCount int64, diskSizeGb f
 	return obj
 }
 
-func buildRegionConfig(t *testing.T, rcParams regionConfigTestParams) advancedcluster.TFRegionConfigsModel {
+func buildRegionConfig(t *testing.T, rcParams *regionConfigTestParams) advancedcluster.TFRegionConfigsModel {
 	t.Helper()
 	analyticsDiskSizeGb := rcParams.diskSizeGb
 	if rcParams.analyticsDiskSizeGb != 0 {
 		analyticsDiskSizeGb = rcParams.analyticsDiskSizeGb
+	}
+	readOnlyDiskSizeGb := rcParams.diskSizeGb
+	if rcParams.readOnlyDiskSizeGb != 0 {
+		readOnlyDiskSizeGb = rcParams.readOnlyDiskSizeGb
 	}
 	return advancedcluster.TFRegionConfigsModel{
 		AutoScaling:          buildAutoScaling(t, rcParams.computeEnabled, rcParams.diskGBEnabled),
 		AnalyticsAutoScaling: buildAutoScaling(t, rcParams.analyticsComputeEnabled, rcParams.analyticsDiskGBEnabled),
 		ElectableSpecs:       buildSpecs(t, rcParams.electableInstanceSize, 3, rcParams.diskSizeGb, rcParams.diskIops),
 		AnalyticsSpecs:       buildSpecs(t, rcParams.analyticsInstanceSize, 1, analyticsDiskSizeGb, rcParams.diskIops),
-		ReadOnlySpecs:        types.ObjectNull(specsAttrTypes),
+		ReadOnlySpecs:        buildSpecs(t, rcParams.readOnlyInstanceSize, 2, readOnlyDiskSizeGb, rcParams.diskIops),
 		ProviderName:         types.StringValue("AWS"),
 		RegionName:           types.StringValue("US_EAST_1"),
 		Priority:             types.Int64Value(7),
@@ -210,117 +216,94 @@ func buildModel(t *testing.T, useEffectiveFields bool, repSpecs ...advancedclust
 }
 
 // buildModelForWarnTest builds a TFModel with a single replication spec containing a single region config.
-func buildModelForWarnTest(t *testing.T, useEffectiveFields bool, rcParams regionConfigTestParams) *advancedcluster.TFModel {
+func buildModelForWarnTest(t *testing.T, useEffectiveFields bool, rcParams *regionConfigTestParams) *advancedcluster.TFModel {
 	t.Helper()
 	return buildModel(t, useEffectiveFields, buildRepSpec(t, buildRegionConfig(t, rcParams)))
 }
 
 func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
-	testCases := []struct {
-		name               string
-		stateRC            regionConfigTestParams
-		planRC             regionConfigTestParams
-		useEffectiveFields bool
-		expectWarning      bool
+	testCases := map[string]struct {
+		stateRC       regionConfigTestParams
+		planRC        regionConfigTestParams
+		expectWarning bool
 	}{
-		{
-			name:               "warns when compute auto-scaling on and electable instance_size changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
-			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"},
-			expectWarning:      true,
+		"warns when compute auto-scaling on and electable instance_size changed": {
+			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
+			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"},
+			expectWarning: true,
 		},
-		{
-			name:               "warns when disk auto-scaling on and disk fields changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10, diskIops: 3000},
-			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20, diskIops: 4000},
-			expectWarning:      true,
+		"warns when disk auto-scaling on and disk fields changed": {
+			stateRC:       regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10, diskIops: 3000},
+			planRC:        regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20, diskIops: 4000},
+			expectWarning: true,
 		},
-		{
-			name:               "warns when analytics compute auto-scaling on and analytics instance_size changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
-			planRC:             regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
-			expectWarning:      true,
+		"warns when analytics compute auto-scaling on and analytics instance_size changed": {
+			stateRC:       regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
+			planRC:        regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
+			expectWarning: true,
 		},
-		{
-			name:               "no warning when use_effective_fields is false",
-			useEffectiveFields: false,
-			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
-			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"},
-			expectWarning:      false,
+		"no warning when auto-scaling is disabled": {
+			stateRC:       regionConfigTestParams{electableInstanceSize: "M10"},
+			planRC:        regionConfigTestParams{electableInstanceSize: "M20"},
+			expectWarning: false,
 		},
-		{
-			name:               "no warning when auto-scaling is disabled",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{electableInstanceSize: "M10"},
-			planRC:             regionConfigTestParams{electableInstanceSize: "M20"},
-			expectWarning:      false,
+		"no warning when auto-scaling is on but no managed spec fields changed": {
+			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
+			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
+			expectWarning: false,
 		},
-		{
-			name:               "no warning when auto-scaling is on but no managed spec fields changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
-			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
-			expectWarning:      false,
+		"no warning when only analytics compute auto-scaling on but electable instance_size changed": {
+			stateRC:       regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10"},
+			planRC:        regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M20"},
+			expectWarning: false,
 		},
-		{
-			name:               "no warning when only analytics compute auto-scaling on but electable instance_size changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10"},
-			planRC:             regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M20"},
-			expectWarning:      false,
+		"no warning when analytics disk auto-scaling on but electable disk_size_gb changed": {
+			stateRC:       regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10},
+			planRC:        regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20},
+			expectWarning: false,
 		},
-		{
-			name:               "no warning when analytics disk auto-scaling on but electable disk_size_gb changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10},
-			planRC:             regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20},
-			expectWarning:      false,
+		"no warning when only electable disk auto-scaling on but analytics disk_size_gb changed": {
+			stateRC:       regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
+			planRC:        regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 20},
+			expectWarning: false,
 		},
-		{
-			name:               "no warning when only electable disk auto-scaling on but analytics disk_size_gb changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
-			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 20},
-			expectWarning:      false,
+		"no warning when only analytics disk auto-scaling on but electable disk_size_gb changed": {
+			stateRC:       regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
+			planRC:        regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20, analyticsDiskSizeGb: 10},
+			expectWarning: false,
 		},
-		{
-			name:               "no warning when only analytics disk auto-scaling on but electable disk_size_gb changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
-			planRC:             regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20, analyticsDiskSizeGb: 10},
-			expectWarning:      false,
+		"warns when compute auto-scaling on and electable disk_size_gb changed": {
+			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
+			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20},
+			expectWarning: true,
 		},
-		{
-			name:               "warns when compute auto-scaling on and electable disk_size_gb changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
-			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20},
-			expectWarning:      true, // compute_enabled also causes Atlas to ignore disk changes
+		"no warning when analytics compute auto-scaling on and analytics disk_size_gb changed": {
+			stateRC:       regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 10},
+			planRC:        regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 20},
+			expectWarning: false,
 		},
-		{
-			name:               "no warning when analytics compute auto-scaling on and analytics disk_size_gb changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 10},
-			planRC:             regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 20},
-			expectWarning:      false, // docs: analytics auto-scaling only ignores instanceSize, not disk fields
+		"warns when disk auto-scaling on and electable instance_size changed": {
+			stateRC:       regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
+			planRC:        regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M20", diskSizeGb: 10},
+			expectWarning: true,
 		},
-		{
-			name:               "warns when disk auto-scaling on and electable instance_size changed",
-			useEffectiveFields: true,
-			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
-			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M20", diskSizeGb: 10},
-			expectWarning:      true, // docs: compute OR disk auto-scaling causes all three fields to be ignored for electable/read-only
+		"warns when compute auto-scaling on and read_only instance_size changed": {
+			stateRC:       regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", readOnlyInstanceSize: "M10"},
+			planRC:        regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", readOnlyInstanceSize: "M20"},
+			expectWarning: true,
+		},
+		"warns when analytics disk auto-scaling on and analytics instance_size changed": {
+			stateRC:       regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
+			planRC:        regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
+			expectWarning: true,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			state := buildModelForWarnTest(t, tc.useEffectiveFields, tc.stateRC)
-			plan := buildModelForWarnTest(t, tc.useEffectiveFields, tc.planRC)
+			state := buildModelForWarnTest(t, true, &tc.stateRC)
+			plan := buildModelForWarnTest(t, true, &tc.planRC)
 			attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 			var diags diag.Diagnostics
 
@@ -336,11 +319,22 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 		})
 	}
 
+	t.Run("no warning when use_effective_fields is false", func(t *testing.T) {
+		ctx := context.Background()
+		state := buildModelForWarnTest(t, false, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		plan := buildModelForWarnTest(t, false, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
+		var diags diag.Diagnostics
+		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
+		assert.False(t, diags.HasError())
+		assert.Equal(t, 0, diags.WarningsCount())
+	})
+
 	// List length changes: new entries added in plan have no state counterpart, so attributeChanges marks them as added and skips them.
 	t.Run("no warning when replication_specs list length changes", func(t *testing.T) {
 		ctx := context.Background()
-		rc1 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		rc2 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		rc1 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		rc2 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
 		state := buildModel(t, true, buildRepSpec(t, rc1))
 		plan := buildModel(t, true, buildRepSpec(t, rc1), buildRepSpec(t, rc2))
 		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
@@ -352,8 +346,8 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 
 	t.Run("no warning when region_configs list length changes", func(t *testing.T) {
 		ctx := context.Background()
-		rc1 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
-		rc2 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		rc1 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		rc2 := buildRegionConfig(t, &regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
 		state := buildModel(t, true, buildRepSpec(t, rc1))
 		plan := buildModel(t, true, buildRepSpec(t, rc1, rc2))
 		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -272,18 +272,18 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			expectWarning:      false,
 		},
 		{
-			name:               "warns when analytics disk auto-scaling on and analytics disk fields changed",
+			name:               "no warning when analytics disk auto-scaling on but electable disk_size_gb changed",
 			useEffectiveFields: true,
 			stateRC:            regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10},
 			planRC:             regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20},
-			expectWarning:      true,
+			expectWarning:      false,
 		},
 		{
 			name:               "no warning when only electable disk auto-scaling on but analytics disk_size_gb changed",
 			useEffectiveFields: true,
 			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
 			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 20},
-			expectWarning:      false, // auto_scaling.disk_gb_enabled only governs electable/read_only disk
+			expectWarning:      false,
 		},
 		{
 			name:               "no warning when only analytics disk auto-scaling on but electable disk_size_gb changed",
@@ -291,6 +291,27 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			stateRC:            regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 10, analyticsDiskSizeGb: 10},
 			planRC:             regionConfigTestParams{analyticsDiskGBEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", diskSizeGb: 20, analyticsDiskSizeGb: 10},
 			expectWarning:      false,
+		},
+		{
+			name:               "warns when compute auto-scaling on and electable disk_size_gb changed",
+			useEffectiveFields: true,
+			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
+			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20},
+			expectWarning:      true, // compute_enabled also causes Atlas to ignore disk changes
+		},
+		{
+			name:               "no warning when analytics compute auto-scaling on and analytics disk_size_gb changed",
+			useEffectiveFields: true,
+			stateRC:            regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 10},
+			planRC:             regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10", analyticsDiskSizeGb: 20},
+			expectWarning:      false, // docs: analytics auto-scaling only ignores instanceSize, not disk fields
+		},
+		{
+			name:               "warns when disk auto-scaling on and electable instance_size changed",
+			useEffectiveFields: true,
+			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
+			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M20", diskSizeGb: 10},
+			expectWarning:      true, // docs: compute OR disk auto-scaling causes all three fields to be ignored for electable/read-only
 		},
 	}
 

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -13,14 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
 )
 
-// Attr type maps mirrors the unexported vars in schema.go to avoid uppercasing them.
-// They are redeclared here because this package is advancedcluster_test and cannot access package-private symbols.
-// Done in order to be able to add unit tests for WarnIgnoredSpecChange function, as they allow to test the function without depending on acceptance tests
 var (
 	autoScalingAttrTypes = map[string]attr.Type{
 		"compute_enabled":            types.BoolType,
@@ -127,24 +123,66 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 	}
 }
 
-func buildPlanWithAutoScaling(t *testing.T, useEffectiveFields, computeEnabled, diskGBEnabled bool) *advancedcluster.TFModel {
+type regionConfigTestParams struct {
+	electableInstanceSize   string // empty = null analytics_specs
+	analyticsInstanceSize   string
+	diskSizeGb              float64
+	diskIops                int64
+	computeEnabled          bool
+	analyticsComputeEnabled bool
+	diskGBEnabled           bool
+}
+
+func buildModelForWarnTest(t *testing.T, useEffectiveFields bool, rcParams regionConfigTestParams) *advancedcluster.TFModel {
 	t.Helper()
 	ctx := context.Background()
 
 	autoScaling, diags := types.ObjectValueFrom(ctx, autoScalingAttrTypes, advancedcluster.TFAutoScalingModel{
-		ComputeEnabled:          types.BoolValue(computeEnabled),
-		DiskGBEnabled:           types.BoolValue(diskGBEnabled),
+		ComputeEnabled:          types.BoolValue(rcParams.computeEnabled),
+		DiskGBEnabled:           types.BoolValue(rcParams.diskGBEnabled),
 		ComputeScaleDownEnabled: types.BoolValue(false),
 		ComputeMinInstanceSize:  types.StringValue("M10"),
 		ComputeMaxInstanceSize:  types.StringValue("M40"),
 	})
 	require.Empty(t, diags)
 
+	analyticsAutoScaling, diags := types.ObjectValueFrom(ctx, autoScalingAttrTypes, advancedcluster.TFAutoScalingModel{
+		ComputeEnabled:          types.BoolValue(rcParams.analyticsComputeEnabled),
+		DiskGBEnabled:           types.BoolValue(false),
+		ComputeScaleDownEnabled: types.BoolValue(false),
+		ComputeMinInstanceSize:  types.StringValue("M10"),
+		ComputeMaxInstanceSize:  types.StringValue("M40"),
+	})
+	require.Empty(t, diags)
+
+	electableSpecs, diags := types.ObjectValueFrom(ctx, specsAttrTypes, advancedcluster.TFSpecsModel{
+		InstanceSize:  types.StringValue(rcParams.electableInstanceSize),
+		NodeCount:     types.Int64Value(3),
+		DiskSizeGb:    types.Float64Value(rcParams.diskSizeGb),
+		DiskIops:      types.Int64Value(rcParams.diskIops),
+		EbsVolumeType: types.StringNull(),
+	})
+	require.Empty(t, diags)
+
+	var analyticsSpecs types.Object
+	if rcParams.analyticsInstanceSize != "" {
+		analyticsSpecs, diags = types.ObjectValueFrom(ctx, specsAttrTypes, advancedcluster.TFSpecsModel{
+			InstanceSize:  types.StringValue(rcParams.analyticsInstanceSize),
+			NodeCount:     types.Int64Value(1),
+			DiskSizeGb:    types.Float64Value(rcParams.diskSizeGb),
+			DiskIops:      types.Int64Value(rcParams.diskIops),
+			EbsVolumeType: types.StringNull(),
+		})
+		require.Empty(t, diags)
+	} else {
+		analyticsSpecs = types.ObjectNull(specsAttrTypes)
+	}
+
 	regionConfig := advancedcluster.TFRegionConfigsModel{
 		AutoScaling:          autoScaling,
-		AnalyticsAutoScaling: types.ObjectNull(autoScalingAttrTypes),
-		AnalyticsSpecs:       types.ObjectNull(specsAttrTypes),
-		ElectableSpecs:       types.ObjectNull(specsAttrTypes),
+		AnalyticsAutoScaling: analyticsAutoScaling,
+		AnalyticsSpecs:       analyticsSpecs,
+		ElectableSpecs:       electableSpecs,
 		ReadOnlySpecs:        types.ObjectNull(specsAttrTypes),
 		ProviderName:         types.StringValue("AWS"),
 		RegionName:           types.StringValue("US_EAST_1"),
@@ -175,67 +213,72 @@ func buildPlanWithAutoScaling(t *testing.T, useEffectiveFields, computeEnabled, 
 func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 	testCases := []struct {
 		name               string
-		changedFields      schemafunc.AttributeChanges
+		stateRC            regionConfigTestParams
+		planRC             regionConfigTestParams
 		useEffectiveFields bool
-		computeEnabled     bool
-		diskGBEnabled      bool
 		expectWarning      bool
 	}{
 		{
-			name:               "warns when compute auto-scaling on and instance_size changed",
+			name:               "warns when compute auto-scaling on and electable instance_size changed",
 			useEffectiveFields: true,
-			computeEnabled:     true,
-			changedFields:      schemafunc.AttributeChanges{"instance_size"},
+			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
+			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"},
 			expectWarning:      true,
 		},
 		{
 			name:               "warns when disk auto-scaling on and disk_size_gb changed",
 			useEffectiveFields: true,
-			diskGBEnabled:      true,
-			changedFields:      schemafunc.AttributeChanges{"disk_size_gb"},
+			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 10},
+			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskSizeGb: 20},
 			expectWarning:      true,
 		},
 		{
-			name:               "warns when compute auto-scaling on and disk_iops changed",
+			name:               "warns when disk auto-scaling on and disk_iops changed",
 			useEffectiveFields: true,
-			computeEnabled:     true,
-			changedFields:      schemafunc.AttributeChanges{"disk_iops"},
+			stateRC:            regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskIops: 3000},
+			planRC:             regionConfigTestParams{diskGBEnabled: true, electableInstanceSize: "M10", diskIops: 4000},
+			expectWarning:      true,
+		},
+		{
+			name:               "warns when analytics compute auto-scaling on and analytics instance_size changed",
+			useEffectiveFields: true,
+			stateRC:            regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
+			planRC:             regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
 			expectWarning:      true,
 		},
 		{
 			name:               "no warning when use_effective_fields is false",
 			useEffectiveFields: false,
-			computeEnabled:     true,
-			changedFields:      schemafunc.AttributeChanges{"instance_size"},
+			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
+			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"},
 			expectWarning:      false,
 		},
 		{
 			name:               "no warning when auto-scaling is disabled",
 			useEffectiveFields: true,
-			computeEnabled:     false,
-			diskGBEnabled:      false,
-			changedFields:      schemafunc.AttributeChanges{"instance_size"},
+			stateRC:            regionConfigTestParams{electableInstanceSize: "M10"},
+			planRC:             regionConfigTestParams{electableInstanceSize: "M20"},
 			expectWarning:      false,
 		},
 		{
 			name:               "no warning when auto-scaling is on but no managed spec fields changed",
 			useEffectiveFields: true,
-			computeEnabled:     true,
-			changedFields:      schemafunc.AttributeChanges{"node_count"},
+			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
+			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"},
 			expectWarning:      false,
 		},
 		{
-			name:               "no warning when replication_specs list length changes (avoid false positive on new spec)",
+			name:               "no warning when only analytics compute auto-scaling on but electable instance_size changed",
 			useEffectiveFields: true,
-			computeEnabled:     true,
-			changedFields:      schemafunc.AttributeChanges{"replication_specs[+1]", "replication_specs[1].region_configs[0].instance_size", "instance_size"},
+			stateRC:            regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M10"},
+			planRC:             regionConfigTestParams{analyticsComputeEnabled: true, electableInstanceSize: "M20"},
 			expectWarning:      false,
 		},
 		{
-			name:               "no warning when region_configs list length changes (avoid false positive on new region config)",
+			name:               "no warning when only compute auto-scaling on but analytics instance_size changed",
 			useEffectiveFields: true,
-			computeEnabled:     true,
-			changedFields:      schemafunc.AttributeChanges{"replication_specs[0].region_configs[+1]", "replication_specs[0].region_configs[1].instance_size", "instance_size"},
+			stateRC:            regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M10"},
+			planRC:             regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10", analyticsInstanceSize: "M20"},
 			expectWarning:      false,
 		},
 	}
@@ -243,10 +286,11 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			plan := buildPlanWithAutoScaling(t, tc.useEffectiveFields, tc.computeEnabled, tc.diskGBEnabled)
+			state := buildModelForWarnTest(t, tc.useEffectiveFields, tc.stateRC)
+			plan := buildModelForWarnTest(t, tc.useEffectiveFields, tc.planRC)
 			var diags diag.Diagnostics
 
-			advancedcluster.WarnIgnoredSpecChange(ctx, &diags, plan, tc.changedFields)
+			advancedcluster.WarnIgnoredSpecChange(ctx, &diags, state, plan)
 
 			assert.False(t, diags.HasError())
 			if tc.expectWarning {
@@ -256,4 +300,84 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			}
 		})
 	}
+
+	// List length changes: new specs/region_configs added in plan have no state counterpart,
+	// so minLen iteration naturally skips them — no false positive warning.
+	t.Run("no warning when replication_specs list length changes", func(t *testing.T) {
+		ctx := context.Background()
+		state := buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		// plan has 2 rep specs; first is unchanged, second is new (no state counterpart)
+		plan := addExtraRepSpec(t, buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"}),
+			regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		var diags diag.Diagnostics
+		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, state, plan)
+		assert.False(t, diags.HasError())
+		assert.Equal(t, 0, diags.WarningsCount())
+	})
+
+	t.Run("no warning when region_configs list length changes", func(t *testing.T) {
+		ctx := context.Background()
+		state := buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
+		// plan has 2 region configs; first is unchanged, second is new (no state counterpart)
+		plan := addExtraRegionConfig(t, buildModelForWarnTest(t, true, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"}),
+			regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
+		var diags diag.Diagnostics
+		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, state, plan)
+		assert.False(t, diags.HasError())
+		assert.Equal(t, 0, diags.WarningsCount())
+	})
+}
+
+// addExtraRepSpec appends a new replication spec to the model's ReplicationSpecs list.
+func addExtraRepSpec(t *testing.T, model *advancedcluster.TFModel, rcParams regionConfigTestParams) *advancedcluster.TFModel {
+	t.Helper()
+	extra := buildModelForWarnTest(t, model.UseEffectiveFields.ValueBool(), rcParams)
+	ctx := context.Background()
+
+	existing := make([]advancedcluster.TFReplicationSpecsModel, 0)
+	diags := model.ReplicationSpecs.ElementsAs(ctx, &existing, false)
+	require.Empty(t, diags)
+
+	extra1 := make([]advancedcluster.TFReplicationSpecsModel, 0)
+	diags = extra.ReplicationSpecs.ElementsAs(ctx, &extra1, false)
+	require.Empty(t, diags)
+
+	combined, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: replicationSpecAttrTypes}, append(existing, extra1...))
+	require.Empty(t, diags)
+
+	model.ReplicationSpecs = combined
+	return model
+}
+
+// addExtraRegionConfig appends a new region config to the first replication spec of the model.
+func addExtraRegionConfig(t *testing.T, model *advancedcluster.TFModel, rcParams regionConfigTestParams) *advancedcluster.TFModel {
+	t.Helper()
+	extra := buildModelForWarnTest(t, model.UseEffectiveFields.ValueBool(), rcParams)
+	ctx := context.Background()
+
+	repSpecs := make([]advancedcluster.TFReplicationSpecsModel, 0)
+	diags := model.ReplicationSpecs.ElementsAs(ctx, &repSpecs, false)
+	require.Empty(t, diags)
+
+	existingRCs := make([]advancedcluster.TFRegionConfigsModel, 0)
+	diags = repSpecs[0].RegionConfigs.ElementsAs(ctx, &existingRCs, false)
+	require.Empty(t, diags)
+
+	extraRepSpecs := make([]advancedcluster.TFReplicationSpecsModel, 0)
+	diags = extra.ReplicationSpecs.ElementsAs(ctx, &extraRepSpecs, false)
+	require.Empty(t, diags)
+
+	extraRCs := make([]advancedcluster.TFRegionConfigsModel, 0)
+	diags = extraRepSpecs[0].RegionConfigs.ElementsAs(ctx, &extraRCs, false)
+	require.Empty(t, diags)
+
+	combined, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: regionConfigAttrTypes}, append(existingRCs, extraRCs...))
+	require.Empty(t, diags)
+
+	repSpecs[0].RegionConfigs = combined
+	repSpecsList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: replicationSpecAttrTypes}, repSpecs)
+	require.Empty(t, diags)
+
+	model.ReplicationSpecs = repSpecsList
+	return model
 }

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
 )
@@ -320,9 +321,10 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 			ctx := context.Background()
 			state := buildModelForWarnTest(t, tc.useEffectiveFields, tc.stateRC)
 			plan := buildModelForWarnTest(t, tc.useEffectiveFields, tc.planRC)
+			attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 			var diags diag.Diagnostics
 
-			advancedcluster.WarnIgnoredSpecChange(ctx, &diags, state, plan)
+			advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
 
 			assert.False(t, diags.HasError())
 			if tc.expectWarning {
@@ -334,25 +336,29 @@ func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
 		})
 	}
 
-	// List length changes: new entries added in plan have no state counterpart, so minLen iteration skips them.
+	// List length changes: new entries added in plan have no state counterpart, so attributeChanges marks them as added and skips them.
 	t.Run("no warning when replication_specs list length changes", func(t *testing.T) {
+		ctx := context.Background()
 		rc1 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
 		rc2 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
 		state := buildModel(t, true, buildRepSpec(t, rc1))
 		plan := buildModel(t, true, buildRepSpec(t, rc1), buildRepSpec(t, rc2))
+		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 		var diags diag.Diagnostics
-		advancedcluster.WarnIgnoredSpecChange(context.Background(), &diags, state, plan)
+		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
 		assert.False(t, diags.HasError())
 		assert.Equal(t, 0, diags.WarningsCount())
 	})
 
 	t.Run("no warning when region_configs list length changes", func(t *testing.T) {
+		ctx := context.Background()
 		rc1 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M10"})
 		rc2 := buildRegionConfig(t, regionConfigTestParams{computeEnabled: true, electableInstanceSize: "M20"})
 		state := buildModel(t, true, buildRepSpec(t, rc1))
 		plan := buildModel(t, true, buildRepSpec(t, rc1, rc2))
+		attributeChanges := schemafunc.NewAttributeChanges(ctx, state, plan)
 		var diags diag.Diagnostics
-		advancedcluster.WarnIgnoredSpecChange(context.Background(), &diags, state, plan)
+		advancedcluster.WarnIgnoredSpecChange(ctx, &diags, attributeChanges, plan)
 		assert.False(t, diags.HasError())
 		assert.Equal(t, 0, diags.WarningsCount())
 	})


### PR DESCRIPTION
## Description

Emits a Terraform warning during `ModifyPlan` when all three conditions are met:
- `use_effective_fields = true`
- Auto-scaling is enabled in the config (`compute_enabled = true` or `disk_gb_enabled = true`)
- The user changes the following fields: `instance_size`, `disk_size_gb`, or `disk_iops`

In this combination, the Atlas API silently ignores the spec change, the new values are stored in Terraform state but the cluster is never modified, producing a false "1 changed" result with no feedback. The warning makes this visible and directs the user to temporarily disable auto-scaling to apply the change.

Per the [Atlas auto-scaling docs](https://www.mongodb.com/docs/atlas/cluster-autoscaling/), the fields ignored depend on the tier:

| Tier | Auto-scaling active | Fields ignored by Atlas |
|---|---|---|
| electable / read-only | compute OR disk enabled | `instance_size`, `disk_size_gb`, `disk_iops` |
| analytics | compute enabled | `instance_size` only |

Note: for analytics nodes, `disk_gb_enabled` alone does not cause Atlas to ignore `instance_size` — confirmed via live repro against the Atlas API.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-388940

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Testing

The warning itself cannot be asserted programmatically. The Terraform Testing framework has no mechanism to assert warnings. The code path is exercised by the existing `TestAccAdvancedCluster_effectiveComputeAutoScalingInstanceSize`, where any code regressions would be caught. Unit tests in `plan_modifier_test.go` cover all per-tier combinations from the docs table above. Manual validation has been done to ensure the warning surfaces according to the acceptance criteria:

1. `use_effective_fields` = true
2. Any form of auto-scaling is enabled (`compute_enabled = true` or `disk_gb_enabled = true`)
3. A change is detected in `instance_size`, `disk_size_gb`, or `disk_iops`


Baseline config:
```hcl
resource "mongodbatlas_advanced_cluster" "test" {
  project_id   = var.project_id
  name         = var.cluster_name
  cluster_type = "REPLICASET"

  use_effective_fields = true

  replication_specs = [{
    region_configs = [{
      provider_name = "AWS"
      region_name   = "EU_WEST_1"
      priority      = 7

      electable_specs = {
        node_count    = 3
        instance_size = "M10"
        disk_size_gb  = 10
      }

      auto_scaling = {
        compute_enabled            = true
        compute_scale_down_enabled = true
        compute_min_instance_size  = "M10"
        compute_max_instance_size  = "M40"
        disk_gb_enabled            = false
      }
    }]
  }]

  backup_enabled                 = false
  termination_protection_enabled = false
}
```

| # | Scenario | Warning message | Result |
|---|----------|-----------------|--------|
| 1 | Create cluster with `instance_size = "M10"` and auto-scaling enabled | No warning | ✅ |
| 2 | Change `instance_size` M10 → M20 (auto-scaling **on**) | `The change to instance_size will be stored in Terraform state but will not modify the actual cluster in Atlas.` | ✅ |
| 3 | Change `disk_size_gb` 10 → 20 (auto-scaling **on**) | `The change to disk_size_gb will be stored in Terraform state but will not modify the actual cluster in Atlas.` | ✅ |
| 4 | Change `disk_iops` 3000 → 4000 (auto-scaling **on**) | `The change to disk_iops will be stored in Terraform state but will not modify the actual cluster in Atlas.` | ✅ |
| 5 | Disable auto-scaling and change `instance_size` (auto-scaling **off**) | No warning | ✅ |
| 6 | Disable `use_effective_fields` and change `instance_size` M10 → M20 | No warning, change applied successfully in Atlas | ✅ |

<details>
<summary>Full warning message (case 2)</summary>

```
│ Warning: Spec change ignored due to auto-scaling
│ 
│   with mongodbatlas_advanced_cluster.test,
│   on main.tf line 14, in resource "mongodbatlas_advanced_cluster" "test":
│   14: resource "mongodbatlas_advanced_cluster" "test" {
│ 
│ The change to instance_size will be stored in Terraform state but will not
│ modify the actual cluster in Atlas. When use_effective_fields is true and
│ auto-scaling is enabled, Atlas controls instance_size, disk_size_gb, and
│ disk_iops values. To apply this change, temporarily disable auto-scaling.
│ See: https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster#manually-updating-specs-with-use_effective_fields
```

</details>

## Further comments