### PR TITLE
fix: Avoids inconsistent result error when oplog_size_mb changes due to instance_size or disk_size_gb changes

### DIFF
--- a/.changelog/4402.txt
+++ b/.changelog/4402.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/mongodbatlas_advanced_cluster: Mark advanced_configuration.oplog_size_mb as unknown in the plan when disk_size_gb or instance_size change to avoid inconsistent result errors
-```

--- a/.changelog/4402.txt
+++ b/.changelog/4402.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Mark advanced_configuration.oplog_size_mb as unknown in the plan when disk_size_gb or instance_size change to avoid inconsistent result errors
+```

--- a/.changelog/4413.txt
+++ b/.changelog/4413.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_advanced_cluster: Marks advanced_configuration.oplog_size_mb as unknown in the plan when disk_size_gb or instance_size change to avoid inconsistent result errors
+resource/mongodbatlas_advanced_cluster: Fixes inconsistent result error when scaling attribute changes cause Atlas to recompute oplog_size_mb
 ```

--- a/.changelog/4413.txt
+++ b/.changelog/4413.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Marks advanced_configuration.oplog_size_mb as unknown in the plan when disk_size_gb or instance_size change to avoid inconsistent result errors
+```

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -21,6 +21,9 @@ var (
 		"custom_openssl_cipher_config_tls12": {"custom_openssl_cipher_config_tls13"},
 		"custom_openssl_cipher_config_tls13": {"custom_openssl_cipher_config_tls12"},
 		"cluster_type":                       {"config_server_management_mode", "config_server_type"}, // computed values of config server change when REPLICA_SET changes to SHARDED
+		// Atlas may recompute oplog when storage or effective tier changes; do not copy stale oplog from state.
+		"disk_size_gb":  {"oplog_size_mb"},
+		"instance_size": {"oplog_size_mb"},
 	}
 )
 

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -22,6 +22,7 @@ var (
 		"custom_openssl_cipher_config_tls13": {"custom_openssl_cipher_config_tls12"},
 		"cluster_type":                       {"config_server_management_mode", "config_server_type"}, // computed values of config server change when REPLICA_SET changes to SHARDED
 		// Atlas may recompute oplog when storage or effective tier changes; do not copy stale oplog from state.
+		"disk_iops":     {"oplog_size_mb"},
 		"disk_size_gb":  {"oplog_size_mb"},
 		"instance_size": {"oplog_size_mb"},
 	}

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -121,6 +121,31 @@ func replicaSetAWSProviderTestCase(t *testing.T) *resource.TestCase {
 	}
 }
 
+func TestAccClusterAdvancedCluster_replicaSetOplogAfterDiskScale(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 6)
+		oplog2560              = 2560
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config: configAWSProviderReplicaSetWithOptionalOplog(t, projectID, clusterName, 50, 3, &oplog2560),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkReplicaSetAWSProvider(true, true, projectID, clusterName, 50, 3, true, true),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.oplog_size_mb", "2560"),
+				),
+			},
+			{
+				Config: configAWSProviderReplicaSetWithOptionalOplog(t, projectID, clusterName, 100, 3, nil),
+				Check:  checkReplicaSetAWSProvider(true, true, projectID, clusterName, 100, 3, true, true),
+			},
+		},
+	})
+}
+
 func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
 	resource.ParallelTest(t, *replicaSetMultiCloudTestCase(t))
 }
@@ -1539,6 +1564,44 @@ func configAWSProvider(t *testing.T, configInfo ReplicaSetAWSConfig, isTPF bool)
 			}]
 	}
 	`, configInfo.ProjectID, configInfo.ClusterName, configInfo.ClusterType, configInfo.DiskSizeGB, configInfo.NodeCountElectable) + dataSourcesConfig
+}
+
+func configAWSProviderReplicaSetWithOptionalOplog(t *testing.T, projectID, clusterName string, diskSizeGB, nodeCountElectable int, oplogSizeMB *int) string {
+	t.Helper()
+	advanced := ""
+	if oplogSizeMB != nil {
+		advanced = fmt.Sprintf(`
+	advanced_configuration = {
+		oplog_size_mb = %d
+	}
+`, *oplogSizeMB)
+	}
+	return fmt.Sprintf(`
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id   = %[1]q
+			name         = %[2]q
+			cluster_type = "REPLICASET"
+			retain_backups_enabled = "true"
+			%[5]s
+			replication_specs = [{
+				region_configs = [{
+					electable_specs = {
+						instance_size   = "M10"
+						node_count      = %[4]d
+						disk_size_gb    = %[3]d
+					}
+					analytics_specs = {
+						instance_size = "M10"
+						node_count    = 1
+						disk_size_gb  = %[3]d
+					}
+					priority      = 7
+					provider_name = "AWS"
+					region_name   = "US_WEST_2"
+				}]
+			}]
+		}
+	`, projectID, clusterName, diskSizeGB, nodeCountElectable, advanced) + dataSourcesConfig
 }
 
 func checkReplicaSetAWSProvider(isTPF, useDataSource bool, projectID, name string, diskSizeGB, nodeCountElectable int, checkDiskSizeGBInnerLevel, checkExternalID bool) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

When `disk_size_gb` or `instance_size` changes, Atlas can recompute the effective oplog size. The advanced cluster plan modifier was copying the previous `advanced_configuration.oplog_size_mb` from state into the plan, which could cause inconsistent state

Test reproducing the issue [run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/25120729004/job/73620450494)

Link to any related issue(s): #4404 CLOUDP-400267

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
