### PR TITLE
chore: Add Terraform setup to update-dev-branches GHA

### DIFF
--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -61,6 +61,11 @@ jobs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: 'go.mod'
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+      with:
+        terraform_version: '1.14.x'
+        terraform_wrapper: false
     - name: Config Git
       run: |
         git config --local user.email svc-api-experience-integrations-escalation@mongodb.com

--- a/scripts/update-tf-version-in-repository.sh
+++ b/scripts/update-tf-version-in-repository.sh
@@ -22,6 +22,7 @@ TEST_SUITE_YAML_FILE=".github/workflows/test-suite.yml"
 ACCEPTANCE_TESTS_YAML_FILE=".github/workflows/acceptance-tests.yml"
 CODE_HEALTH_YAML_FILE=".github/workflows/code-health.yml"
 EXAMPLES_YAML_FILE=".github/workflows/examples.yml"
+UPDATE_DEV_BRANCHES_YAML_FILE=".github/workflows/update-dev-branches.yml"
 TOOL_VERSIONS_FILE=".tool-versions"
 
 LATEST_TF_VERSION=$(echo "$TF_VERSIONS_ARR" | sed -E 's/^\["([^"]+).*/\1/')
@@ -35,6 +36,9 @@ sed -i.bak -E "s|terraform_version: '.*'|terraform_version: '$LATEST_TF_VERSION'
 
 # Update Terraform version in code-health.yml
 sed -i.bak -E "s|terraform_version: '.*'|terraform_version: '$LATEST_TF_VERSION'|" "$CODE_HEALTH_YAML_FILE"
+
+# Update Terraform version in update-dev-branches.yml
+sed -i.bak -E "s|terraform_version: '.*'|terraform_version: '$LATEST_TF_VERSION'|" "$UPDATE_DEV_BRANCHES_YAML_FILE"
 
 # Update Terraform version in acceptance-tests.yml
 sed -i.bak -E "s~terraform_version \|\| '[0-9]+\.[0-9]+\.x'~terraform_version \|\| '$LATEST_TF_VERSION'~" "$ACCEPTANCE_TESTS_YAML_FILE"


### PR DESCRIPTION
## Description

Follow-up to #4411, which added `hashicorp/setup-terraform` to `code-health.yml` jobs to ensure Terraform is available on PATH for unit tests. The `update-dev-branches` workflow was not identified as affected at the time, but it also runs `make test` in its "Project check" step without Terraform installed, causing the same failure.

This PR adds the missing `hashicorp/setup-terraform` step to `update-dev-branches.yml` and registers the file in `scripts/update-tf-version-in-repository.sh` so future automated Terraform version bumps keep it in sync.

Link to any related issue(s): CLOUDP-398527

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments