### PR TITLE
chore: Expand bot project prefixes to cover all CFN tests

### DIFF
--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -32,7 +32,8 @@ const (
 
 var (
 	botProjectPrefixes = []string{
-		"cfn-test-bot-",
+		"cfn-", // general CFN tests
+		"ct-",  // CFN contract tests
 		"test-acc-tf-p-",
 	}
 	// keptPrefixes has the prefix of the projects that we want to delete their resources but keep the projects themselves.


### PR DESCRIPTION
## Description

Adds `cfn-` and `ct-` to the `botProjectPrefixes` list in the Atlas org cleanup test so that all projects created by CloudFormation resource tests are included in the daily cleanup run.

- Previously only `cfn-test-bot-` was covered. CFN e2e tests use `cfn-e2e-*` and contract tests use `ct-*` (e.g., `ct-online-archive-*`, `ct-cloud-backup-restore-jobs-*`), so most CFN-created projects were skipped with "reason: not bot project". Example failing run: https://github.com/mongodb/mongodbatlas-cloudformation-resources/actions/runs/25045739713/job/73360214392
- Prefixes will be able to be narrowed after CLOUDP-299242 is done

Link to any related issue(s): CLOUDP-400605

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments