### PR TITLE
chore: Revert hc-install workaround and use terraform from PATH in test infra

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-changelog v0.0.0-20240318095659-4d68c58a6e7f
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-version v1.9.0
-	github.com/hashicorp/hc-install v0.9.4
+	github.com/hashicorp/hc-install v0.9.4 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-exec v0.25.1
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/internal/testutil/hcl/common.go
+++ b/internal/testutil/hcl/common.go
@@ -32,11 +32,9 @@ func getTF() *tfexec.Terraform {
 	if tf != nil {
 		return tf
 	}
-	// TODO: revert SkipChecksumVerification once HashiCorp fixes expired PGP key in hc-install (hashicorp/hc-install#370), tracked in CLOUDP-398527.
 	installer := &releases.ExactVersion{
-		Product:                  product.Terraform,
-		Version:                  version.Must(version.NewVersion("1.10.1")),
-		SkipChecksumVerification: true,
+		Product: product.Terraform,
+		Version: version.Must(version.NewVersion("1.10.1")),
 	}
 	execPath, err := installer.Install(context.Background())
 	if err != nil {

--- a/internal/testutil/hcl/common.go
+++ b/internal/testutil/hcl/common.go
@@ -1,17 +1,13 @@
 package hcl
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
-
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/hc-install/product"
-	"github.com/hashicorp/hc-install/releases"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -32,13 +28,9 @@ func getTF() *tfexec.Terraform {
 	if tf != nil {
 		return tf
 	}
-	installer := &releases.ExactVersion{
-		Product: product.Terraform,
-		Version: version.Must(version.NewVersion("1.10.1")),
-	}
-	execPath, err := installer.Install(context.Background())
+	execPath, err := exec.LookPath("terraform")
 	if err != nil {
-		panic(err)
+		panic("terraform not found in PATH: " + err.Error())
 	}
 	tempDir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Description

Reverts the temporary `SkipChecksumVerification: true` workaround from #4389 now that HashiCorp fixed the expired PGP key (hashicorp/hc-install#370). Also replaces the hardcoded `hc-install ExactVersion("1.10.1")` installer with `exec.LookPath`, so `getTF()` uses whatever Terraform is already in PATH, eliminating version drift and the `hc-install` dependency in test infrastructure.

**Verification:** Before this fix, `TestAccSearchDeployment_timeoutTest` panicked with `unable to verify checksums signature: openpgp: key expired` ([run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/24643279439/job/72051162652)). With this PR the same test passes ([run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/25115601874/job/73601621432)).

Link to any related issue(s): CLOUDP-398527

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments