### PR TITLE
chore: Filter out deletions in pre-commit staged Go files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-STAGED_GO_FILES=$(git diff --cached --name-only | grep '\.go$' | tr '\n' ' ' || true)
+STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.go$' | tr '\n' ' ' || true)
 
 if [[ -n "${STAGED_GO_FILES}" ]]; then
     make verify files="${STAGED_GO_FILES}"


### PR DESCRIPTION
## Description

Filter staged deletions out of the pre-commit's `STAGED_GO_FILES` so deleted paths don't end up in `make verify files=...`.

Today a staged `git rm foo.go` doesn't fail the commit (gofmt errors go to stderr, the recipe captures stdout) but it does make the hook silently run `golangci-lint` / `go fix -diff` against a wider scope than intended. `--diff-filter=ACMR` drops deletions so the hook either runs against real paths or skips `make verify` entirely.

Caught by augmentcode while reviewing CFN PR [mongodb/mongodbatlas-cloudformation-resources#1645](https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/1645), which mirrored this repo's pre-commit.

```diff
-STAGED_GO_FILES=$(git diff --cached --name-only | grep '\.go$' | tr '\n' ' ' || true)
+STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.go$' | tr '\n' ' ' || true)
```

The `.tf` block is unaffected (`make tflint` ignores `files=`).

Link to any related issue(s): CLOUDP-386713

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
