### PR TITLE
feat: Adds `use_legacy_path_structure` attribute for S3 log_integration

### DIFF
--- a/.changelog/4419.txt
+++ b/.changelog/4419.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_log_integration: Adds `use_legacy_path_structure` attribute for `S3_LOG_EXPORT` type to use the legacy daily-folder path structure
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_log_integration: Adds `use_legacy_path_structure` attribute for `S3_LOG_EXPORT` type to use the legacy daily-folder path structure
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_log_integrations: Adds `use_legacy_path_structure` attribute for `S3_LOG_EXPORT` type to use the legacy daily-folder path structure
+```

--- a/docs/data-sources/log_integration.md
+++ b/docs/data-sources/log_integration.md
@@ -69,6 +69,7 @@ The following attributes depend on the value of `type`:
 - `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
 - `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `use_legacy_path_structure` (Boolean) When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.
 
 #### `SPLUNK_LOG_EXPORT`
 

--- a/docs/data-sources/log_integrations.md
+++ b/docs/data-sources/log_integrations.md
@@ -80,6 +80,7 @@ The following attributes depend on the value of `type`:
 - `iam_role_id` (String) Unique 24-character hexadecimal string that identifies the AWS IAM role that Atlas uses to access the S3 bucket.
 - `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
 - `prefix_path` (String) Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
+- `use_legacy_path_structure` (Boolean) When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.
 
 #### `SPLUNK_LOG_EXPORT`
 

--- a/docs/resources/log_integration.md
+++ b/docs/resources/log_integration.md
@@ -29,12 +29,13 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth" {
 }
 
 resource "mongodbatlas_log_integration" "example" {
-  project_id  = mongodbatlas_project.project.id
-  type        = "S3_LOG_EXPORT"
-  log_types   = ["MONGOD_AUDIT"]
-  bucket_name = aws_s3_bucket.log_bucket.bucket
-  iam_role_id = mongodbatlas_cloud_provider_access_authorization.auth.role_id
-  prefix_path = "atlas-logs"
+  project_id                = mongodbatlas_project.project.id
+  type                      = "S3_LOG_EXPORT"
+  log_types                 = ["MONGOD_AUDIT"]
+  bucket_name               = aws_s3_bucket.log_bucket.bucket
+  iam_role_id               = mongodbatlas_cloud_provider_access_authorization.auth.role_id
+  prefix_path               = "atlas-logs"
+  use_legacy_path_structure = var.use_legacy_path_structure
 }
 ```
 
@@ -186,6 +187,7 @@ Required:
 
 Optional:
 - `kms_key` (String) AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
+- `use_legacy_path_structure` (Boolean) When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.
 
 #### `SPLUNK_LOG_EXPORT`
 

--- a/examples/mongodbatlas_log_integration/s3bucket/main.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket/main.tf
@@ -14,10 +14,11 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth" {
 }
 
 resource "mongodbatlas_log_integration" "example" {
-  project_id  = mongodbatlas_project.project.id
-  type        = "S3_LOG_EXPORT"
-  log_types   = ["MONGOD_AUDIT"]
-  bucket_name = aws_s3_bucket.log_bucket.bucket
-  iam_role_id = mongodbatlas_cloud_provider_access_authorization.auth.role_id
-  prefix_path = "atlas-logs"
+  project_id                = mongodbatlas_project.project.id
+  type                      = "S3_LOG_EXPORT"
+  log_types                 = ["MONGOD_AUDIT"]
+  bucket_name               = aws_s3_bucket.log_bucket.bucket
+  iam_role_id               = mongodbatlas_cloud_provider_access_authorization.auth.role_id
+  prefix_path               = "atlas-logs"
+  use_legacy_path_structure = var.use_legacy_path_structure
 }

--- a/examples/mongodbatlas_log_integration/s3bucket/variables.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket/variables.tf
@@ -50,3 +50,9 @@ variable "aws_iam_role_name" {
   default     = "atlas-log-integration-role"
   type        = string
 }
+
+variable "use_legacy_path_structure" {
+  description = "When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export"
+  default     = null
+  type        = bool
+}

--- a/internal/serviceapi/logintegration/data_source_schema.go
+++ b/internal/serviceapi/logintegration/data_source_schema.go
@@ -101,28 +101,33 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.",
 			},
+			"use_legacy_path_structure": dsschema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Applies to type: S3_LOG_EXPORT. When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.",
+			},
 		},
 	}
 }
 
 type TFDSModel struct {
-	ApiKey               types.String                                              `tfsdk:"api_key" autogen:"sensitive,omitjson"`
-	BucketName           types.String                                              `tfsdk:"bucket_name" autogen:"omitjson"`
-	HecToken             types.String                                              `tfsdk:"hec_token" autogen:"sensitive,omitjson"`
-	HecUrl               types.String                                              `tfsdk:"hec_url" autogen:"omitjson"`
-	IamRoleId            types.String                                              `tfsdk:"iam_role_id" autogen:"omitjson"`
-	IntegrationId        types.String                                              `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
-	KmsKey               types.String                                              `tfsdk:"kms_key" autogen:"omitjson"`
-	LogTypes             customtypes.SetValue[types.String]                        `tfsdk:"log_types" autogen:"omitjson"`
-	OtelEndpoint         types.String                                              `tfsdk:"otel_endpoint" autogen:"omitjson"`
-	OtelSuppliedHeaders  customtypes.NestedListValue[TFDSOtelSuppliedHeadersModel] `tfsdk:"otel_supplied_headers" autogen:"sensitive,omitjson"`
-	PrefixPath           types.String                                              `tfsdk:"prefix_path" autogen:"omitjson"`
-	ProjectId            types.String                                              `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
-	Region               types.String                                              `tfsdk:"region" autogen:"omitjson"`
-	RoleId               types.String                                              `tfsdk:"role_id" autogen:"omitjson"`
-	StorageAccountName   types.String                                              `tfsdk:"storage_account_name" autogen:"omitjson"`
-	StorageContainerName types.String                                              `tfsdk:"storage_container_name" autogen:"omitjson"`
-	Type                 types.String                                              `tfsdk:"type" autogen:"omitjson"`
+	ApiKey                 types.String                                              `tfsdk:"api_key" autogen:"sensitive,omitjson"`
+	BucketName             types.String                                              `tfsdk:"bucket_name" autogen:"omitjson"`
+	HecToken               types.String                                              `tfsdk:"hec_token" autogen:"sensitive,omitjson"`
+	HecUrl                 types.String                                              `tfsdk:"hec_url" autogen:"omitjson"`
+	IamRoleId              types.String                                              `tfsdk:"iam_role_id" autogen:"omitjson"`
+	IntegrationId          types.String                                              `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
+	KmsKey                 types.String                                              `tfsdk:"kms_key" autogen:"omitjson"`
+	LogTypes               customtypes.SetValue[types.String]                        `tfsdk:"log_types" autogen:"omitjson"`
+	OtelEndpoint           types.String                                              `tfsdk:"otel_endpoint" autogen:"omitjson"`
+	OtelSuppliedHeaders    customtypes.NestedListValue[TFDSOtelSuppliedHeadersModel] `tfsdk:"otel_supplied_headers" autogen:"sensitive,omitjson"`
+	PrefixPath             types.String                                              `tfsdk:"prefix_path" autogen:"omitjson"`
+	ProjectId              types.String                                              `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
+	Region                 types.String                                              `tfsdk:"region" autogen:"omitjson"`
+	RoleId                 types.String                                              `tfsdk:"role_id" autogen:"omitjson"`
+	StorageAccountName     types.String                                              `tfsdk:"storage_account_name" autogen:"omitjson"`
+	StorageContainerName   types.String                                              `tfsdk:"storage_container_name" autogen:"omitjson"`
+	Type                   types.String                                              `tfsdk:"type" autogen:"omitjson"`
+	UseLegacyPathStructure types.Bool                                                `tfsdk:"use_legacy_path_structure" autogen:"omitjson"`
 }
 type TFDSOtelSuppliedHeadersModel struct {
 	Name  types.String `tfsdk:"name" autogen:"omitjson"`

--- a/internal/serviceapi/logintegration/plural_data_source_schema.go
+++ b/internal/serviceapi/logintegration/plural_data_source_schema.go
@@ -111,6 +111,10 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 							Computed:            true,
 							MarkdownDescription: "Human-readable label that identifies the service to which you want to integrate with Atlas. The value must match the log integration type. This value cannot be modified after the integration is created.",
 						},
+						"use_legacy_path_structure": dsschema.BoolAttribute{
+							Computed:            true,
+							MarkdownDescription: "Applies to type: S3_LOG_EXPORT. When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.",
+						},
 					},
 				},
 			},
@@ -124,22 +128,23 @@ type TFPluralDSModel struct {
 	Results         customtypes.NestedListValue[TFPluralDSResultsModel] `tfsdk:"results" autogen:"omitjson"`
 }
 type TFPluralDSResultsModel struct {
-	ApiKey               types.String                                                           `tfsdk:"api_key" autogen:"sensitive,omitjson"`
-	BucketName           types.String                                                           `tfsdk:"bucket_name" autogen:"omitjson"`
-	HecToken             types.String                                                           `tfsdk:"hec_token" autogen:"sensitive,omitjson"`
-	HecUrl               types.String                                                           `tfsdk:"hec_url" autogen:"omitjson"`
-	IamRoleId            types.String                                                           `tfsdk:"iam_role_id" autogen:"omitjson"`
-	IntegrationId        types.String                                                           `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
-	KmsKey               types.String                                                           `tfsdk:"kms_key" autogen:"omitjson"`
-	LogTypes             customtypes.SetValue[types.String]                                     `tfsdk:"log_types" autogen:"omitjson"`
-	OtelEndpoint         types.String                                                           `tfsdk:"otel_endpoint" autogen:"omitjson"`
-	OtelSuppliedHeaders  customtypes.NestedListValue[TFPluralDSResultsOtelSuppliedHeadersModel] `tfsdk:"otel_supplied_headers" autogen:"sensitive,omitjson"`
-	PrefixPath           types.String                                                           `tfsdk:"prefix_path" autogen:"omitjson"`
-	Region               types.String                                                           `tfsdk:"region" autogen:"omitjson"`
-	RoleId               types.String                                                           `tfsdk:"role_id" autogen:"omitjson"`
-	StorageAccountName   types.String                                                           `tfsdk:"storage_account_name" autogen:"omitjson"`
-	StorageContainerName types.String                                                           `tfsdk:"storage_container_name" autogen:"omitjson"`
-	Type                 types.String                                                           `tfsdk:"type" autogen:"omitjson"`
+	ApiKey                 types.String                                                           `tfsdk:"api_key" autogen:"sensitive,omitjson"`
+	BucketName             types.String                                                           `tfsdk:"bucket_name" autogen:"omitjson"`
+	HecToken               types.String                                                           `tfsdk:"hec_token" autogen:"sensitive,omitjson"`
+	HecUrl                 types.String                                                           `tfsdk:"hec_url" autogen:"omitjson"`
+	IamRoleId              types.String                                                           `tfsdk:"iam_role_id" autogen:"omitjson"`
+	IntegrationId          types.String                                                           `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
+	KmsKey                 types.String                                                           `tfsdk:"kms_key" autogen:"omitjson"`
+	LogTypes               customtypes.SetValue[types.String]                                     `tfsdk:"log_types" autogen:"omitjson"`
+	OtelEndpoint           types.String                                                           `tfsdk:"otel_endpoint" autogen:"omitjson"`
+	OtelSuppliedHeaders    customtypes.NestedListValue[TFPluralDSResultsOtelSuppliedHeadersModel] `tfsdk:"otel_supplied_headers" autogen:"sensitive,omitjson"`
+	PrefixPath             types.String                                                           `tfsdk:"prefix_path" autogen:"omitjson"`
+	Region                 types.String                                                           `tfsdk:"region" autogen:"omitjson"`
+	RoleId                 types.String                                                           `tfsdk:"role_id" autogen:"omitjson"`
+	StorageAccountName     types.String                                                           `tfsdk:"storage_account_name" autogen:"omitjson"`
+	StorageContainerName   types.String                                                           `tfsdk:"storage_container_name" autogen:"omitjson"`
+	Type                   types.String                                                           `tfsdk:"type" autogen:"omitjson"`
+	UseLegacyPathStructure types.Bool                                                             `tfsdk:"use_legacy_path_structure" autogen:"omitjson"`
 }
 type TFPluralDSResultsOtelSuppliedHeadersModel struct {
 	Name  types.String `tfsdk:"name" autogen:"omitjson"`

--- a/internal/serviceapi/logintegration/resource_schema.go
+++ b/internal/serviceapi/logintegration/resource_schema.go
@@ -126,7 +126,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Required: []string{"otel_endpoint", "otel_supplied_headers"},
 							},
 							"S3_LOG_EXPORT": {
-								Allowed:  []string{"bucket_name", "iam_role_id", "kms_key", "prefix_path"},
+								Allowed:  []string{"bucket_name", "iam_role_id", "kms_key", "prefix_path", "use_legacy_path_structure"},
 								Required: []string{"bucket_name", "iam_role_id", "prefix_path"},
 							},
 							"SPLUNK_LOG_EXPORT": {
@@ -137,28 +137,34 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					}),
 				},
 			},
+			"use_legacy_path_structure": schema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Optional for type: S3_LOG_EXPORT. When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.",
+			},
 		},
 	}
 }
 
 type TFModel struct {
-	ApiKey               types.String                                            `tfsdk:"api_key" autogen:"sensitive"`
-	BucketName           types.String                                            `tfsdk:"bucket_name"`
-	ProjectId            types.String                                            `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
-	HecToken             types.String                                            `tfsdk:"hec_token" autogen:"sensitive"`
-	HecUrl               types.String                                            `tfsdk:"hec_url"`
-	IamRoleId            types.String                                            `tfsdk:"iam_role_id"`
-	IntegrationId        types.String                                            `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
-	KmsKey               types.String                                            `tfsdk:"kms_key"`
-	LogTypes             customtypes.SetValue[types.String]                      `tfsdk:"log_types"`
-	OtelEndpoint         types.String                                            `tfsdk:"otel_endpoint"`
-	OtelSuppliedHeaders  customtypes.NestedListValue[TFOtelSuppliedHeadersModel] `tfsdk:"otel_supplied_headers" autogen:"sensitive"`
-	PrefixPath           types.String                                            `tfsdk:"prefix_path"`
-	Region               types.String                                            `tfsdk:"region"`
-	RoleId               types.String                                            `tfsdk:"role_id"`
-	StorageAccountName   types.String                                            `tfsdk:"storage_account_name"`
-	StorageContainerName types.String                                            `tfsdk:"storage_container_name"`
-	Type                 types.String                                            `tfsdk:"type"`
+	ApiKey                 types.String                                            `tfsdk:"api_key" autogen:"sensitive"`
+	BucketName             types.String                                            `tfsdk:"bucket_name"`
+	ProjectId              types.String                                            `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
+	HecToken               types.String                                            `tfsdk:"hec_token" autogen:"sensitive"`
+	HecUrl                 types.String                                            `tfsdk:"hec_url"`
+	IamRoleId              types.String                                            `tfsdk:"iam_role_id"`
+	IntegrationId          types.String                                            `tfsdk:"integration_id" apiname:"id" autogen:"omitjson"`
+	KmsKey                 types.String                                            `tfsdk:"kms_key"`
+	LogTypes               customtypes.SetValue[types.String]                      `tfsdk:"log_types"`
+	OtelEndpoint           types.String                                            `tfsdk:"otel_endpoint"`
+	OtelSuppliedHeaders    customtypes.NestedListValue[TFOtelSuppliedHeadersModel] `tfsdk:"otel_supplied_headers" autogen:"sensitive"`
+	PrefixPath             types.String                                            `tfsdk:"prefix_path"`
+	Region                 types.String                                            `tfsdk:"region"`
+	RoleId                 types.String                                            `tfsdk:"role_id"`
+	StorageAccountName     types.String                                            `tfsdk:"storage_account_name"`
+	StorageContainerName   types.String                                            `tfsdk:"storage_container_name"`
+	Type                   types.String                                            `tfsdk:"type"`
+	UseLegacyPathStructure types.Bool                                              `tfsdk:"use_legacy_path_structure"`
 }
 type TFOtelSuppliedHeadersModel struct {
 	Name  types.String `tfsdk:"name"`

--- a/internal/serviceapi/logintegration/resource_test.go
+++ b/internal/serviceapi/logintegration/resource_test.go
@@ -41,6 +41,7 @@ var (
 
 type s3Config struct {
 	kmsKey            *string
+	useLegacyPath     *bool
 	bucketName        string
 	bucketPolicyName  string
 	iamRoleName       string
@@ -75,6 +76,7 @@ func TestAccLogIntegration_basicS3(t *testing.T) {
 		awsIAMRoleName       = acc.RandomIAMRole()
 		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
 		kmsKey               = os.Getenv("AWS_KMS_KEY_ID")
+		useLegacyPath        = true
 		withDS               = true
 	)
 
@@ -85,19 +87,19 @@ func TestAccLogIntegration_basicS3(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasicS3(projectID, logTypesMongoD, &s3Config{nil, s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, withDS),
-				Check:  checkBasicS3(logTypesMongoD, s3BucketName, prefixPath, withDS),
+				Config: configBasicS3(projectID, logTypesMongoD, &s3Config{nil, nil, s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, withDS),
+				Check:  checkBasicS3(logTypesMongoD, s3BucketName, prefixPath, !useLegacyPath, withDS),
 			},
 			{
-				Config: configBasicS3(projectID, logTypesAll, &s3Config{&kmsKey, s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, !withDS),
-				Check:  checkBasicS3(logTypesAll, s3BucketName, prefixPath, !withDS),
+				Config: configBasicS3(projectID, logTypesAll, &s3Config{&kmsKey, new(useLegacyPath), s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, !withDS),
+				Check:  checkBasicS3(logTypesAll, s3BucketName, prefixPath, useLegacyPath, !withDS),
 			},
 			{
-				Config: configBasicS3(projectID, logTypesMongoS, &s3Config{nil, s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, !withDS),
-				Check:  checkBasicS3(logTypesMongoS, s3BucketName, prefixPath, !withDS),
+				Config: configBasicS3(projectID, logTypesMongoS, &s3Config{nil, new(!useLegacyPath), s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, !withDS),
+				Check:  checkBasicS3(logTypesMongoS, s3BucketName, prefixPath, !useLegacyPath, !withDS),
 			},
 			{
-				Config:                               configBasicS3(projectID, logTypesMongoS, &s3Config{&kmsKey, s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, false),
+				Config:                               configBasicS3(projectID, logTypesMongoS, &s3Config{&kmsKey, new(!useLegacyPath), s3BucketName, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath}, false),
 				ResourceName:                         resourceName,
 				ImportStateIdFunc:                    importStateIDFunc(resourceName),
 				ImportState:                          true,
@@ -303,6 +305,10 @@ func configBasicS3(projectID string, logTypes []string, config *s3Config, withDS
 	if config.kmsKey != nil {
 		kmsKeyHCL = fmt.Sprintf("kms_key = %q", *config.kmsKey)
 	}
+	useLegacyPathHCL := ""
+	if config.useLegacyPath != nil {
+		useLegacyPathHCL = fmt.Sprintf("use_legacy_path_structure = %t", *config.useLegacyPath)
+	}
 	dsConfig := ""
 	if withDS {
 		dsConfig = datasourcesConfig
@@ -318,20 +324,22 @@ func configBasicS3(projectID string, logTypes []string, config *s3Config, withDS
 			bucket_name = aws_s3_bucket.log_bucket.bucket
 			prefix_path = %[4]q
 			%[5]s
+			%[6]s
 		}
 
-		%[6]s
-	`, awsIAMRoleAuthAndS3Config(projectID, config), projectID, logTypesStr, config.prefixPath, kmsKeyHCL, dsConfig)
+		%[7]s
+	`, awsIAMRoleAuthAndS3Config(projectID, config), projectID, logTypesStr, config.prefixPath, kmsKeyHCL, useLegacyPathHCL, dsConfig)
 }
 
-func checkBasicS3(logTypes []string, bucketName, prefixPath string, withDS bool) resource.TestCheckFunc {
+func checkBasicS3(logTypes []string, bucketName, prefixPath string, useLegacyPath, withDS bool) resource.TestCheckFunc {
 	setChecks := []string{"iam_role_id", "integration_id"}
 	mapChecks := map[string]string{
-		"bucket_name": bucketName,
-		"prefix_path": prefixPath,
-		"type":        "S3_LOG_EXPORT",
-		"log_types.#": strconv.Itoa(len(logTypes)),
-		"log_types.0": logTypes[0],
+		"bucket_name":               bucketName,
+		"prefix_path":               prefixPath,
+		"type":                      "S3_LOG_EXPORT",
+		"log_types.#":               strconv.Itoa(len(logTypes)),
+		"log_types.0":               logTypes[0],
+		"use_legacy_path_structure": strconv.FormatBool(useLegacyPath),
 	}
 	return commonCheck(setChecks, mapChecks, withDS)
 }

--- a/tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
+++ b/tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
@@ -1117,6 +1117,9 @@ components:
             - CREDIT_CARD_ABOUT_TO_EXPIRE
             - PENDING_INVOICE_OVER_THRESHOLD
             - DAILY_BILL_OVER_THRESHOLD
+            - DAILY_BILLING_CHANGE_OVER_THRESHOLD
+            - WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+            - MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
             - CPS_SNAPSHOT_STARTED
             - CPS_SNAPSHOT_SUCCESSFUL
             - CPS_SNAPSHOT_FAILED
@@ -1150,6 +1153,7 @@ components:
             - FTS_INDEX_DELETION_FAILED
             - FTS_INDEX_BUILD_COMPLETE
             - FTS_INDEX_BUILD_FAILED
+            - FTS_INDEX_CLEANED_UP
             - FTS_INDEX_STALE
             - FTS_INDEXES_RESTORE_FAILED
             - FTS_INDEXES_SYNONYM_MAPPING_INVALID
@@ -1206,6 +1210,8 @@ components:
             - PREDICTIVE_COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE
             - PREDICTIVE_COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE
             - CLUSTER_AUTO_SHARDING_INITIATED
+            - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_BASE
+            - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_ANALYTICS
             - CPS_DATA_PROTECTION_ENABLE_REQUESTED
             - CPS_DATA_PROTECTION_ENABLED
             - CPS_DATA_PROTECTION_UPDATE_REQUESTED
@@ -1702,6 +1708,203 @@ components:
             - DEFAULT
           type: string
       type: object
+    ApiAtlasCollectionRestoreCollectionStateResponse:
+      description: Collection-level state within a collection restore job.
+      properties:
+        effectiveTargetNamespace:
+          description: Actual target namespace after restore (e.g. after conflict rename).
+          readOnly: true
+          type: string
+        restoredDocuments:
+          description: Number of documents restored so far.
+          format: int64
+          readOnly: true
+          type: integer
+        sourceNamespace:
+          description: Source namespace that was requested to restore.
+          readOnly: true
+          type: string
+        state:
+          description: Current state of this collection within the restore job.
+          enum:
+            - NOT_STARTED
+            - IN_PROGRESS
+            - FINALIZING
+            - NOT_FOUND
+            - UNSUPPORTED
+            - SUCCESSFUL
+            - ROLLBACK
+            - NOT_RESTORED
+            - FAILED
+            - INDEX_BUILD_FAILED
+          readOnly: true
+          type: string
+        targetNamespace:
+          description: Requested target namespace for the restored collection.
+          readOnly: true
+          type: string
+        totalDocuments:
+          description: Total document count for this collection.
+          format: int64
+          readOnly: true
+          type: integer
+      type: object
+    ApiAtlasCollectionRestoreJobRequest:
+      description: Request body for creating a collection restore job.
+      properties:
+        collectionSuffix:
+          description: Optional suffix applied to restored collection names.
+          type: string
+        collections:
+          description: List of collections to restore (up to 100 items).
+          items:
+            $ref: "#/components/schemas/ApiAtlasRestoreNamespaceView"
+          maxItems: 100
+          type: array
+        databaseSuffix:
+          description: Optional suffix applied to restored database names.
+          type: string
+        databases:
+          description: List of databases to restore (up to 100 items).
+          items:
+            $ref: "#/components/schemas/ApiAtlasRestoreNamespaceView"
+          maxItems: 100
+          type: array
+        indexStrategy:
+          description: Strategy for restoring indexes (all, none, or all except TTL).
+          enum:
+            - ALL
+            - NONE
+            - ALL_EXCEPT_TTL
+          type: string
+        oplogInc:
+          description: Oplog increment for point-in-time restore.
+          format: int32
+          type: integer
+        oplogTs:
+          description: Oplog timestamp (seconds part) for point-in-time restore.
+          format: int32
+          type: integer
+        overwriteStrategy:
+          description: Strategy for overwriting existing data (new if exists or overwrite if exists).
+          enum:
+            - NEW_IF_EXISTS
+            - OVERWRITE_IF_EXISTS
+          type: string
+        pointInTimeUtcSeconds:
+          description: Point-in-time restore time in seconds since UNIX epoch.
+          format: int32
+          type: integer
+        snapshotId:
+          description: ID of the snapshot to restore.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          type: string
+        targetClusterName:
+          description: Target cluster name.
+          type: string
+        targetGroupId:
+          description: Unique 24-hexadecimal digit string that identifies the target group.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          type: string
+      required:
+        - indexStrategy
+        - overwriteStrategy
+        - targetClusterName
+        - targetGroupId
+      type: object
+    ApiAtlasCollectionRestoreJobResponse:
+      description: Collection restore job summary including the list of databases and collections in the restore scope (up to 100 items each).
+      properties:
+        collectionSuffix:
+          description: Suffix applied to restored collection names.
+          type: string
+        collections:
+          description: List of collections in the restore scope (up to 100 items).
+          items:
+            $ref: "#/components/schemas/ApiAtlasRestoreNamespaceView"
+          maxItems: 100
+          type: array
+        createdAt:
+          description: Date and time when the restore job was created (ISO 8601 format in UTC).
+          format: date-time
+          readOnly: true
+          type: string
+        databaseSuffix:
+          description: Suffix applied to restored database names.
+          type: string
+        databases:
+          description: List of databases in the restore scope (up to 100 items).
+          items:
+            $ref: "#/components/schemas/ApiAtlasRestoreNamespaceView"
+          maxItems: 100
+          type: array
+        errorMessage:
+          description: Error message when the job has failed or been canceled.
+          readOnly: true
+          type: string
+        finishedAt:
+          description: Date and time when the restore job finished (ISO 8601 format in UTC).
+          format: date-time
+          readOnly: true
+          type: string
+        id:
+          description: Unique 24-hexadecimal digit string that identifies the collection restore job.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          readOnly: true
+          type: string
+        indexStrategy:
+          description: Strategy for restoring indexes (all, none, or all except TTL).
+          enum:
+            - ALL
+            - NONE
+            - ALL_EXCEPT_TTL
+          type: string
+        oplogInc:
+          description: Oplog increment for point-in-time restore.
+          format: int32
+          type: integer
+        oplogTs:
+          description: Oplog timestamp (seconds part) for point-in-time restore.
+          format: int32
+          type: integer
+        overwriteStrategy:
+          description: Strategy for overwriting existing data (new if exists or overwrite if exists).
+          enum:
+            - NEW_IF_EXISTS
+            - OVERWRITE_IF_EXISTS
+          type: string
+        pointInTimeUtcSeconds:
+          description: Point-in-time restore time in seconds since UNIX epoch.
+          format: int32
+          type: integer
+        snapshotId:
+          description: Unique 24-hexadecimal digit string that identifies the snapshot being restored.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          type: string
+        state:
+          description: Current state of the collection restore job.
+          enum:
+            - INITIALIZING
+            - IN_PROGRESS
+            - FINALIZING
+            - SUCCESSFUL
+            - CANCELED
+            - FAILED
+          readOnly: true
+          type: string
+        targetClusterName:
+          description: Human-readable label that identifies the target cluster.
+          type: string
+        targetGroupId:
+          description: Unique 24-hexadecimal digit string that identifies the target group.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          type: string
+      type: object
     ApiAtlasFTSAnalyzersViewManual:
       description: Settings that describe one Atlas Search custom analyzer.
       properties:
@@ -2068,6 +2271,18 @@ components:
           example: v1
           readOnly: true
           type: string
+      type: object
+    ApiAtlasRestoreNamespaceView:
+      description: Source and optional target namespace for a restore.
+      properties:
+        sourceNamespace:
+          description: Namespace requested to restore (e.g. database name or `database.collection`).
+          type: string
+        targetNamespace:
+          description: Requested target namespace for the restored data; if empty, source namespace is used.
+          type: string
+      required:
+        - sourceNamespace
       type: object
     ApiAtlasSnapshotScheduleView:
       properties:
@@ -2527,6 +2742,14 @@ components:
           description: Name of the database this policy applies to.
           readOnly: true
           type: string
+        effectiveState:
+          description: Current effective state of the policy.
+          enum:
+            - ACTIVE
+            - PAUSING
+            - PAUSED
+          readOnly: true
+          type: string
         id:
           description: Unique identifier of the policy.
           example: 32b6e34b3d91647abb20e7b8
@@ -2541,7 +2764,6 @@ components:
             - ACTIVE
             - PAUSING
             - PAUSED
-            - DELETED
           readOnly: true
           type: string
         targetCollection:
@@ -2551,6 +2773,7 @@ components:
       required:
         - action
         - dbName
+        - effectiveState
         - id
         - schedule
         - state
@@ -2849,6 +3072,39 @@ components:
       required:
         - instanceSize
         - nodeCount
+      type: object
+    ApiStandbyLinkFailoverReadinessResponse:
+      description: Response body containing a standby link failover readiness snapshot for assessing potential data loss before an unplanned failover.
+      properties:
+        estimatedDataLossSeconds:
+          description: Best-effort estimate of potential data loss in seconds if failover is triggered now.
+          example: 3
+          format: double
+          readOnly: true
+          type: number
+        estimatedFailoverTimeSeconds:
+          description: Best-effort estimate of total expected recovery time in seconds, including Atlas-side failover overhead.
+          example: 45
+          format: double
+          readOnly: true
+          type: number
+        groupId:
+          description: Unique 24-hexadecimal digit string that identifies the project that owns the standby link.
+          example: 69af15ed46c6ab2dbf1c3d0e
+          pattern: ^([a-f0-9]{24})$
+          readOnly: true
+          type: string
+        standbyLinkId:
+          description: Unique 24-hexadecimal digit string that identifies the standby link described by this readiness snapshot.
+          example: 6655f1f77bcf86cd79943901
+          pattern: ^([a-f0-9]{24})$
+          readOnly: true
+          type: string
+      required:
+        - estimatedDataLossSeconds
+        - estimatedFailoverTimeSeconds
+        - groupId
+        - standbyLinkId
       type: object
     ApiStandbyLinkFailoverRequest:
       description: Request to initiate a failover operation.
@@ -8017,6 +8273,7 @@ components:
               - Legacy Backup
               - AI Models
               - Automated Embedding
+              - Native Reranking
               - Flex Consulting
               - Support
               - Credits
@@ -9571,10 +9828,10 @@ components:
       readOnly: true
       type: object
     DefaultGroupLimitResponse:
-      description: Description of a user-configurable, project-level limit.
+      description: General information about a project-level, user-configured limit, including its name, maximum value, default value, and a description.
       properties:
-        defaultValue:
-          description: Default value for this limit. Returns null if no default value exists.
+        defaultLimit:
+          description: Default limit value. Returns null if no default exists.
           format: int32
           readOnly: true
           type: integer
@@ -9582,8 +9839,8 @@ components:
           description: Human-friendly description of what the limit controls.
           readOnly: true
           type: string
-        maximumValue:
-          description: Maximum value for this limit. Returns null if no maximum value exists.
+        maximumLimit:
+          description: Maximum limit value. Returns null if no maximum exists.
           format: int32
           readOnly: true
           type: integer
@@ -9660,6 +9917,45 @@ components:
           writeOnly: true
       type: object
       writeOnly: true
+    DeprecatedStreamProcessorMetricThreshold:
+      deprecated: true
+      description: "Threshold value that triggers an alert. Deprecated: use `metricThreshold` instead."
+      properties:
+        metricName:
+          description: Human-readable label that identifies the metric against which MongoDB Cloud checks the configured `metricThreshold.threshold`.
+          type: string
+        mode:
+          description: MongoDB Cloud computes the current metric value as an average.
+          enum:
+            - AVERAGE
+          type: string
+        operator:
+          description: Comparison operator to apply when checking the current metric value.
+          enum:
+            - LESS_THAN
+            - GREATER_THAN
+          type: string
+        threshold:
+          description: Value of metric that, when exceeded, triggers an alert.
+          format: double
+          type: number
+        units:
+          $ref: "#/components/schemas/RawMetricUnits"
+          description: Element used to express the quantity. This can be an element of time, storage capacity, and the like.
+      required:
+        - metricName
+      type: object
+      x-xgen-discriminator:
+        propertyName: metricName
+        mapping:
+          STREAM_PROCESSOR_CHANGE_STREAM_LAG:
+            properties: []
+          STREAM_PROCESSOR_DLQ_MESSAGE_COUNT:
+            properties: []
+          STREAM_PROCESSOR_KAFKA_LAG:
+            properties: []
+          STREAM_PROCESSOR_OUTPUT_MESSAGE_COUNT:
+            properties: []
     Destination:
       description: Document that describes the destination of the migration.
       properties:
@@ -9772,6 +10068,24 @@ components:
         - frequencyType
         - retentionUnit
         - retentionValue
+      type: object
+    DiskBackupCollectionResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        name:
+          description: Human-readable label that identifies the collection in the database within the snapshot.
+          readOnly: true
+          type: string
+      required:
+        - name
       type: object
     DiskBackupCopyPolicyItem:
       description: Specifications for one copy policy item.
@@ -9956,6 +10270,24 @@ components:
           type: string
       required:
         - zoneId
+      type: object
+    DiskBackupDatabaseResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        name:
+          description: Human-readable label that identifies the database within the snapshot.
+          readOnly: true
+          type: string
+      required:
+        - name
       type: object
     DiskBackupExportJob:
       properties:
@@ -11507,6 +11839,12 @@ components:
         - PENDING_INVOICE_OVER_THRESHOLD
         - DAILY_BILL_UNDER_THRESHOLD
         - DAILY_BILL_OVER_THRESHOLD
+        - DAILY_BILLING_CHANGE_NORMAL
+        - DAILY_BILLING_CHANGE_OVER_THRESHOLD
+        - WEEKLY_BILLING_CHANGE_NORMAL
+        - WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+        - MONTHLY_BILLING_CHANGE_NORMAL
+        - MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
         - CLUSTER_CONNECTION_GET_DATABASES
         - CLUSTER_CONNECTION_GET_DATABASE_COLLECTIONS
         - CLUSTER_CONNECTION_GET_DATABASE_NAMESPACES
@@ -11516,6 +11854,7 @@ components:
         - CLUSTER_CONNECTION_CREATE_COLLECTION
         - CLUSTER_CONNECTION_SAMPLE_COLLECTION_FIELD_NAMES
         - CLUSTER_CONNECTION_SAMPLE_COLLECTION_FIELD_NAMES_AND_TYPES
+        - CLUSTER_CONNECTION_FIND_DOCUMENTS
         - CLUSTER_CONNECTION_GET_NAMESPACES_AND_PROJECT_SQL_SCHEMA_DATA
         - CLUSTER_MONGOS_IS_PRESENT
         - CLUSTER_MONGOS_IS_MISSING
@@ -11785,6 +12124,8 @@ components:
         - ENCRYPTION_AT_REST_CONFIGURATION_VALIDATION_FAILED
         - ENCRYPTION_AT_REST_CONFIGURATION_VALIDATION_SUCCEEDED
         - ENCRYPTION_AT_REST_KEY_ROTATION_STARTED
+        - ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_CREATED
+        - ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_DELETED
         - NDS_SET_IMAGE_OVERRIDES
         - NDS_SET_CHEF_TARBALL_URI
         - RESTRICTED_EMPLOYEE_ACCESS_BYPASS
@@ -11896,6 +12237,9 @@ components:
         - OTEL_LOG_STREAMING_ENABLED
         - OTEL_LOG_STREAMING_CONFIGURATION_UPDATED
         - OTEL_LOG_STREAMING_DISABLED
+        - OTEL_METRIC_INTEGRATION_ENABLED
+        - OTEL_METRIC_INTEGRATION_CONFIGURATION_UPDATED
+        - OTEL_METRIC_INTEGRATION_DISABLED
         - AZURE_CLUSTER_PREFERRED_STORAGE_TYPE_UPDATED
         - CONTAINER_DELETED
         - REGIONALIZED_PRIVATE_ENDPOINT_MODE_ENABLED
@@ -11944,6 +12288,7 @@ components:
         - SHADOW_CLUSTER_REPLAY_STATUS_UPDATE
         - NODE_HIDDEN_BY_ADMIN
         - NODE_UNHIDDEN_BY_ADMIN
+        - CLUSTER_CREATED_VIA_ANIS
         - DB_CHECK_UPDATED
         - CLUSTER_SAMPLED_FOR_DB_CHECK
         - DB_CHECK_SCHEDULED_FOR_CLUSTER
@@ -11961,6 +12306,8 @@ components:
         - COMPUTE_AUTO_SCALE_INITIATED_ANALYTICS
         - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_BASE
         - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_ANALYTICS
+        - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_BASE
+        - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_ANALYTICS
         - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE
         - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_ANALYTICS
         - COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE
@@ -12092,6 +12439,10 @@ components:
         - RESOURCE_POLICY_VIOLATED
         - QUERY_SHAPE_BLOCKED
         - QUERY_SHAPE_UNBLOCKED
+        - SHARD_KEY_ANALYSIS_STARTED
+        - SHARD_KEY_ANALYSIS_FINISHED
+        - QUERY_SAMPLING_STARTED
+        - QUERY_SAMPLING_STOPPED
         - AI_MODELS_API_KEY_CREATED
         - AI_MODELS_API_KEY_DELETED
     EventTypeForOrg:
@@ -12284,6 +12635,12 @@ components:
         - ORG_INVOICE_OVER_THRESHOLD
         - ORG_DAILY_BILL_UNDER_THRESHOLD
         - ORG_DAILY_BILL_OVER_THRESHOLD
+        - ORG_DAILY_BILLING_CHANGE_NORMAL
+        - ORG_DAILY_BILLING_CHANGE_OVER_THRESHOLD
+        - ORG_WEEKLY_BILLING_CHANGE_NORMAL
+        - ORG_WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+        - ORG_MONTHLY_BILLING_CHANGE_NORMAL
+        - ORG_MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
         - ORG_GROUP_CHARGES_UNDER_THRESHOLD
         - ORG_GROUP_CHARGES_OVER_THRESHOLD
         - ORG_TWO_FACTOR_AUTH_REQUIRED
@@ -12320,6 +12677,7 @@ components:
         - SANDBOX_TEMPLATE_UPDATED
         - ORGANIZATION_VOYAGE_SETTINGS_CREATED
         - ORGANIZATION_VOYAGE_SETTINGS_DELETED
+        - PROJECT_CREATED_VIA_ANIS
         - AWS_SELF_SERVE_ACCOUNT_LINKED
         - AWS_SELF_SERVE_ACCOUNT_LINK_PENDING
         - AWS_SELF_SERVE_ACCOUNT_CANCELLED
@@ -12366,6 +12724,7 @@ components:
         - RESOURCE_POLICY_MODIFIED
         - RESOURCE_POLICY_DELETED
         - RESOURCE_POLICY_VIOLATED
+        - AI_MODELS_USAGE_TIER_UPDATED
     EventViewForNdsGroup:
       type: object
       properties:
@@ -13832,66 +14191,6 @@ components:
           type: boolean
       title: Flex Cluster Description Update
       type: object
-    FlexClusterMetricThreshold:
-      description: Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics about the serverless database.
-      properties:
-        metricName:
-          description: Human-readable label that identifies the metric against which MongoDB Cloud checks the configured `metricThreshold.threshold`.
-          type: string
-        mode:
-          description: MongoDB Cloud computes the current metric value as an average.
-          enum:
-            - AVERAGE
-          type: string
-        operator:
-          description: Comparison operator to apply when checking the current metric value.
-          enum:
-            - LESS_THAN
-            - GREATER_THAN
-          type: string
-        threshold:
-          description: Value of metric that, when exceeded, triggers an alert.
-          format: double
-          type: number
-        units:
-          $ref: "#/components/schemas/TimeMetricUnits"
-      required:
-        - metricName
-      title: Flex Cluster Metric Threshold
-      type: object
-      x-xgen-discriminator:
-        propertyName: metricName
-        mapping:
-          FLEX_AVG_COMMAND_EXECUTION_TIME:
-            properties: []
-          FLEX_AVG_READ_EXECUTION_TIME:
-            properties: []
-          FLEX_AVG_WRITE_EXECUTION_TIME:
-            properties: []
-          FLEX_CONNECTIONS:
-            properties: []
-          FLEX_CONNECTIONS_PERCENT:
-            properties: []
-          FLEX_DATA_SIZE_TOTAL:
-            properties: []
-          FLEX_NETWORK_BYTES_IN:
-            properties: []
-          FLEX_NETWORK_BYTES_OUT:
-            properties: []
-          FLEX_NETWORK_NUM_REQUESTS:
-            properties: []
-          FLEX_OPCOUNTER_CMD:
-            properties: []
-          FLEX_OPCOUNTER_DELETE:
-            properties: []
-          FLEX_OPCOUNTER_GETMORE:
-            properties: []
-          FLEX_OPCOUNTER_INSERT:
-            properties: []
-          FLEX_OPCOUNTER_QUERY:
-            properties: []
-          FLEX_OPCOUNTER_UPDATE:
-            properties: []
     FlexConnectionStrings20241113:
       description: Collection of Uniform Resource Locators that point to the MongoDB database.
       externalDocs:
@@ -14261,9 +14560,9 @@ components:
           readOnly: true
           type: string
         metricThreshold:
-          $ref: "#/components/schemas/FlexClusterMetricThreshold"
-        threshold:
           $ref: "#/components/schemas/StreamProcessorMetricThreshold"
+        threshold:
+          $ref: "#/components/schemas/DeprecatedStreamProcessorMetricThreshold"
     GroupIPAddresses:
       description: List of IP addresses in a project.
       properties:
@@ -16482,6 +16781,10 @@ components:
           description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
           example: logs/mongodb/
           type: string
+        useLegacyPathStructure:
+          description: "When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`."
+          nullable: true
+          type: boolean
         apiKey:
           description: API key for authentication.
           example: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6
@@ -16580,6 +16883,7 @@ components:
               - iamRoleId
               - kmsKey
               - prefixPath
+              - useLegacyPathStructure
             required:
               - bucketName
               - iamRoleId
@@ -16636,6 +16940,10 @@ components:
           description: Path prefix where the log files will be stored. Atlas will add further sub-directories based on the log type.
           example: logs/mongodb/
           type: string
+        useLegacyPathStructure:
+          description: "When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`."
+          nullable: true
+          type: boolean
         apiKey:
           description: API key for authentication.
           example: "****************************o5p6"
@@ -16735,6 +17043,7 @@ components:
               - iamRoleId
               - kmsKey
               - prefixPath
+              - useLegacyPathStructure
             required:
               - bucketName
               - iamRoleId
@@ -16798,6 +17107,7 @@ components:
         - PORT
         - HOSTNAME_AND_PORT
         - REPLICA_SET_NAME
+        - ATLAS_NODE_TYPE
         - SHARD_NAME
         - INSTANCE_NAME
         - PROCESSOR_NAME
@@ -17136,6 +17446,170 @@ components:
           readOnly: true
           type: number
       readOnly: true
+      type: object
+    MetricIntegrationRequest:
+      description: Request schema for creating a metric integration.
+      properties:
+        aggregationTemporality:
+          description: The temporality to send to the metric integration.
+          enum:
+            - DELTA
+            - CUMULATIVE
+          type: string
+        endpoint:
+          description: OpenTelemetry collector endpoint URL. Must use HTTPS.
+          example: https://otel-collector.example.com:4318/v1/metrics
+          maxLength: 2048
+          type: string
+        headers:
+          description: HTTP headers for authentication and configuration. Total size limit 2KB.
+          items:
+            $ref: "#/components/schemas/Header"
+          maxItems: 10
+          minItems: 1
+          type: array
+        integrationType:
+          description: Type of metric integration. Identifies which protocol will be used for the integration. This value cannot be modified after the integration is created.
+          enum:
+            - OTEL
+          type: string
+        metricSelection:
+          description: Array of metric categories to export. Determines which types of metrics are sent to the integration.
+          items:
+            enum:
+              - ATLAS_STREAM_PROCESSING
+            type: string
+          maxItems: 30
+          minItems: 1
+          type: array
+          uniqueItems: true
+        providerType:
+          description: The provider type for the metric integration. Identifies the third-party service provider.
+          enum:
+            - CUSTOM
+            - DYNATRACE
+            - NEW_RELIC
+          type: string
+      required:
+        - aggregationTemporality
+        - endpoint
+        - headers
+        - integrationType
+        - metricSelection
+        - providerType
+      title: Metric Integration Request
+      type: object
+    MetricIntegrationResponse:
+      description: Response schema for metric integration operations.
+      properties:
+        aggregationTemporality:
+          description: The temporality to send to the metric integration.
+          enum:
+            - DELTA
+            - CUMULATIVE
+          type: string
+        endpoint:
+          description: OpenTelemetry collector endpoint URL.
+          example: https://otel-collector.example.com:4318/v1/metrics
+          maxLength: 2048
+          type: string
+        headers:
+          description: HTTP headers for authentication and configuration. Header values are redacted in responses.
+          items:
+            $ref: "#/components/schemas/Header"
+          maxItems: 10
+          minItems: 1
+          type: array
+        integrationType:
+          description: Type of metric integration. Identifies which protocol will be used for the integration.
+          enum:
+            - OTEL
+          type: string
+        metricIntegrationId:
+          description: Unique hexadecimal digit string that identifies the metric integration configuration.
+          example: 507f1f77bcf86cd799439011
+          maxLength: 24
+          minLength: 24
+          readOnly: true
+          type: string
+        metricSelection:
+          description: Array of metric categories to export. Determines which types of metrics are sent to the integration.
+          items:
+            enum:
+              - ATLAS_STREAM_PROCESSING
+            type: string
+          maxItems: 30
+          minItems: 1
+          type: array
+          uniqueItems: true
+        providerType:
+          description: The provider type for the metric integration. Identifies the third-party service provider.
+          enum:
+            - CUSTOM
+            - DYNATRACE
+            - NEW_RELIC
+          type: string
+      required:
+        - aggregationTemporality
+        - endpoint
+        - headers
+        - integrationType
+        - metricIntegrationId
+        - metricSelection
+        - providerType
+      title: Metric Integration Response
+      type: object
+    MetricIntegrationUpdateRequest:
+      description: Request schema for updating a metric integration.
+      properties:
+        aggregationTemporality:
+          description: The temporality to send to the metric integration.
+          enum:
+            - DELTA
+            - CUMULATIVE
+          type: string
+        endpoint:
+          description: OpenTelemetry collector endpoint URL. Must use HTTPS.
+          example: https://otel-collector.example.com:4318/v1/metrics
+          maxLength: 2048
+          type: string
+        headers:
+          description: HTTP headers for authentication and configuration. Total size limit 2KB.
+          items:
+            $ref: "#/components/schemas/Header"
+          maxItems: 10
+          minItems: 1
+          type: array
+        integrationType:
+          description: Type of metric integration. Identifies which protocol will be used for the integration. This value cannot be modified after the integration is created.
+          enum:
+            - OTEL
+          type: string
+        metricSelection:
+          description: Array of metric categories to export. Determines which types of metrics are sent to the integration.
+          items:
+            enum:
+              - ATLAS_STREAM_PROCESSING
+            type: string
+          maxItems: 30
+          minItems: 1
+          type: array
+          uniqueItems: true
+        providerType:
+          description: The provider type for the metric integration. Identifies the third-party service provider.
+          enum:
+            - CUSTOM
+            - DYNATRACE
+            - NEW_RELIC
+          type: string
+      required:
+        - aggregationTemporality
+        - endpoint
+        - headers
+        - integrationType
+        - metricSelection
+        - providerType
+      title: Metric Integration Update Request
       type: object
     MetricsMeasurement:
       properties:
@@ -18345,6 +18819,58 @@ components:
       required:
         - results
       type: object
+    PaginatedApiAtlasCollectionRestoreCollectionStateView:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/ApiAtlasCollectionRestoreCollectionStateResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
+    PaginatedApiAtlasCollectionRestoreJobView:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/ApiAtlasCollectionRestoreJobResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
     PaginatedApiAtlasDatabaseUserView:
       description: List of MongoDB Database users granted access to databases in the specified project.
       properties:
@@ -18361,6 +18887,58 @@ components:
           description: List of returned documents that MongoDB Cloud provides when completing this request.
           items:
             $ref: "#/components/schemas/CloudDatabaseUser"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
+    PaginatedApiAtlasDiskBackupCollectionView:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/DiskBackupCollectionResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
+    PaginatedApiAtlasDiskBackupDatabaseView:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/DiskBackupDatabaseResponse"
           readOnly: true
           type: array
         totalCount:
@@ -19590,6 +20168,32 @@ components:
           description: List of returned documents that MongoDB Cloud provides when completing this request.
           items:
             $ref: "#/components/schemas/LogIntegrationResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
+    PaginatedMetricIntegrationResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/MetricIntegrationResponse"
           readOnly: true
           type: array
         totalCount:
@@ -22418,6 +23022,41 @@ components:
         - managedAuthentication
         - ssl
       type: object
+    StartStreamProcessorWithPreviewView:
+      description: A request to start a stream processor.
+      properties:
+        failover:
+          $ref: "#/components/schemas/StreamsStartProcessorFailover"
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        resumeFromCheckpoint:
+          description: When true or not specified, the stream processor resumes from its last checkpoint. When false, the stream processor starts fresh.
+          type: boolean
+        startAtOperationTime:
+          description: The operation time after which the change stream source should begin reporting. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+          externalDocs:
+            description: ISO 8601
+            url: https://en.wikipedia.org/wiki/ISO_8601
+          format: date-time
+          type: string
+        tier:
+          description: Selected tier for the Stream Workspace. Configures Memory / VCPU allowances.
+          enum:
+            - SP50
+            - SP30
+            - SP10
+            - SP5
+            - SP2
+          title: Stream Workspace Tier
+          type: string
+      type: object
     StateReason:
       description: State reason of the Job. This is set when the job state is "Failed".
       properties:
@@ -23051,16 +23690,18 @@ components:
           description: |-
             Vendor that manages the cloud service. The list of supported vendor values is:
             - AWS
-            -- MSK for AWS MSK Kafka clusters
-            -- CONFLUENT for Confluent Kafka clusters on AWS
-            -- KINESIS for AWS Kinesis Data Streams
+            -- `MSK` for AWS MSK Kafka clusters
+            -- `CONFLUENT` for Confluent Kafka clusters on AWS
+            -- `KINESIS` for AWS Kinesis Data Streams
 
             - Azure
-            -- EVENTHUB for Azure EventHub.
-            -- CONFLUENT for Confluent Kafka clusters on Azure
+            -- `EVENTHUB` for Azure EventHub.
+            -- `CONFLUENT` for Confluent Kafka clusters on Azure
+            -- `AZURE_BLOB_STORAGE` for Azure Blob Storage
 
             - GCP
-            -- CONFLUENT for Confluent Kafka clusters on GCP
+            -- `CONFLUENT` for Confluent Kafka clusters on GCP
+            -- `PUBSUB` for Google Cloud Pub/Sub
 
             **NOTE** Omitting the vendor field will default to using the GENERIC vendor.
           type: string
@@ -23098,6 +23739,16 @@ components:
           items:
             $ref: "#/components/schemas/Document"
           type: array
+        tier:
+          description: Selected tier for the Stream Workspace. Configures Memory / VCPU allowances.
+          enum:
+            - SP50
+            - SP30
+            - SP10
+            - SP5
+            - SP2
+          title: Stream Workspace Tier
+          type: string
       type: object
     StreamsProcessorWithStats:
       description: An atlas stream processor with optional stats.
@@ -23166,7 +23817,7 @@ components:
         - state
       type: object
     StreamsPublicPrivateLinkNetworking:
-      description: Networking configuration for connections that support `PUBLIC` and `PRIVATE_LINK` access types.
+      description: Networking configuration for connections that support `PUBLIC` and `PRIVATE_LINK` access types. For GCP connections, use `PRIVATE_LINK` for GCP Private Service Connect (PSC).
       properties:
         access:
           $ref: "#/components/schemas/StreamsPublicPrivateLinkNetworkingAccess"
@@ -23184,7 +23835,7 @@ components:
       description: Information about networking access.
       properties:
         connectionId:
-          description: The ID of the Private Link connection. Required for `PRIVATE_LINK` type.
+          description: The ID of the Private Link connection. Required for `PRIVATE_LINK` type. For GCP connections using Private Service Connect (PSC), this is the PSC connection ID.
           example: 32b6e34b3d91647abb20e7b8
           pattern: ^([a-f0-9]{24})$
           type: string
@@ -23198,7 +23849,7 @@ components:
           readOnly: true
           type: array
         type:
-          description: Selected networking type. Either `PUBLIC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
+          description: Selected networking type. Either `PUBLIC` or `PRIVATE_LINK`. Defaults to `PUBLIC`. For AWS, Azure, and GCP connections, use `PRIVATE_LINK` for AWS PrivateLink, Azure Private Link, or GCP Private Service Connect (PSC) respectively.
           enum:
             - PUBLIC
             - PRIVATE_LINK
@@ -23221,6 +23872,25 @@ components:
           default: false
           description: Flag that indicates whether to add a `sample_stream_solar` connection.
           type: boolean
+      type: object
+    StreamsStartProcessorFailover:
+      description: Failover options for starting a stream processor.
+      properties:
+        dryRun:
+          description: If true, simulates the operation without making any changes.
+          type: boolean
+        mode:
+          description: "Strategy for the processor: GRACEFUL - attempt to stop the processor, error if processor cannot be stopped. if stop was successful, start the processor in the new region with the latest checkpoint.  FORCED - attempt to stop the processor, proceed to starting the processor in the new region with checkpoints disabled regardless of whether or not the stop succeeds."
+          enum:
+            - GRACEFUL
+            - FORCED
+          type: string
+        region:
+          description: Cloud provider region where the stream processor should be started in failover mode. The region must be a valid region for the stream processor's cloud provider and must be included in the tenant's configured failover regions, or it may be the tenant's default (primary) region.
+          example: VIRGINIA_USA
+          type: string
+      required:
+        - region
       type: object
     StreamsStartStreamProcessorWith:
       description: A request to start a stream processor.
@@ -23733,19 +24403,6 @@ components:
               - url
             required:
               - url
-    TimeMetricUnits:
-      default: HOURS
-      description: Element used to express the quantity. This can be an element of time, storage capacity, and the like.
-      enum:
-        - NANOSECONDS
-        - MILLISECONDS
-        - MILLION_MINUTES
-        - SECONDS
-        - MINUTES
-        - HOURS
-        - DAYS
-      title: Time Metric Units
-      type: string
     TriggerIngestionPipelineRequest:
       properties:
         datasetRetentionPolicy:
@@ -23919,6 +24576,7 @@ components:
               - Legacy Backup
               - AI Models
               - Automated Embedding
+              - Native Reranking
               - Flex Consulting
               - Support
               - Credits
@@ -24816,7 +25474,7 @@ info:
   termsOfService: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
   title: MongoDB Atlas Administration API
   version: "2.0"
-  x-xgen-sha: 89ed99cad2b18e0be76ec5ab02184ba4c31b13c7
+  x-xgen-sha: a19351f3e69de146edafd83d797e6e9d118f6e8e
 openapi: 3.0.1
 paths:
   /api/atlas/v2:
@@ -24976,11 +25634,25 @@ paths:
       parameters:
         - $ref: "#/components/parameters/envelope"
         - $ref: "#/components/parameters/pretty"
-        - description: Human-readable label that identifies the user-managed limit whose description you want to retrieve.
+        - description: Identifies the user-managed limit.
           in: path
           name: limitName
           required: true
           schema:
+            enum:
+              - MONGODB_USERS
+              - NUM_CLUSTERS
+              - NUM_SERVERLESS_MTMS
+              - NUM_USER_CUSTOM_ROLES
+              - MAX_NETWORK_PERMISSION_ENTRIES
+              - MAX_CROSS_REGION_NETWORK_PERMISSION_ENTRIES
+              - MAX_NODES_PER_PRIVATELINK_REGION
+              - BYTES_PROCESSED_QUERY
+              - BYTES_PROCESSED_DAILY
+              - BYTES_PROCESSED_WEEKLY
+              - BYTES_PROCESSED_MONTHLY
+              - NUM_PRIVATE_SERVICE_CONNECTIONS_PER_REGION_GROUP
+              - GCP_PSC_NAT_SUBNET_MASK
             type: string
       responses:
         "200":
@@ -24997,8 +25669,6 @@ paths:
               $ref: "#/components/headers/HeaderRateLimitLimit"
             RateLimit-Remaining:
               $ref: "#/components/headers/HeaderRateLimitRemaining"
-        "400":
-          $ref: "#/components/responses/badRequest"
         "401":
           $ref: "#/components/responses/unauthorized"
         "403":
@@ -25047,6 +25717,9 @@ paths:
       summary: Return All Event Types
       tags:
         - Events
+      x-rolesRequirements:
+        - Organization Member
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/listEventTypes
   /api/atlas/v2/federationSettings/{federationSettingsId}:
     delete:
@@ -25080,6 +25753,8 @@ paths:
       summary: Delete One Federation Settings Instance
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/deleteFederationSetting
   /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs:
     get:
@@ -25118,6 +25793,8 @@ paths:
       summary: Return All Organization Configurations from One Federation
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/listFederationSettingConnectedOrgConfigs
       x-xgen-operation-id-override: listConnectedOrgConfigs
   /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}:
@@ -25161,6 +25838,8 @@ paths:
       summary: Remove One Organization Configuration from One Federation
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/removeFederationSettingConnectedOrgConfig
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -25208,6 +25887,8 @@ paths:
       summary: Return One Organization Configuration from One Federation
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingConnectedOrgConfig
       x-xgen-operation-id-override: getConnectedOrgConfig
     patch:
@@ -25268,6 +25949,8 @@ paths:
       summary: Update One Organization Configuration in One Federation
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/updateFederationSettingConnectedOrgConfig
       x-xgen-operation-id-override: updateConnectedOrgConfig
   /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings:
@@ -25306,6 +25989,8 @@ paths:
       summary: Return All Role Mappings from One Organization
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/listFederationSettingConnectedOrgConfigRoleMappings
       x-xgen-operation-id-override: listRoleMappings
     post:
@@ -25350,6 +26035,8 @@ paths:
       summary: Create One Role Mapping in One Organization Configuration
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/createFederationSettingConnectedOrgConfigRoleMapping
       x-xgen-operation-id-override: createRoleMapping
   /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}:
@@ -25394,6 +26081,8 @@ paths:
       summary: Remove One Role Mapping from One Organization
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/deleteFederationSettingConnectedOrgConfigRoleMapping
       x-xgen-operation-id-override: deleteRoleMapping
     get:
@@ -25439,6 +26128,8 @@ paths:
       summary: Return One Role Mapping from One Organization
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingConnectedOrgConfigRoleMapping
       x-xgen-operation-id-override: getRoleMapping
     put:
@@ -25491,6 +26182,8 @@ paths:
       summary: Update One Role Mapping in One Organization
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/updateFederationSettingConnectedOrgConfigRoleMapping
       x-xgen-operation-id-override: updateRoleMapping
   /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders:
@@ -25552,6 +26245,8 @@ paths:
       summary: Return All Identity Providers in One Federation
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/listFederationSettingIdentityProviders
       x-xgen-operation-id-override: listIdentityProviders
     post:
@@ -25598,6 +26293,8 @@ paths:
       summary: Create One Identity Provider
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/createFederationSettingIdentityProvider
       x-xgen-operation-id-override: createIdentityProvider
   /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}:
@@ -25646,6 +26343,8 @@ paths:
       summary: Delete One Identity Provider
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/deleteFederationSettingIdentityProvider
       x-xgen-operation-id-override: deleteIdentityProvider
     get:
@@ -25694,6 +26393,8 @@ paths:
       summary: Return One Identity Provider by ID
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingIdentityProvider
       x-xgen-operation-id-override: getIdentityProvider
     patch:
@@ -25759,6 +26460,8 @@ paths:
       summary: Update One Identity Provider
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/updateFederationSettingIdentityProvider
       x-xgen-operation-id-override: updateIdentityProvider
   /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/jwks:
@@ -25807,6 +26510,8 @@ paths:
       summary: Revoke JWKS from One OIDC Identity Provider
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/revokeFederationSettingIdentityProviderJwks
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -25849,6 +26554,8 @@ paths:
       summary: Return Metadata of One Identity Provider
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingIdentityProviderMetadata
       x-xgen-method-verb-override:
         customMethod: false
@@ -25979,6 +26686,8 @@ paths:
       summary: Remove One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/deleteGroup
     get:
       description: Returns details about the specified project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -26015,6 +26724,8 @@ paths:
       summary: Return One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroup
     patch:
       description: Updates the human-readable label that identifies the specified project, or the tags associated with the project. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -26058,6 +26769,8 @@ paths:
       summary: Update One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroup
   /api/atlas/v2/groups/{groupId}/access:
     post:
@@ -26112,6 +26825,8 @@ paths:
       summary: Add One MongoDB Cloud User to One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/addGroupAccessUser
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -26157,6 +26872,8 @@ paths:
       summary: Return All Project IP Access List Entries
       tags:
         - Project IP Access List
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-changelog:
         2025-05-08: Corrects an issue where the endpoint would include Atlas internal entries.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/listGroupAccessListEntries
@@ -26214,6 +26931,8 @@ paths:
       summary: Add Entries to Project IP Access List
       tags:
         - Project IP Access List
+      x-rolesRequirements:
+        - Project Network Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/createGroupAccessListEntry
       x-xgen-method-verb-override:
         customMethod: false
@@ -26267,6 +26986,8 @@ paths:
       summary: Remove One Entry from One Project IP Access List
       tags:
         - Project IP Access List
+      x-rolesRequirements:
+        - Project Network Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/deleteGroupAccessListEntry
       x-xgen-method-verb-override:
         customMethod: false
@@ -26316,6 +27037,8 @@ paths:
       summary: Return One Project IP Access List Entry
       tags:
         - Project IP Access List
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/getGroupAccessListEntry
       x-xgen-method-verb-override:
         customMethod: false
@@ -26365,6 +27088,8 @@ paths:
       summary: Return Status of One Project IP Access List Entry
       tags:
         - Project IP Access List
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/getGroupAccessListStatus
       x-xgen-operation-id-override: getAccessListStatus
   /api/atlas/v2/groups/{groupId}/activityFeed:
@@ -26444,6 +27169,8 @@ paths:
       summary: Return Pre-Filtered Activity Feed Link for One Project
       tags:
         - Activity Feed
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Activity-Feed/operation/getGroupActivityFeed
   /api/atlas/v2/groups/{groupId}/aiModelApiKeys:
     get:
@@ -26483,6 +27210,8 @@ paths:
       summary: Return AI Model API Keys for One Group
       tags:
         - AI Model API Keys
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/listGroupAiModelApiKeys
       x-xgen-operation-id-override: listGroupModelKeys
     post:
@@ -26532,6 +27261,8 @@ paths:
       summary: Create New AI Model API Key
       tags:
         - AI Model API Keys
+      x-rolesRequirements:
+        - Project Model Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/createGroupAiModelApiKey
       x-xgen-operation-id-override: createModelApiKey
   /api/atlas/v2/groups/{groupId}/aiModelApiKeys/{apiKeyId}:
@@ -26576,6 +27307,8 @@ paths:
       summary: Delete Existing AI Model API Key
       tags:
         - AI Model API Keys
+      x-rolesRequirements:
+        - Project Model Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/deleteGroupAiModelApiKey
       x-xgen-operation-id-override: deleteModelApiKey
     get:
@@ -26619,6 +27352,8 @@ paths:
       summary: Return Single AI Model API Key for One Group
       tags:
         - AI Model API Keys
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/getGroupAiModelApiKey
       x-xgen-operation-id-override: getGroupModelKey
     patch:
@@ -26674,6 +27409,8 @@ paths:
       summary: Update Existing AI Model API Key
       tags:
         - AI Model API Keys
+      x-rolesRequirements:
+        - Project Model Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/updateGroupAiModelApiKey
       x-xgen-operation-id-override: updateModelApiKey
   /api/atlas/v2/groups/{groupId}/aiModelRateLimits:
@@ -26714,6 +27451,8 @@ paths:
       summary: Return AI Model Rate Limits for One Group
       tags:
         - AI Model Rate Limits
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listGroupAiModelRateLimits
       x-xgen-operation-id-override: listGroupModelLimits
   /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:
@@ -26758,6 +27497,8 @@ paths:
       summary: Return Single AI Model Rate Limit for One Group
       tags:
         - AI Model Rate Limits
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getGroupAiModelRateLimit
       x-xgen-operation-id-override: getGroupModelLimit
     patch:
@@ -26813,6 +27554,8 @@ paths:
       summary: Update AI Model Rate Limit
       tags:
         - AI Model Rate Limits
+      x-rolesRequirements:
+        - Project Model Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/updateGroupAiModelRateLimit
       x-xgen-operation-id-override: updateModelRateLimit
   /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:reset:
@@ -26857,6 +27600,8 @@ paths:
       summary: Reset AI Model Rate Limit for One Model Group
       tags:
         - AI Model Rate Limits
+      x-rolesRequirements:
+        - Project Model Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimit
       x-xgen-operation-id-override: resetModelRateLimit
   /api/atlas/v2/groups/{groupId}/aiModelRateLimits:reset:
@@ -26893,6 +27638,8 @@ paths:
       summary: Reset AI Model Rate Limits for Group
       tags:
         - AI Model Rate Limits
+      x-rolesRequirements:
+        - Project Model Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimits
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -26938,6 +27685,8 @@ paths:
       summary: Return All Alert Configurations in One Project
       tags:
         - Alert Configurations
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/listGroupAlertConfigs
       x-xgen-operation-id-override: listAlertConfigs
     post:
@@ -26985,6 +27734,8 @@ paths:
       summary: Create One Alert Configuration in One Project
       tags:
         - Alert Configurations
+      x-rolesRequirements:
+        - Project Alerts Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/createGroupAlertConfig
       x-xgen-operation-id-override: createAlertConfig
   /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}:
@@ -27033,6 +27784,8 @@ paths:
       summary: Remove One Alert Configuration from One Project
       tags:
         - Alert Configurations
+      x-rolesRequirements:
+        - Project Alerts Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/deleteGroupAlertConfig
       x-xgen-operation-id-override: deleteAlertConfig
     get:
@@ -27082,6 +27835,8 @@ paths:
       summary: Return One Alert Configuration from One Project
       tags:
         - Alert Configurations
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/getGroupAlertConfig
       x-xgen-operation-id-override: getAlertConfig
     patch:
@@ -27140,6 +27895,8 @@ paths:
       summary: Toggle State of One Alert Configuration in One Project
       tags:
         - Alert Configurations
+      x-rolesRequirements:
+        - Project Alerts Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/toggleGroupAlertConfig
       x-xgen-method-verb-override:
         customMethod: true
@@ -27203,6 +27960,8 @@ paths:
       summary: Update One Alert Configuration in One Project
       tags:
         - Alert Configurations
+      x-rolesRequirements:
+        - Project Alerts Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/updateGroupAlertConfig
       x-xgen-operation-id-override: updateAlertConfig
   /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}/alerts:
@@ -27256,6 +28015,8 @@ paths:
       summary: Return All Open Alerts for One Alert Configuration
       tags:
         - Alerts
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/getGroupAlertConfigAlerts
       x-xgen-operation-id-override: getAlertConfigAlerts
   /api/atlas/v2/groups/{groupId}/alerts:
@@ -27309,6 +28070,8 @@ paths:
       summary: Return All Alerts from One Project
       tags:
         - Alerts
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/listGroupAlerts
       x-xgen-operation-id-override: listAlerts
   /api/atlas/v2/groups/{groupId}/alerts/{alertId}:
@@ -27358,6 +28121,8 @@ paths:
       summary: Return One Alert from One Project
       tags:
         - Alerts
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/getGroupAlert
       x-xgen-operation-id-override: getAlert
     patch:
@@ -27423,6 +28188,8 @@ paths:
       summary: Acknowledge One Alert from One Project
       tags:
         - Alerts
+      x-rolesRequirements:
+        - Project Alerts Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/acknowledgeGroupAlert
       x-xgen-method-verb-override:
         customMethod: true
@@ -27478,6 +28245,8 @@ paths:
       summary: Return All Alert Configurations Set for One Alert
       tags:
         - Alert Configurations
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/getGroupAlertAlertConfigs
       x-xgen-operation-id-override: getAlertConfigs
   /api/atlas/v2/groups/{groupId}/apiKeys:
@@ -27520,6 +28289,8 @@ paths:
       summary: Return All Organization API Keys Assigned to One Project
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/listGroupApiKeys
     post:
       description: Creates and assigns the specified organization API key to the specified project. Users with the Project Owner role in the project associated with the API key can use the organization API key to access the resources. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Access Manager role.
@@ -27561,6 +28332,8 @@ paths:
       summary: Create and Assign One Organization API Key to One Project
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/createGroupApiKey
   /api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}:
     delete:
@@ -27606,6 +28379,8 @@ paths:
       summary: Unassign One Organization API Key from One Project
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/removeGroupApiKey
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -27662,6 +28437,8 @@ paths:
       summary: Update Organization API Key Roles for One Project
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/updateGroupApiKeyRoles
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -27715,6 +28492,8 @@ paths:
       summary: Assign One Organization API Key to One Project
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/addGroupApiKey
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -27753,6 +28532,8 @@ paths:
       summary: Return Auditing Configuration for One Project
       tags:
         - Auditing
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Auditing/operation/getGroupAuditLog
     patch:
       description: Updates the auditing configuration for the specified project. The auditing configuration defines the events that MongoDB Cloud records in the audit log. To use this resource, the requesting Service Account or API Key must have the Project Owner role. This feature isn't available for `M0`, `M2`, `M5`, or serverless clusters.
@@ -27796,6 +28577,8 @@ paths:
       summary: Update Auditing Configuration for One Project
       tags:
         - Auditing
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Auditing/operation/updateGroupAuditLog
       x-xgen-operation-id-override: updateAuditLog
   /api/atlas/v2/groups/{groupId}/awsCustomDNS:
@@ -27832,6 +28615,8 @@ paths:
       summary: Return One Custom DNS Configuration for Atlas Clusters on AWS
       tags:
         - AWS Clusters DNS
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AWS-Clusters-DNS/operation/getGroupAwsCustomDns
       x-xgen-operation-id-override: getAwsCustomDns
     patch:
@@ -27874,6 +28659,8 @@ paths:
       summary: Update State of One Custom DNS Configuration for Atlas Clusters on AWS
       tags:
         - AWS Clusters DNS
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AWS-Clusters-DNS/operation/toggleGroupAwsCustomDns
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -27924,6 +28711,8 @@ paths:
       summary: Return Object Storage Private Endpoints for Cloud Backups for One Cloud Provider in One Project
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupBackupPrivateEndpoints
       x-xgen-operation-id-override: listBackupPrivateEndpoints
     post:
@@ -27978,6 +28767,8 @@ paths:
       summary: Create One Object Storage Private Endpoint for Cloud Backups for One Cloud Provider in One Project
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupBackupPrivateEndpoint
       x-xgen-operation-id-override: createBackupPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/backup/{cloudProvider}/privateEndpoints/{endpointId}:
@@ -28027,6 +28818,8 @@ paths:
       summary: Delete One Object Storage Private Endpoint for Cloud Backups for One Cloud Provider from One Project
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupBackupPrivateEndpoint
       x-xgen-operation-id-override: deleteBackupPrivateEndpoint
     get:
@@ -28077,6 +28870,8 @@ paths:
       summary: Return One Object Storage Private Endpoint for Cloud Backups for One Cloud Provider in One Project
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupBackupPrivateEndpoint
       x-xgen-operation-id-override: getBackupPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/backup/exportBuckets:
@@ -28121,6 +28916,8 @@ paths:
       summary: Return All Snapshot Export Buckets
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupBackupExportBuckets
       x-xgen-operation-id-override: listExportBuckets
     post:
@@ -28252,6 +29049,8 @@ paths:
       summary: Create One Snapshot Export Bucket
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupBackupExportBucket
       x-xgen-operation-id-override: createExportBucket
   /api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}:
@@ -28295,6 +29094,8 @@ paths:
       summary: Delete One Snapshot Export Bucket
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupBackupExportBucket
       x-xgen-operation-id-override: deleteExportBucket
     get:
@@ -28390,6 +29191,8 @@ paths:
       summary: Return One Snapshot Export Bucket
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupBackupExportBucket
       x-xgen-operation-id-override: getExportBucket
     patch:
@@ -28443,6 +29246,8 @@ paths:
       summary: Update One Export Bucket Private Networking Settings
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupBackupExportBucket
       x-xgen-operation-id-override: updateBackupExportBucket
   /api/atlas/v2/groups/{groupId}/backupCompliancePolicy:
@@ -28479,6 +29284,8 @@ paths:
       summary: Disable Backup Compliance Policy Settings
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/disableGroupBackupCompliancePolicy
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -28522,6 +29329,8 @@ paths:
       summary: Return Backup Compliance Policy Settings
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupBackupCompliancePolicy
       x-xgen-operation-id-override: getCompliancePolicy
     put:
@@ -28582,6 +29391,8 @@ paths:
       summary: Update Backup Compliance Policy Settings
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupBackupCompliancePolicy
       x-xgen-operation-id-override: updateCompliancePolicy
   /api/atlas/v2/groups/{groupId}/cloudProviderAccess:
@@ -28618,6 +29429,8 @@ paths:
       summary: Return All Cloud Provider Access Roles
       tags:
         - Cloud Provider Access
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/listGroupCloudProviderAccess
       x-xgen-operation-id-override: listCloudProviderAccess
     post:
@@ -28663,6 +29476,8 @@ paths:
       summary: Create One Cloud Provider Access Role
       tags:
         - Cloud Provider Access
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/createGroupCloudProviderAccess
       x-xgen-operation-id-override: createCloudProviderAccess
   /api/atlas/v2/groups/{groupId}/cloudProviderAccess/{cloudProvider}/{roleId}:
@@ -28716,6 +29531,8 @@ paths:
       summary: Deauthorize One Cloud Provider Access Role
       tags:
         - Cloud Provider Access
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/deauthorizeGroupCloudProviderAccessRole
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -28762,6 +29579,8 @@ paths:
       summary: Return One Cloud Provider Access Role
       tags:
         - Cloud Provider Access
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/getGroupCloudProviderAccess
       x-xgen-operation-id-override: getCloudProviderAccess
     patch:
@@ -28818,6 +29637,8 @@ paths:
       summary: Authorize One Cloud Provider Access Role
       tags:
         - Cloud Provider Access
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/authorizeGroupCloudProviderAccessRole
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -28888,6 +29709,8 @@ paths:
       summary: Return All Clusters in One Project
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/listGroupClusters
       x-xgen-operation-id-override: listClusters
     post:
@@ -29130,6 +29953,8 @@ paths:
       summary: Create One Cluster in One Project
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Cluster Creator
       x-xgen-changelog:
         2025-06-05: Fixed a bug that previously permitted users to configure multiple regionConfigs for the same region and cloud provider within a replicationSpec
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createGroupCluster
@@ -29191,6 +30016,8 @@ paths:
       summary: Remove One Cluster from One Project
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/deleteGroupCluster
       x-xgen-operation-id-override: deleteCluster
     get:
@@ -29263,6 +30090,8 @@ paths:
       summary: Return One Cluster from One Project
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupCluster
       x-xgen-operation-id-override: getCluster
     patch:
@@ -29354,6 +30183,9 @@ paths:
       summary: Update One Cluster in One Project
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Cluster Manager
+        - Project Replica Set Manager
       x-xgen-changelog:
         2025-06-05: Fixed a bug that previously permitted users to configure multiple regionConfigs for the same region and cloud provider within a replicationSpec
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/updateGroupCluster
@@ -29451,6 +30283,8 @@ paths:
       summary: Return Cluster-Level Query Latency
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupClusterCollStatMeasurements
       x-xgen-operation-id-override: listCollStatMeasurements
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/{clusterView}/collStats/namespaces:
@@ -29506,6 +30340,8 @@ paths:
       summary: Return Ranked Namespaces from One Cluster
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/getGroupClusterCollStatNamespaces
       x-xgen-method-verb-override:
         customMethod: false
@@ -29555,6 +30391,8 @@ paths:
       summary: Return Auto Scaling Configuration for One Sharded Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/autoGroupClusterScalingConfiguration
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -29603,6 +30441,8 @@ paths:
       summary: Return All Snapshot Export Jobs
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupExports
       x-xgen-operation-id-override: listBackupExports
     post:
@@ -29655,6 +30495,8 @@ paths:
       summary: Create One Snapshot Export Job
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Export Operator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupClusterBackupExport
       x-xgen-operation-id-override: createBackupExport
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports/{exportId}:
@@ -29705,6 +30547,8 @@ paths:
       summary: Return One Snapshot Export Job
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupExport
       x-xgen-operation-id-override: getBackupExport
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs:
@@ -29751,6 +30595,8 @@ paths:
       summary: Return All Restore Jobs for One Cluster
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupRestoreJobs
       x-xgen-operation-id-override: listBackupRestoreJobs
     post:
@@ -29807,6 +30653,9 @@ paths:
       summary: Create One Restore Job of One Cluster
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Export Operator
+        - Project Backup Recovery Operator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupClusterBackupRestoreJob
       x-xgen-operation-id-override: createBackupRestoreJob
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs/{restoreJobId}:
@@ -29859,6 +30708,9 @@ paths:
       summary: Cancel One Restore Job for One Cluster
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Export Operator
+        - Project Backup Recovery Operator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/cancelGroupClusterBackupRestoreJob
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -29911,6 +30763,8 @@ paths:
       summary: Return One Restore Job for One Cluster
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupRestoreJob
       x-xgen-operation-id-override: getBackupRestoreJob
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule:
@@ -29960,6 +30814,8 @@ paths:
       summary: Remove All Cloud Backup Schedules
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupClusterBackupSchedule
       x-xgen-operation-id-override: deleteClusterBackupSchedule
     get:
@@ -30007,6 +30863,8 @@ paths:
       summary: Return One Cloud Backup Schedule
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSchedule
       x-xgen-method-verb-override:
         customMethod: "False"
@@ -30072,6 +30930,8 @@ paths:
       summary: Update Cloud Backup Schedule for One Cluster
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupClusterBackupSchedule
       x-xgen-operation-id-override: updateBackupSchedule
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots:
@@ -30092,6 +30952,24 @@ paths:
           schema:
             pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
             type: string
+        - description: Desired point in time, expressed as the number of seconds that have elapsed since the UNIX epoch. If specified, returns the closest snapshot created before that point in time. Mutually exclusive with `oplogTs` and `oplogInc`.
+          in: query
+          name: pointInTimeUtcSeconds
+          schema:
+            format: int64
+            type: integer
+        - description: Oplog timestamp that represents the desired point in time. This is the first part of an Oplog timestamp. Must be used with `oplogInc`. Mutually exclusive with `pointInTimeUtcSeconds`.
+          in: query
+          name: oplogTs
+          schema:
+            format: int64
+            type: integer
+        - description: Oplog operation number that represents the desired point in time. This is the second part of an Oplog timestamp. Must be used with `oplogTs`. Mutually exclusive with `pointInTimeUtcSeconds`.
+          in: query
+          name: oplogInc
+          schema:
+            format: int64
+            type: integer
       responses:
         "200":
           content:
@@ -30120,6 +30998,8 @@ paths:
       summary: Return All Replica Set Cloud Backups
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshots
       x-xgen-operation-id-override: listBackupSnapshots
     post:
@@ -30174,6 +31054,8 @@ paths:
       summary: Take One On-Demand Snapshot
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Creator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/takeGroupClusterBackupSnapshots
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -30227,6 +31109,8 @@ paths:
       summary: Remove One Replica Set Cloud Backup
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupClusterBackupSnapshot
       x-xgen-operation-id-override: deleteClusterBackupSnapshot
     get:
@@ -30278,6 +31162,8 @@ paths:
       summary: Return One Replica Set Cloud Backup
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshot
       x-xgen-operation-id-override: getClusterBackupSnapshot
     patch:
@@ -30336,8 +31222,260 @@ paths:
       summary: Update Expiration Date for One Cloud Backup
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupClusterBackupSnapshot
       x-xgen-operation-id-override: updateBackupSnapshot
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases:
+    get:
+      description: Returns the list of databases that exist in the specified snapshot. Use this to discover namespaces before creating a collection restore job. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+      operationId: listGroupClusterBackupSnapshotDatabases
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/includeCount"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+          in: path
+          name: snapshotId
+          required: true
+          schema:
+            pattern: ^([a-f0-9]{24})$
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiAtlasDiskBackupDatabaseView"
+              x-xgen-preview:
+                name: snapshot-namespaces
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Databases in One Snapshot
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshotDatabases
+      x-xgen-operation-id-override: listBackupSnapshotDatabases
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases/{databaseName}:
+    get:
+      description: Returns one database that exists in the specified snapshot. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+      operationId: getGroupClusterBackupSnapshotDatabase
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+          in: path
+          name: snapshotId
+          required: true
+          schema:
+            pattern: ^([a-f0-9]{24})$
+            type: string
+        - description: Human-readable label that identifies the database.
+          in: path
+          name: databaseName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/DiskBackupDatabaseResponse"
+              x-xgen-preview:
+                name: snapshot-namespaces
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Database in One Snapshot
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshotDatabase
+      x-xgen-operation-id-override: getBackupSnapshotDatabase
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases/{databaseName}/collections:
+    get:
+      description: Returns the list of collections in the specified database that exist in the snapshot. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+      operationId: listGroupClusterBackupSnapshotDatabaseCollections
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/includeCount"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+          in: path
+          name: snapshotId
+          required: true
+          schema:
+            pattern: ^([a-f0-9]{24})$
+            type: string
+        - description: Human-readable label that identifies the database.
+          in: path
+          name: databaseName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiAtlasDiskBackupCollectionView"
+              x-xgen-preview:
+                name: snapshot-namespaces
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Collections in One Database in One Snapshot
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshotDatabaseCollections
+      x-xgen-operation-id-override: listSnapshotDatabaseCollections
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases/{databaseName}/collections/{collectionName}:
+    get:
+      description: Returns one collection that exists in the specified database in the snapshot. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+      operationId: getGroupClusterBackupSnapshotDatabaseCollection
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+          in: path
+          name: snapshotId
+          required: true
+          schema:
+            pattern: ^([a-f0-9]{24})$
+            type: string
+        - description: Human-readable label that identifies the database.
+          in: path
+          name: databaseName
+          required: true
+          schema:
+            type: string
+        - description: Human-readable label that identifies the collection.
+          in: path
+          name: collectionName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/DiskBackupCollectionResponse"
+              x-xgen-preview:
+                name: snapshot-namespaces
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Collection in One Database in One Snapshot
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshotDatabaseCollection
+      x-xgen-operation-id-override: getSnapshotDatabaseCollection
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/shardedCluster/{snapshotId}:
     delete:
       description: Removes one snapshot of one sharded cluster from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
@@ -30384,6 +31522,8 @@ paths:
       summary: Remove One Sharded Cluster Cloud Backup
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupClusterBackupSnapshotShardedCluster
       x-xgen-operation-id-override: deleteBackupShardedCluster
     get:
@@ -30435,6 +31575,8 @@ paths:
       summary: Return One Sharded Cluster Cloud Backup
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshotShardedCluster
       x-xgen-operation-id-override: getBackupShardedCluster
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/shardedClusters:
@@ -30480,6 +31622,8 @@ paths:
       summary: Return All Sharded Cluster Cloud Backups
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshotShardedClusters
       x-xgen-operation-id-override: listBackupShardedClusters
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backupCheckpoints:
@@ -30527,6 +31671,8 @@ paths:
       summary: Return All Legacy Backup Checkpoints
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/listGroupClusterBackupCheckpoints
       x-xgen-operation-id-override: listClusterBackupCheckpoints
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backupCheckpoints/{checkpointId}:
@@ -30580,6 +31726,8 @@ paths:
       summary: Return One Legacy Backup Checkpoint
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterBackupCheckpoint
       x-xgen-operation-id-override: getClusterBackupCheckpoint
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned:
@@ -30624,6 +31772,8 @@ paths:
       summary: Return Pinned Namespaces
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupClusterCollStatPinnedNamespaces
       x-xgen-method-verb-override:
         customMethod: true
@@ -30689,6 +31839,8 @@ paths:
       summary: Add Pinned Namespaces
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/updateGroupClusterCollStatPinnedNamespaces
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -30754,6 +31906,8 @@ paths:
       summary: Pin Namespaces
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/pinGroupClusterCollStatPinnedNamespaces
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -30808,11 +31962,327 @@ paths:
       summary: Unpin Namespaces
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/unpinGroupClusterCollStatUnpinNamespaces
       x-xgen-method-verb-override:
         customMethod: "True"
         verb: unpinNamespaces
       x-xgen-operation-id-override: unpinNamespaces
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs:
+    get:
+      description: Returns all collection restore jobs for one cluster from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+      operationId: listGroupClusterCollectionRestoreJobs
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster with the collection restore jobs you want to return.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiAtlasCollectionRestoreJobView"
+              x-xgen-preview:
+                name: collection-restore-jobs
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Collection Restore Jobs for One Cluster
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterCollectionRestoreJobs
+      x-xgen-operation-id-override: listCollectionRestoreJobs
+    post:
+      description: Creates one collection-level restore job for one cluster from the specified project. Collection-level restores allow restoring specific databases or collections from a snapshot or point-in-time. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role or Project Backup Recovery Operator role.
+      operationId: createGroupClusterCollectionRestoreJob
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the source cluster for the restore.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/ApiAtlasCollectionRestoreJobRequest"
+            x-xgen-preview:
+              name: collection-restore-jobs
+            x-xgen-version: preview
+        description: Creates one collection-level restore job for one cluster from the specified project.
+        required: true
+      responses:
+        "201":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiAtlasCollectionRestoreJobResponse"
+              x-xgen-preview:
+                name: collection-restore-jobs
+              x-xgen-version: preview
+          description: Created
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "409":
+          $ref: "#/components/responses/conflict"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Create One Collection Restore Job
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Recovery Operator
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupClusterCollectionRestoreJob
+      x-xgen-operation-id-override: createCollectionRestoreJob
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs/{jobId}:
+    get:
+      description: Returns one collection restore job for one cluster from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+      operationId: getGroupClusterCollectionRestoreJob
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster with the collection restore jobs you want to return.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the collection restore job to return.
+          in: path
+          name: jobId
+          required: true
+          schema:
+            pattern: ^([a-f0-9]{24})$
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiAtlasCollectionRestoreJobResponse"
+              x-xgen-preview:
+                name: collection-restore-jobs
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Collection Restore Job for One Cluster
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterCollectionRestoreJob
+      x-xgen-operation-id-override: getCollectionRestoreJob
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs/{jobId}/collections:
+    get:
+      description: "Returns all collection-level restore states for one collection restore job from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role. Note: If the restore job is in the INITIALIZING state, this endpoint returns an empty list because collection-level states have not yet been created."
+      operationId: listGroupClusterCollectionRestoreJobCollections
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster with the collection restore job you want to return.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the collection restore job.
+          in: path
+          name: jobId
+          required: true
+          schema:
+            pattern: ^([a-f0-9]{24})$
+            type: string
+        - description: Collection-level state to filter by.
+          in: query
+          name: state
+          schema:
+            description: Current state of this collection within the restore job.
+            enum:
+              - NOT_STARTED
+              - IN_PROGRESS
+              - FINALIZING
+              - NOT_FOUND
+              - UNSUPPORTED
+              - SUCCESSFUL
+              - ROLLBACK
+              - NOT_RESTORED
+              - FAILED
+              - INDEX_BUILD_FAILED
+            type: string
+        - description: Source namespace to filter by (e.g. `db.collection`).
+          in: query
+          name: sourceNamespace
+          schema:
+            type: string
+        - description: Target namespace to filter by (e.g. `db.collection`).
+          in: query
+          name: targetNamespace
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiAtlasCollectionRestoreCollectionStateView"
+              x-xgen-preview:
+                name: collection-restore-jobs
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Collection States for One Collection Restore Job
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterCollectionRestoreJobCollections
+      x-xgen-operation-id-override: listRestoreJobCollections
+  /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs/{jobId}/collections/{sourceNamespace}:
+    get:
+      description: Returns one collection-level restore state for one collection restore job from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+      operationId: getGroupClusterCollectionRestoreJobCollection
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Human-readable label that identifies the cluster with the collection restore job you want to return.
+          in: path
+          name: clusterName
+          required: true
+          schema:
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the collection restore job.
+          in: path
+          name: jobId
+          required: true
+          schema:
+            pattern: ^([a-f0-9]{24})$
+            type: string
+        - description: Source namespace that identifies the collection to return (e.g. `db.collection`).
+          in: path
+          name: sourceNamespace
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiAtlasCollectionRestoreCollectionStateResponse"
+              x-xgen-preview:
+                name: collection-restore-jobs
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Collection State for One Collection Restore Job
+      tags:
+        - Cloud Backups
+      x-rolesRequirements:
+        - Project Backup Manager
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterCollectionRestoreJobCollection
+      x-xgen-operation-id-override: getRestoreJobCollection
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes:
     post:
       deprecated: true
@@ -30870,6 +32340,8 @@ paths:
       summary: Create One Atlas Search Index
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/createGroupClusterFtsIndex
       x-xgen-operation-id-override: createClusterFtsIndex
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}:
@@ -30933,6 +32405,11 @@ paths:
       summary: Return All Atlas Search Indexes for One Collection
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Search Index Editor
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/listGroupClusterFtsIndex
       x-xgen-method-verb-override:
         customMethod: false
@@ -30991,6 +32468,8 @@ paths:
       summary: Remove One Atlas Search Index
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterFtsIndex
       x-xgen-operation-id-override: deleteClusterFtsIndex
     get:
@@ -31045,6 +32524,11 @@ paths:
       summary: Return One Atlas Search Index
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Search Index Editor
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterFtsIndex
       x-xgen-operation-id-override: getClusterFtsIndex
     patch:
@@ -31110,6 +32594,8 @@ paths:
       summary: Update One Atlas Search Index
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterFtsIndex
       x-xgen-operation-id-override: updateClusterFtsIndex
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites:
@@ -31182,6 +32668,8 @@ paths:
       summary: Return One Managed Namespace in One Global Cluster
       tags:
         - Global Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/getGroupClusterGlobalWrites
       x-xgen-operation-id-override: getClusterGlobalWrites
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping:
@@ -31254,6 +32742,8 @@ paths:
       summary: Remove All Custom Zone Mappings from One Global Cluster
       tags:
         - Global Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/deleteGroupClusterGlobalWriteCustomZoneMapping
       x-xgen-operation-id-override: deleteCustomZoneMapping
     post:
@@ -31341,6 +32831,8 @@ paths:
       summary: Add One Custom Zone Mapping to One Global Cluster
       tags:
         - Global Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/createGroupClusterGlobalWriteCustomZoneMapping
       x-xgen-operation-id-override: createCustomZoneMapping
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces:
@@ -31425,6 +32917,8 @@ paths:
       summary: Remove One Managed Namespace from One Global Cluster
       tags:
         - Global Clusters
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/deleteGroupClusterGlobalWriteManagedNamespaces
       x-xgen-operation-id-override: deleteManagedNamespaces
     post:
@@ -31514,6 +33008,8 @@ paths:
       summary: Create One Managed Namespace in One Global Cluster
       tags:
         - Global Clusters
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/createGroupClusterGlobalWriteManagedNamespace
       x-xgen-operation-id-override: createManagedNamespace
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index:
@@ -31625,6 +33121,8 @@ paths:
           $ref: "#/components/responses/forbidden"
         "404":
           $ref: "#/components/responses/notFound"
+        "409":
+          $ref: "#/components/responses/conflict"
         "429":
           $ref: "#/components/responses/tooManyRequests"
         "500":
@@ -31632,8 +33130,12 @@ paths:
       summary: Create One Rolling Index
       tags:
         - Rolling Index
+      x-rolesRequirements:
+        - Project Data Access Admin
+        - Project Index Manager
       x-xgen-changelog:
         2025-05-08: Corrects an issue where the endpoint would allow a rolling index build to be initiated while there was already an index build in progress. The endpoint now returns 400 if an index build is already in progress.
+        2026-04-06: Corrects an issue where index creation was throwing a 500 error instead of a 409 error when there was an existing index with the same name.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rolling-Index/operation/createGroupClusterIndexRollingIndex
       x-xgen-method-verb-override:
         customMethod: false
@@ -31689,6 +33191,8 @@ paths:
       summary: Return All Lifecycle Management Policies for One Cluster
       tags:
         - Lifecycle Management
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/listGroupClusterLifecycleManagementPolicies
       x-xgen-operation-id-override: listLifecycleManagementPolicies
     post:
@@ -31752,6 +33256,8 @@ paths:
       summary: Create One Lifecycle Management Policy
       tags:
         - Lifecycle Management
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/createGroupClusterLifecycleManagementPolicy
       x-xgen-operation-id-override: createLifecycleManagementPolicy
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/lifecycleManagementPolicies/{policyId}:
@@ -31809,6 +33315,8 @@ paths:
       summary: Delete One Lifecycle Management Policy
       tags:
         - Lifecycle Management
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/deleteGroupClusterLifecycleManagementPolicy
       x-xgen-operation-id-override: deleteLifecycleManagementPolicy
     get:
@@ -31865,6 +33373,8 @@ paths:
       summary: Return One Lifecycle Management Policy
       tags:
         - Lifecycle Management
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/getGroupClusterLifecycleManagementPolicy
       x-xgen-operation-id-override: getLifecycleManagementPolicy
     patch:
@@ -31935,6 +33445,8 @@ paths:
       summary: Update One Lifecycle Management Policy
       tags:
         - Lifecycle Management
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/updateGroupClusterLifecycleManagementPolicy
       x-xgen-operation-id-override: updateLifecycleManagementPolicy
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives:
@@ -31984,6 +33496,8 @@ paths:
       summary: Return All Online Archives for One Cluster
       tags:
         - Online Archive
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/listGroupClusterOnlineArchives
       x-xgen-operation-id-override: listOnlineArchives
     post:
@@ -32040,6 +33554,8 @@ paths:
       summary: Create One Online Archive
       tags:
         - Online Archive
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-changelog:
         2023-08-02: If 'criteria':'DATE' is specified, then you must specify 'DATE' values in partition fields
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/createGroupClusterOnlineArchive
@@ -32093,6 +33609,8 @@ paths:
       summary: Remove One Online Archive
       tags:
         - Online Archive
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/deleteGroupClusterOnlineArchive
       x-xgen-operation-id-override: deleteOnlineArchive
     get:
@@ -32147,6 +33665,8 @@ paths:
       summary: Return One Online Archive
       tags:
         - Online Archive
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/getGroupClusterOnlineArchive
       x-xgen-operation-id-override: getOnlineArchive
     patch:
@@ -32210,6 +33730,8 @@ paths:
       summary: Update One Online Archive
       tags:
         - Online Archive
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/updateGroupClusterOnlineArchive
       x-xgen-operation-id-override: updateOnlineArchive
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz:
@@ -32281,6 +33803,11 @@ paths:
       summary: Download Online Archive Query Logs
       tags:
         - Online Archive
+      x-rolesRequirements:
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/downloadGroupClusterOnlineArchiveQueryLogs
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -32332,6 +33859,10 @@ paths:
       summary: End One Outage Simulation
       tags:
         - Cluster Outage Simulation
+      x-rolesRequirements:
+        - Project Cluster Manager
+        - Project Cluster Resilience Tester
+        - Project Replica Set Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cluster-Outage-Simulation/operation/endGroupClusterOutageSimulation
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -32382,6 +33913,8 @@ paths:
       summary: Return One Outage Simulation
       tags:
         - Cluster Outage Simulation
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cluster-Outage-Simulation/operation/getGroupClusterOutageSimulation
       x-xgen-method-verb-override:
         customMethod: false
@@ -32439,6 +33972,10 @@ paths:
       summary: Start One Outage Simulation
       tags:
         - Cluster Outage Simulation
+      x-rolesRequirements:
+        - Project Cluster Manager
+        - Project Cluster Resilience Tester
+        - Project Replica Set Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cluster-Outage-Simulation/operation/startGroupClusterOutageSimulation
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -32485,6 +34022,8 @@ paths:
       summary: Return All Suggested Indexes to Drop
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupClusterPerformanceAdvisorDropIndexSuggestions
       x-xgen-operation-id-override: listDropIndexSuggestions
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/performanceAdvisor/schemaAdvice:
@@ -32528,6 +34067,8 @@ paths:
       summary: Return Schema Advice
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupClusterPerformanceAdvisorSchemaAdvice
       x-xgen-operation-id-override: listSchemaAdvice
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/performanceAdvisor/suggestedIndexes:
@@ -32610,6 +34151,8 @@ paths:
       summary: Return All Suggested Indexes
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupClusterPerformanceAdvisorSuggestedIndexes
       x-xgen-operation-id-override: listClusterSuggestedIndexes
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs:
@@ -32663,6 +34206,8 @@ paths:
       summary: Return Advanced Configuration Options for One Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupClusterProcessArgs
       x-xgen-operation-id-override: getProcessArgs
     patch:
@@ -32727,6 +34272,8 @@ paths:
       summary: Update Advanced Configuration Options for One Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/updateGroupClusterProcessArgs
       x-xgen-operation-id-override: updateProcessArgs
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/queryShapeInsights/{queryShapeHash}/details:
@@ -32811,6 +34358,8 @@ paths:
       summary: Return Query Shape Details
       tags:
         - Query Shape Insights
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/getGroupClusterQueryShapeInsightDetails
       x-xgen-operation-id-override: getQueryShapeDetails
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/queryShapeInsights/summaries:
@@ -32958,6 +34507,8 @@ paths:
       summary: Return Query Statistic Summaries
       tags:
         - Query Shape Insights
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/listGroupClusterQueryShapeInsightSummaries
       x-xgen-operation-id-override: listQueryShapeSummaries
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/queryShapes:
@@ -33014,6 +34565,8 @@ paths:
       summary: Return All Query Shapes
       tags:
         - Query Shape Insights
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/listGroupClusterQueryShapes
       x-xgen-operation-id-override: listClusterQueryShapes
       x-xgen-version: 2025-03-12
@@ -33067,6 +34620,8 @@ paths:
       summary: Return One Query Shape
       tags:
         - Query Shape Insights
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/getGroupClusterQueryShape
       x-xgen-operation-id-override: getClusterQueryShape
       x-xgen-version: 2025-03-12
@@ -33126,6 +34681,8 @@ paths:
       summary: Update Query Shape Rejection Status
       tags:
         - Query Shape Insights
+      x-rolesRequirements:
+        - Project Data Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/updateGroupClusterQueryShape
       x-xgen-operation-id-override: updateClusterQueryShape
       x-xgen-version: 2025-03-12
@@ -33171,6 +34728,8 @@ paths:
       summary: Test Failover for One Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/restartGroupClusterPrimaries
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -33234,6 +34793,8 @@ paths:
       summary: Return All Legacy Backup Restore Jobs
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/listGroupClusterRestoreJobs
       x-xgen-operation-id-override: listClusterRestoreJobs
     post:
@@ -33289,6 +34850,8 @@ paths:
       summary: Create One Legacy Backup Restore Job
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/createGroupClusterRestoreJob
       x-xgen-operation-id-override: createClusterRestoreJob
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs/{jobId}:
@@ -33348,6 +34911,8 @@ paths:
       summary: Return One Legacy Backup Restore Job
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterRestoreJob
       x-xgen-operation-id-override: getClusterRestoreJob
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment:
@@ -33404,6 +34969,8 @@ paths:
       summary: Delete Search Nodes
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterSearchDeployment
       x-xgen-operation-id-override: deleteClusterSearchDeployment
     get:
@@ -33458,6 +35025,8 @@ paths:
       summary: Return All Search Nodes
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-changelog:
         2025-03-12: Updates the return of the API when no nodes exist, the endpoint returns 200 with an empty JSON ({}) instead of 400.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterSearchDeployment
@@ -33524,6 +35093,8 @@ paths:
       summary: Update Search Nodes
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterSearchDeployment
       x-xgen-operation-id-override: updateClusterSearchDeployment
     post:
@@ -33593,6 +35164,8 @@ paths:
       summary: Create Search Nodes
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/createGroupClusterSearchDeployment
       x-xgen-operation-id-override: createClusterSearchDeployment
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes:
@@ -33650,6 +35223,11 @@ paths:
       summary: Return All Atlas Search Indexes for One Cluster
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Search Index Editor
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/listGroupClusterSearchIndexes
       x-xgen-operation-id-override: listClusterSearchIndexes
     post:
@@ -33706,6 +35284,8 @@ paths:
       summary: Create One Atlas Search Index
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/createGroupClusterSearchIndex
       x-xgen-operation-id-override: createClusterSearchIndex
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}:
@@ -33775,6 +35355,11 @@ paths:
       summary: Return All Atlas Search Indexes for One Collection
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Search Index Editor
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/listGroupClusterSearchIndex
       x-xgen-method-verb-override:
         customMethod: false
@@ -33842,6 +35427,8 @@ paths:
       summary: Remove One Atlas Search Index by Name
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterSearchIndexByName
       x-xgen-method-verb-override:
         customMethod: true
@@ -33910,6 +35497,11 @@ paths:
       summary: Return One Atlas Search Index by Name
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Search Index Editor
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterSearchIndexByName
       x-xgen-method-verb-override:
         customMethod: true
@@ -33987,6 +35579,8 @@ paths:
       summary: Update One Atlas Search Index by Name
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterSearchIndexByName
       x-xgen-method-verb-override:
         customMethod: true
@@ -34043,6 +35637,8 @@ paths:
       summary: Remove One Atlas Search Index by ID
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterSearchIndex
       x-xgen-operation-id-override: deleteClusterSearchIndex
     get:
@@ -34103,6 +35699,11 @@ paths:
       summary: Return One Atlas Search Index by ID
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Search Index Editor
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterSearchIndex
       x-xgen-operation-id-override: getClusterSearchIndex
     patch:
@@ -34166,6 +35767,8 @@ paths:
       summary: Update One Atlas Search Index by ID
       tags:
         - Atlas Search
+      x-rolesRequirements:
+        - Project Search Index Editor
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterSearchIndex
       x-xgen-operation-id-override: updateClusterSearchIndex
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule:
@@ -34216,6 +35819,8 @@ paths:
       summary: Return One Snapshot Schedule
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterSnapshotSchedule
       x-xgen-operation-id-override: getClusterSnapshotSchedule
     patch:
@@ -34274,6 +35879,8 @@ paths:
       summary: Update Snapshot Schedule for One Cluster
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/updateGroupClusterSnapshotSchedule
       x-xgen-operation-id-override: updateClusterSnapshotSchedule
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots:
@@ -34334,6 +35941,8 @@ paths:
       summary: Return All Legacy Backup Snapshots
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/listGroupClusterSnapshots
       x-xgen-operation-id-override: listClusterSnapshots
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}:
@@ -34388,6 +35997,8 @@ paths:
       summary: Remove One Legacy Backup Snapshot
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/deleteGroupClusterSnapshot
       x-xgen-operation-id-override: deleteClusterSnapshot
     get:
@@ -34441,6 +36052,8 @@ paths:
       summary: Return One Legacy Backup Snapshot
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterSnapshot
       x-xgen-operation-id-override: getClusterSnapshot
     patch:
@@ -34501,6 +36114,8 @@ paths:
       summary: Update Expiration Date for One Legacy Backup Snapshot
       tags:
         - Legacy Backup
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/updateGroupClusterSnapshot
       x-xgen-operation-id-override: updateClusterSnapshot
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/status:
@@ -34544,6 +36159,8 @@ paths:
       summary: Return Status of All Cluster Operations
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupClusterStatus
       x-xgen-operation-id-override: getClusterStatus
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:grantMongoDBEmployeeAccess:
@@ -34597,6 +36214,8 @@ paths:
       summary: Grant MongoDB Employee Cluster Access for One Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Support Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/grantGroupClusterMongoDbEmployeeAccess
       x-xgen-operation-id-override: grantMongoEmployeeAccess
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion:
@@ -34649,6 +36268,8 @@ paths:
       summary: Pin Feature Compatibility Version for One Cluster in One Project
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/pinGroupClusterFeatureCompatibilityVersion
       x-xgen-operation-id-override: pinFeatureCompatibilityVersion
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:revokeMongoDBEmployeeAccess:
@@ -34694,6 +36315,8 @@ paths:
       summary: Revoke MongoDB Employee Cluster Access for One Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Support Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/revokeGroupClusterMongoDbEmployeeAccess
       x-xgen-operation-id-override: revokeMongoEmployeeAccess
   /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion:
@@ -34741,6 +36364,8 @@ paths:
       summary: Unpin Feature Compatibility Version for One Cluster in One Project
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/unpinGroupClusterFeatureCompatibilityVersion
       x-xgen-operation-id-override: unpinFeatureCompatibilityVersion
   /api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz:
@@ -34824,6 +36449,12 @@ paths:
       summary: Download Logs for One Cluster Host in One Project
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Cluster Log Viewer
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/downloadGroupClusterLog
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -34878,6 +36509,8 @@ paths:
       summary: Return All Cloud Provider Regions
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/listGroupClusterProviderRegions
       x-xgen-operation-id-override: listClusterProviderRegions
   /api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade:
@@ -34933,6 +36566,8 @@ paths:
       summary: Upgrade One Shared-Tier Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/upgradeGroupClusterTenantUpgrade
       x-xgen-method-verb-override:
         customMethod: true
@@ -34993,6 +36628,8 @@ paths:
       summary: Upgrade One Shared-Tier Cluster to One Serverless Instance
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/upgradeGroupClusterTenantUpgradeToServerless
       x-xgen-method-verb-override:
         customMethod: true
@@ -35031,6 +36668,8 @@ paths:
       summary: Return All Metric Names
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupCollStatMetrics
       x-xgen-operation-id-override: listCollStatMetrics
   /api/atlas/v2/groups/{groupId}/containers:
@@ -35081,6 +36720,8 @@ paths:
       summary: Return All Network Peering Containers in One Project for One Cloud Provider
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/listGroupContainers
     post:
       description: Creates one new network peering container in the specified project. MongoDB Cloud can deploy Network Peering connections in a network peering container. GCP can have one container per project. AWS and Azure can have one container per cloud provider region. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -35126,6 +36767,8 @@ paths:
       summary: Create One Network Peering Container
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/createGroupContainer
   /api/atlas/v2/groups/{groupId}/containers/{containerId}:
     delete:
@@ -35171,6 +36814,8 @@ paths:
       summary: Remove One Network Peering Container
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/deleteGroupContainer
     get:
       description: Returns details about one network peering container in one specified project. Network peering containers contain network peering connections. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -35213,6 +36858,8 @@ paths:
       summary: Return One Network Peering Container
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/getGroupContainer
     patch:
       description: Updates the network details and labels of one specified network peering container in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -35266,6 +36913,8 @@ paths:
       summary: Update One Network Peering Container
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/updateGroupContainer
   /api/atlas/v2/groups/{groupId}/containers/all:
     get:
@@ -35304,6 +36953,8 @@ paths:
       summary: Return All Network Peering Containers in One Project
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/listGroupContainerAll
       x-xgen-method-verb-override:
         customMethod: "False"
@@ -35344,6 +36995,8 @@ paths:
       summary: Return All Custom Roles in One Project
       tags:
         - Custom Database Roles
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/listGroupCustomDbRoleRoles
       x-xgen-operation-id-override: listCustomDbRoles
     post:
@@ -35390,6 +37043,9 @@ paths:
       summary: Create One Custom Role
       tags:
         - Custom Database Roles
+      x-rolesRequirements:
+        - Project Database Access Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/createGroupCustomDbRoleRole
       x-xgen-operation-id-override: createCustomDbRole
   /api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}:
@@ -35434,6 +37090,9 @@ paths:
       summary: Remove One Custom Role from One Project
       tags:
         - Custom Database Roles
+      x-rolesRequirements:
+        - Project Database Access Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/deleteGroupCustomDbRoleRole
       x-xgen-operation-id-override: deleteCustomDbRole
     get:
@@ -35475,6 +37134,8 @@ paths:
       summary: Return One Custom Role in One Project
       tags:
         - Custom Database Roles
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/getGroupCustomDbRoleRole
       x-xgen-operation-id-override: getCustomDbRole
     patch:
@@ -35527,6 +37188,9 @@ paths:
       summary: Update One Custom Role in One Project
       tags:
         - Custom Database Roles
+      x-rolesRequirements:
+        - Project Database Access Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/updateGroupCustomDbRoleRole
       x-xgen-operation-id-override: updateCustomDbRole
   /api/atlas/v2/groups/{groupId}/dataFederation:
@@ -35574,6 +37238,8 @@ paths:
       summary: Return All Federated Database Instances in One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/listGroupDataFederation
       x-xgen-operation-id-override: listDataFederation
     post:
@@ -35624,6 +37290,8 @@ paths:
       summary: Create One Federated Database Instance in One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createGroupDataFederation
       x-xgen-operation-id-override: createDataFederation
   /api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}:
@@ -35664,6 +37332,8 @@ paths:
       summary: Remove One Federated Database Instance from One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/deleteGroupDataFederation
       x-xgen-operation-id-override: deleteDataFederation
     get:
@@ -35706,6 +37376,8 @@ paths:
       summary: Return One Federated Database Instance in One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/getGroupDataFederation
       x-xgen-operation-id-override: getDataFederation
     patch:
@@ -35762,6 +37434,8 @@ paths:
       summary: Update One Federated Database Instance in One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/updateGroupDataFederation
       x-xgen-operation-id-override: updateDataFederation
   /api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits:
@@ -35806,6 +37480,8 @@ paths:
       summary: Return All Query Limits for One Federated Database Instance
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/listGroupDataFederationLimits
       x-xgen-operation-id-override: listDataFederationLimits
   /api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}:
@@ -35866,6 +37542,8 @@ paths:
       summary: Delete One Query Limit for One Federated Database Instance
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/deleteGroupDataFederationLimit
       x-xgen-operation-id-override: deleteDataFederationLimit
     get:
@@ -35926,6 +37604,8 @@ paths:
       summary: Return One Federated Database Instance Query Limit for One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/getGroupDataFederationLimit
       x-xgen-operation-id-override: getDataFederationLimit
     patch:
@@ -35994,6 +37674,8 @@ paths:
       summary: Configure One Query Limit for One Federated Database Instance
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/setGroupDataFederationLimit
       x-xgen-method-verb-override:
         customMethod: true
@@ -36059,6 +37741,11 @@ paths:
       summary: Download Query Logs for One Federated Database Instance
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/downloadGroupDataFederationQueryLogs
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -36101,6 +37788,8 @@ paths:
       summary: Return All Database Users in One Project
       tags:
         - Database Users
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/listGroupDatabaseUsers
       x-xgen-operation-id-override: listDatabaseUsers
     post:
@@ -36241,6 +37930,9 @@ paths:
       summary: Create One Database User in One Project
       tags:
         - Database Users
+      x-rolesRequirements:
+        - Project Database Access Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/createGroupDatabaseUser
       x-xgen-operation-id-override: createDatabaseUser
   /api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}:
@@ -36301,6 +37993,9 @@ paths:
       summary: Remove One Database User from One Project
       tags:
         - Database Users
+      x-rolesRequirements:
+        - Project Database Access Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/deleteGroupDatabaseUser
       x-xgen-operation-id-override: deleteDatabaseUser
     get:
@@ -36362,6 +38057,8 @@ paths:
       summary: Return One Database User from One Project
       tags:
         - Database Users
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/getGroupDatabaseUser
       x-xgen-operation-id-override: getDatabaseUser
     patch:
@@ -36434,6 +38131,9 @@ paths:
       summary: Update One Database User in One Project
       tags:
         - Database Users
+      x-rolesRequirements:
+        - Project Database Access Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/updateGroupDatabaseUser
       x-xgen-operation-id-override: updateDatabaseUser
   /api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs:
@@ -36481,6 +38181,8 @@ paths:
       summary: Return All X.509 Certificates Assigned to One Database User
       tags:
         - X.509 Authentication
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/X.509-Authentication/operation/listGroupDatabaseUserCerts
       x-xgen-operation-id-override: listDatabaseUserCerts
     post:
@@ -36542,6 +38244,8 @@ paths:
       summary: Create One X.509 Certificate for One Database User
       tags:
         - X.509 Authentication
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/X.509-Authentication/operation/createGroupDatabaseUserCert
       x-xgen-operation-id-override: createDatabaseUserCert
   /api/atlas/v2/groups/{groupId}/dbAccessHistory/clusters/{clusterName}:
@@ -36624,6 +38328,9 @@ paths:
       summary: Return Database Access History for One Cluster by Cluster Name
       tags:
         - Access Tracking
+      x-rolesRequirements:
+        - Project Cluster Log Viewer
+        - Project Database Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Access-Tracking/operation/getGroupDbAccessHistoryCluster
       x-xgen-operation-id-override: getAccessHistoryCluster
   /api/atlas/v2/groups/{groupId}/dbAccessHistory/processes/{hostname}:
@@ -36703,6 +38410,9 @@ paths:
       summary: Return Database Access History for One Cluster by Hostname
       tags:
         - Access Tracking
+      x-rolesRequirements:
+        - Project Cluster Log Viewer
+        - Project Database Access Admin
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Access-Tracking/operation/getGroupDbAccessHistoryProcess
       x-xgen-operation-id-override: getAccessHistoryProcess
   /api/atlas/v2/groups/{groupId}/encryptionAtRest:
@@ -36742,6 +38452,8 @@ paths:
       summary: Return One Configuration for Encryption at Rest Using Customer-Managed Keys for One Project
       tags:
         - Encryption at Rest using Customer Key Management
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/getGroupEncryptionAtRest
       x-xgen-operation-id-override: getEncryptionAtRest
     patch:
@@ -36800,6 +38512,8 @@ paths:
       summary: Update Encryption at Rest Configuration in One Project
       tags:
         - Encryption at Rest using Customer Key Management
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/updateGroupEncryptionAtRest
       x-xgen-operation-id-override: updateEncryptionAtRest
   /api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints:
@@ -36848,6 +38562,8 @@ paths:
       summary: Return Private Endpoints for Encryption at Rest Using Customer Key Management for One Cloud Provider in One Project
       tags:
         - Encryption at Rest using Customer Key Management
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/listGroupEncryptionAtRestPrivateEndpoints
       x-xgen-operation-id-override: listRestPrivateEndpoints
     post:
@@ -36899,6 +38615,8 @@ paths:
       summary: Create One Private Endpoint for Encryption at Rest Using Customer Key Management for One Cloud Provider in One Project
       tags:
         - Encryption at Rest using Customer Key Management
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/createGroupEncryptionAtRestPrivateEndpoint
       x-xgen-operation-id-override: createRestPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints/{endpointId}:
@@ -36949,6 +38667,8 @@ paths:
       summary: Delete One Private Endpoint for Encryption at Rest Using Customer Key Management for One Cloud Provider from One Project
       tags:
         - Encryption at Rest using Customer Key Management
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/requestGroupEncryptionAtRestPrivateEndpointDeletion
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -37003,6 +38723,8 @@ paths:
       summary: Return One Private Endpoint for Encryption at Rest Using Customer Key Management for One Cloud Provider in One Project
       tags:
         - Encryption at Rest using Customer Key Management
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/getGroupEncryptionAtRestPrivateEndpoint
       x-xgen-operation-id-override: getRestPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/events:
@@ -37100,6 +38822,8 @@ paths:
       summary: Return Events from One Project
       tags:
         - Events
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/listGroupEvents
   /api/atlas/v2/groups/{groupId}/events/{eventId}:
     get:
@@ -37154,6 +38878,8 @@ paths:
       summary: Return One Event from One Project
       tags:
         - Events
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/getGroupEvent
   /api/atlas/v2/groups/{groupId}/flexClusters:
     get:
@@ -37194,6 +38920,8 @@ paths:
       summary: Return All Flex Clusters from One Project
       tags:
         - Flex Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/listGroupFlexClusters
       x-xgen-operation-id-override: listFlexClusters
     post:
@@ -37242,6 +38970,8 @@ paths:
       summary: Create One Flex Cluster in One Project
       tags:
         - Flex Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/createGroupFlexCluster
       x-xgen-operation-id-override: createFlexCluster
   /api/atlas/v2/groups/{groupId}/flexClusters/{name}:
@@ -37287,6 +39017,8 @@ paths:
       summary: Remove One Flex Cluster from One Project
       tags:
         - Flex Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/deleteGroupFlexCluster
       x-xgen-operation-id-override: deleteFlexCluster
     get:
@@ -37333,6 +39065,8 @@ paths:
       summary: Return One Flex Cluster from One Project
       tags:
         - Flex Clusters
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/getGroupFlexCluster
       x-xgen-operation-id-override: getFlexCluster
     patch:
@@ -37386,6 +39120,8 @@ paths:
       summary: Update One Flex Cluster in One Project
       tags:
         - Flex Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/updateGroupFlexCluster
       x-xgen-operation-id-override: updateFlexCluster
   /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/download:
@@ -37440,6 +39176,8 @@ paths:
       summary: Download One Flex Cluster Snapshot
       tags:
         - Flex Snapshots
+      x-rolesRequirements:
+        - Project Backup Export Operator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Snapshots/operation/downloadGroupFlexClusterBackup
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -37490,6 +39228,8 @@ paths:
       summary: Return All Restore Jobs for One Flex Cluster
       tags:
         - Flex Restore Jobs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Restore-Jobs/operation/listGroupFlexClusterBackupRestoreJobs
       x-xgen-operation-id-override: listFlexRestoreJobs
     post:
@@ -37543,6 +39283,8 @@ paths:
       summary: Create One Restore Job for One Flex Cluster
       tags:
         - Flex Restore Jobs
+      x-rolesRequirements:
+        - Project Backup Recovery Operator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Restore-Jobs/operation/createGroupFlexClusterBackupRestoreJob
       x-xgen-operation-id-override: createFlexRestoreJob
   /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/restoreJobs/{restoreJobId}:
@@ -37595,6 +39337,8 @@ paths:
       summary: Return One Restore Job for One Flex Cluster
       tags:
         - Flex Restore Jobs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Restore-Jobs/operation/getGroupFlexClusterBackupRestoreJob
       x-xgen-operation-id-override: getFlexRestoreJob
   /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/snapshots:
@@ -37643,6 +39387,8 @@ paths:
       summary: Return All Snapshots for One Flex Cluster
       tags:
         - Flex Snapshots
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Snapshots/operation/listGroupFlexClusterBackupSnapshots
       x-xgen-operation-id-override: listFlexBackupSnapshots
   /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/snapshots/{snapshotId}:
@@ -37695,6 +39441,8 @@ paths:
       summary: Return One Snapshot for One Flex Cluster
       tags:
         - Flex Snapshots
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Snapshots/operation/getGroupFlexClusterBackupSnapshot
       x-xgen-operation-id-override: getFlexBackupSnapshot
   /api/atlas/v2/groups/{groupId}/flexClusters:tenantUpgrade:
@@ -37744,6 +39492,8 @@ paths:
       summary: Upgrade One Flex Cluster
       tags:
         - Flex Clusters
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/tenantGroupFlexClusterUpgrade
       x-xgen-operation-id-override: tenantUpgrade
   /api/atlas/v2/groups/{groupId}/hosts/{processId}/fts/metrics:
@@ -37782,6 +39532,8 @@ paths:
       summary: Return All Atlas Search Metric Types for One Process
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupHostFtsMetrics
       x-xgen-operation-id-override: listHostFtsMetrics
   /api/atlas/v2/groups/{groupId}/hosts/{processId}/fts/metrics/indexes/{databaseName}/{collectionName}/{indexName}/measurements:
@@ -37850,6 +39602,8 @@ paths:
       summary: Return Atlas Search Metrics for One Index in One Namespace
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupHostFtsMetricIndexMeasurements
       x-xgen-operation-id-override: getIndexMeasurements
   /api/atlas/v2/groups/{groupId}/hosts/{processId}/fts/metrics/indexes/{databaseName}/{collectionName}/measurements:
@@ -37917,6 +39671,8 @@ paths:
       summary: Return All Atlas Search Index Metrics for One Namespace
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupHostFtsMetricIndexMeasurements
       x-xgen-method-verb-override:
         customMethod: false
@@ -37986,6 +39742,8 @@ paths:
       summary: Return Atlas Search Hardware and Status Metrics
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupHostFtsMetricMeasurements
       x-xgen-operation-id-override: listMeasurements
   /api/atlas/v2/groups/{groupId}/integrations:
@@ -38027,6 +39785,8 @@ paths:
       summary: Return All Active Third-Party Service Integrations
       tags:
         - Third-Party Integrations
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/listGroupIntegrations
   /api/atlas/v2/groups/{groupId}/integrations/{integrationType}:
     delete:
@@ -38080,6 +39840,8 @@ paths:
       summary: Remove One Third-Party Service Integration
       tags:
         - Third-Party Integrations
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-changelog:
         2026-01-07: Log export to S3, Splunk, and Datadog is not supported by this API.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/deleteGroupIntegration
@@ -38136,6 +39898,8 @@ paths:
       summary: Return One Third-Party Service Integration
       tags:
         - Third-Party Integrations
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-changelog:
         2026-01-07: Log export to S3, Splunk, and Datadog is not supported by this API.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/getGroupIntegration
@@ -38204,6 +39968,8 @@ paths:
       summary: Create One Third-Party Service Integration
       tags:
         - Third-Party Integrations
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-changelog:
         2026-01-07: Log export to S3, Splunk, and Datadog is not supported by this API.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/createGroupIntegration
@@ -38270,6 +40036,8 @@ paths:
       summary: Update One Third-Party Service Integration
       tags:
         - Third-Party Integrations
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-changelog:
         2026-01-07: Log export to S3, Splunk, and Datadog is not supported by this API.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/updateGroupIntegration
@@ -38317,6 +40085,8 @@ paths:
       summary: Return All Invitations in One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listGroupInvites
     patch:
       deprecated: true
@@ -38362,6 +40132,8 @@ paths:
       summary: Update One Invitation in One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupInvites
     post:
       deprecated: true
@@ -38405,6 +40177,8 @@ paths:
       summary: Create Invitation for One MongoDB Cloud User in One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/createGroupInvite
   /api/atlas/v2/groups/{groupId}/invites/{invitationId}:
     delete:
@@ -38446,6 +40220,8 @@ paths:
       summary: Remove One Invitation from One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/deleteGroupInvite
     get:
       deprecated: true
@@ -38489,6 +40265,8 @@ paths:
       summary: Return One Invitation in One Project by Invitation ID
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupInvite
     patch:
       deprecated: true
@@ -38540,6 +40318,8 @@ paths:
       summary: Update One Invitation in One Project by Invitation ID
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupInviteById
       x-xgen-method-verb-override:
         customMethod: false
@@ -38579,6 +40359,8 @@ paths:
       summary: Return All IP Addresses for One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupIpAddresses
   /api/atlas/v2/groups/{groupId}/limits:
     get:
@@ -38620,6 +40402,8 @@ paths:
       summary: Return All Limits for One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listGroupLimits
   /api/atlas/v2/groups/{groupId}/limits/{limitName}:
     delete:
@@ -38693,6 +40477,8 @@ paths:
       summary: Remove One Project Limit
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/deleteGroupLimit
     get:
       description: Returns the specified limit for the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -38767,6 +40553,8 @@ paths:
       summary: Return One Limit for One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupLimit
     patch:
       description: |-
@@ -38851,6 +40639,8 @@ paths:
       summary: Set One Project Limit
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/setGroupLimit
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -38918,6 +40708,8 @@ paths:
       summary: Create One Migration for One Local Managed Cluster to MongoDB Atlas
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/createGroupLiveMigration
   /api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}:
     get:
@@ -38954,6 +40746,8 @@ paths:
       summary: Return One Migration Job
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/getGroupLiveMigration
   /api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover:
     put:
@@ -38990,6 +40784,8 @@ paths:
       summary: Cut Over One Migrated Cluster
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/cutoverGroupLiveMigration
       x-xgen-method-verb-override:
         customMethod: true
@@ -39047,6 +40843,8 @@ paths:
       summary: Validate One Migration Request
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/validateGroupLiveMigrations
       x-xgen-method-verb-override:
         customMethod: true
@@ -39094,6 +40892,8 @@ paths:
       summary: Return One Migration Validation Job
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/getGroupLiveMigrationValidateStatus
       x-xgen-method-verb-override:
         customMethod: true
@@ -39143,6 +40943,8 @@ paths:
       summary: Return All Active Log Integrations
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/listGroupLogIntegrations
     post:
       description: Creates a new log integration configuration identified by a unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
@@ -39186,6 +40988,8 @@ paths:
       summary: Create One Log Integration
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/createGroupLogIntegration
   /api/atlas/v2/groups/{groupId}/logIntegrations/{id}:
     delete:
@@ -39227,6 +41031,8 @@ paths:
       summary: Remove One Log Integration
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/deleteGroupLogIntegration
     get:
       description: Returns the configuration for one log integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
@@ -39269,6 +41075,8 @@ paths:
       summary: Return One Log Integration
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/getGroupLogIntegration
     put:
       description: Updates the configuration for one log integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
@@ -39318,6 +41126,8 @@ paths:
       summary: Update One Log Integration
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/updateGroupLogIntegration
   /api/atlas/v2/groups/{groupId}/maintenanceWindow:
     delete:
@@ -39352,6 +41162,8 @@ paths:
       summary: Reset One Maintenance Window for One Project
       tags:
         - Maintenance Windows
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/resetGroupMaintenanceWindow
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -39390,6 +41202,8 @@ paths:
       summary: Return One Maintenance Window for One Project
       tags:
         - Maintenance Windows
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/getGroupMaintenanceWindow
       x-xgen-operation-id-override: getMaintenanceWindow
     patch:
@@ -39431,6 +41245,8 @@ paths:
       summary: Update One Maintenance Window for One Project
       tags:
         - Maintenance Windows
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/updateGroupMaintenanceWindow
       x-xgen-operation-id-override: updateMaintenanceWindow
   /api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer:
@@ -39466,6 +41282,8 @@ paths:
       summary: Toggle Automatic Deferral of Maintenance for One Project
       tags:
         - Maintenance Windows
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/toggleGroupMaintenanceWindowAutoDefer
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -39504,6 +41322,8 @@ paths:
       summary: Defer One Maintenance Window for One Project
       tags:
         - Maintenance Windows
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/deferGroupMaintenanceWindow
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -39542,6 +41362,8 @@ paths:
       summary: Return Managed Slow Operation Threshold Status
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/getGroupManagedSlowMs
       x-xgen-operation-id-override: getManagedSlowMs
   /api/atlas/v2/groups/{groupId}/managedSlowMs/disable:
@@ -39576,6 +41398,8 @@ paths:
       summary: Disable Managed Slow Operation Threshold
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/disableGroupManagedSlowMs
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -39612,10 +41436,270 @@ paths:
       summary: Enable Managed Slow Operation Threshold
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/enableGroupManagedSlowMs
       x-xgen-method-verb-override:
         customMethod: true
       x-xgen-operation-id-override: enableManagedSlowMs
+  /api/atlas/v2/groups/{groupId}/metricIntegrations:
+    get:
+      description: Returns all metric integration configurations for the project. Optionally filter by integration type and provider type. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+      operationId: listGroupMetricIntegrations
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/includeCount"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - description: Optional filter by integration type (e.g., `OTEL`). When specified, `providerType` must also be specified.
+          in: query
+          name: integrationType
+          schema:
+            type: string
+        - description: Optional filter by provider type (e.g., `CUSTOM`). When specified, `integrationType` must also be specified.
+          in: query
+          name: providerType
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedMetricIntegrationResponse"
+              x-xgen-preview:
+                name: metric-integrations
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Active Metric Integrations
+      tags:
+        - Metric Integrations
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/listGroupMetricIntegrations
+    post:
+      description: Creates a new metric integration configuration identified by a unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+      operationId: createGroupMetricIntegration
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/MetricIntegrationRequest"
+            x-xgen-preview:
+              name: metric-integrations
+              public: "false"
+            x-xgen-version: preview
+        description: Metric integration configuration to create.
+        required: true
+      responses:
+        "201":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/MetricIntegrationResponse"
+              x-xgen-preview:
+                name: metric-integrations
+                public: "false"
+              x-xgen-version: preview
+          description: Created
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Create One Metric Integration
+      tags:
+        - Metric Integrations
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/createGroupMetricIntegration
+  /api/atlas/v2/groups/{groupId}/metricIntegrations/{metricIntegrationId}:
+    delete:
+      description: Removes the configuration for one metric integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+      operationId: deleteGroupMetricIntegration
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Unique identifier of the metric integration configuration.
+          in: path
+          name: metricIntegrationId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.preview+json:
+              x-xgen-preview:
+                name: metric-integrations
+                public: "false"
+              x-xgen-version: preview
+          description: This endpoint does not return a response body.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Remove One Metric Integration
+      tags:
+        - Metric Integrations
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/deleteGroupMetricIntegration
+    get:
+      description: Returns the configuration for one metric integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+      operationId: getGroupMetricIntegration
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Unique identifier of the metric integration configuration.
+          in: path
+          name: metricIntegrationId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/MetricIntegrationResponse"
+              x-xgen-preview:
+                name: metric-integrations
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Metric Integration
+      tags:
+        - Metric Integrations
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/getGroupMetricIntegration
+    put:
+      description: Updates the configuration for one metric integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+      operationId: updateGroupMetricIntegration
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/pretty"
+        - description: Unique identifier of the metric integration configuration.
+          in: path
+          name: metricIntegrationId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/MetricIntegrationUpdateRequest"
+            x-xgen-preview:
+              name: metric-integrations
+              public: "false"
+            x-xgen-version: preview
+        description: Updated metric integration configuration.
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/MetricIntegrationResponse"
+              x-xgen-preview:
+                name: metric-integrations
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Update One Metric Integration
+      tags:
+        - Metric Integrations
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/updateGroupMetricIntegration
   /api/atlas/v2/groups/{groupId}/mongoDBVersions:
     get:
       description: Returns the MongoDB Long Term Support Major Versions available to new clusters in this project.
@@ -39687,6 +41771,8 @@ paths:
       summary: Return All Available MongoDB LTS Versions for Clusters in One Project
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupMongoDbVersions
       x-xgen-operation-id-override: getMongoDbVersions
   /api/atlas/v2/groups/{groupId}/peers:
@@ -39738,6 +41824,8 @@ paths:
       summary: Return All Network Peering Connections in One Project
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/listGroupPeers
     post:
       description: Creates one new network peering connection in the specified project. Network peering allows multiple cloud-hosted applications to securely connect to the same project. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Network Access Manager role. To learn more about considerations and prerequisites, see the Network Peering Documentation.
@@ -39786,6 +41874,8 @@ paths:
       summary: Create One Network Peering Connection
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Network Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/createGroupPeer
   /api/atlas/v2/groups/{groupId}/peers/{peerId}:
     delete:
@@ -39830,6 +41920,8 @@ paths:
       summary: Remove One Network Peering Connection
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Network Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/deleteGroupPeer
     get:
       description: Returns details about one specified network peering connection in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -39873,6 +41965,8 @@ paths:
       summary: Return One Network Peering Connection in One Project
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/getGroupPeer
     patch:
       description: Updates one specified network peering connection in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Network Access Manager role.
@@ -39925,6 +42019,8 @@ paths:
       summary: Update One Network Peering Connection
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Network Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/updateGroupPeer
   /api/atlas/v2/groups/{groupId}/pipelines:
     get:
@@ -39965,6 +42061,8 @@ paths:
       summary: Return All Data Lake Pipelines in One Project
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/listGroupPipelines
       x-xgen-operation-id-override: listPipelines
     post:
@@ -40013,6 +42111,8 @@ paths:
       summary: Create One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/createGroupPipeline
       x-xgen-operation-id-override: createPipeline
   /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}:
@@ -40055,6 +42155,8 @@ paths:
       summary: Remove One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/deleteGroupPipeline
       x-xgen-operation-id-override: deletePipeline
     get:
@@ -40101,6 +42203,8 @@ paths:
       summary: Return One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipeline
       x-xgen-operation-id-override: getPipeline
     patch:
@@ -40155,6 +42259,8 @@ paths:
       summary: Update One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/updateGroupPipeline
       x-xgen-operation-id-override: updatePipeline
   /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/availableSchedules:
@@ -40204,6 +42310,8 @@ paths:
       summary: Return All Ingestion Schedules for One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipelineAvailableSchedules
       x-xgen-operation-id-override: getAvailablePipelineSchedules
   /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/availableSnapshots:
@@ -40260,6 +42368,8 @@ paths:
       summary: Return All Backup Snapshots for One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipelineAvailableSnapshots
       x-xgen-operation-id-override: getAvailablePipelineSnapshots
   /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause:
@@ -40307,6 +42417,8 @@ paths:
       summary: Pause One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/pauseGroupPipeline
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -40356,6 +42468,8 @@ paths:
       summary: Resume One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/resumeGroupPipeline
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -40414,6 +42528,8 @@ paths:
       summary: Return All Data Lake Pipeline Runs in One Project
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/listGroupPipelineRuns
       x-xgen-operation-id-override: listPipelineRuns
   /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/runs/{pipelineRunId}:
@@ -40469,6 +42585,8 @@ paths:
       summary: Delete One Pipeline Run Dataset
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/deleteGroupPipelineRun
       x-xgen-operation-id-override: deletePipelineRun
     get:
@@ -40523,6 +42641,8 @@ paths:
       summary: Return One Data Lake Pipeline Run
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipelineRun
       x-xgen-operation-id-override: getPipelineRun
   /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger:
@@ -40577,6 +42697,8 @@ paths:
       summary: Trigger On-Demand Snapshot Ingestion
       tags:
         - Data Lake Pipelines
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/triggerGroupPipeline
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -40630,6 +42752,8 @@ paths:
       summary: Return All Private Endpoint Services for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/listGroupPrivateEndpointEndpointService
       x-xgen-operation-id-override: listPrivateEndpointService
   /api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}:
@@ -40684,6 +42808,8 @@ paths:
       summary: Remove One Private Endpoint Service for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/deleteGroupPrivateEndpointEndpointService
       x-xgen-operation-id-override: deletePrivateEndpointService
     get:
@@ -40739,6 +42865,8 @@ paths:
       summary: Return One Private Endpoint Service for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/getGroupPrivateEndpointEndpointService
       x-xgen-operation-id-override: getPrivateEndpointService
   /api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint:
@@ -40806,6 +42934,8 @@ paths:
       summary: Create One Private Endpoint for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/createGroupPrivateEndpointEndpointServiceEndpoint
       x-xgen-operation-id-override: createPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint/{endpointId}:
@@ -40867,6 +42997,8 @@ paths:
       summary: Remove One Private Endpoint for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/deleteGroupPrivateEndpointEndpointServiceEndpoint
       x-xgen-operation-id-override: deletePrivateEndpoint
     get:
@@ -40929,6 +43061,8 @@ paths:
       summary: Return One Private Endpoint for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/getGroupPrivateEndpointEndpointServiceEndpoint
       x-xgen-operation-id-override: getPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService:
@@ -40977,6 +43111,8 @@ paths:
       summary: Create One Private Endpoint Service for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/createGroupPrivateEndpointEndpointService
       x-xgen-operation-id-override: createPrivateEndpointService
   /api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService/{endpointServiceId}:
@@ -41029,6 +43165,8 @@ paths:
       summary: Update One Private Endpoint Service for One Provider
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/updateGroupPrivateEndpointEndpointService
       x-xgen-operation-id-override: updatePrivateEndpointService
   /api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode:
@@ -41065,6 +43203,8 @@ paths:
       summary: Return Regionalized Private Endpoint Status
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/getGroupPrivateEndpointRegionalMode
       x-xgen-method-verb-override:
         customMethod: false
@@ -41112,6 +43252,8 @@ paths:
       summary: Toggle Regionalized Private Endpoint Status
       tags:
         - Private Endpoint Services
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/toggleGroupPrivateEndpointRegionalMode
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -41166,6 +43308,8 @@ paths:
       summary: Return All Private Endpoints for One Serverless Instance
       tags:
         - Serverless Private Endpoints
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/listGroupPrivateEndpointServerlessInstanceEndpoint
       x-xgen-operation-id-override: listServerlessPrivateEndpoint
     post:
@@ -41226,6 +43370,8 @@ paths:
       summary: Create One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/createGroupPrivateEndpointServerlessInstanceEndpoint
       x-xgen-operation-id-override: createServerlessPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}:
@@ -41280,6 +43426,8 @@ paths:
       summary: Remove One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/deleteGroupPrivateEndpointServerlessInstanceEndpoint
       x-xgen-operation-id-override: deleteServerlessPrivateEndpoint
     get:
@@ -41335,6 +43483,8 @@ paths:
       summary: Return One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/getGroupPrivateEndpointServerlessInstanceEndpoint
       x-xgen-operation-id-override: getServerlessPrivateEndpoint
     patch:
@@ -41397,6 +43547,8 @@ paths:
       summary: Update One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/updateGroupPrivateEndpointServerlessInstanceEndpoint
       x-xgen-operation-id-override: updateServerlessPrivateEndpoint
   /api/atlas/v2/groups/{groupId}/privateIpMode:
@@ -41437,6 +43589,8 @@ paths:
       summary: Verify Connect via Peering-Only Mode for One Project
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/verifyGroupPrivateIpMode
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -41488,6 +43642,8 @@ paths:
       summary: Disable Connect via Peering-Only Mode for One Project
       tags:
         - Network Peering
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/disableGroupPrivateIpModePeering
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -41532,6 +43688,8 @@ paths:
       summary: Return All Federated Database Instance and Online Archive Private Endpoints in One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/listGroupPrivateNetworkSettingEndpointIds
       x-xgen-operation-id-override: listPrivateEndpointIds
     post:
@@ -41579,6 +43737,8 @@ paths:
       summary: Create One Federated Database Instance and Online Archive Private Endpoint for One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createGroupPrivateNetworkSettingEndpointId
       x-xgen-operation-id-override: createPrivateEndpointId
   /api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds/{endpointId}:
@@ -41620,6 +43780,8 @@ paths:
       summary: Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/deleteGroupPrivateNetworkSettingEndpointId
       x-xgen-operation-id-override: deletePrivateEndpointId
     get:
@@ -41664,6 +43826,8 @@ paths:
       summary: Return One Federated Database Instance and Online Archive Private Endpoint in One Project
       tags:
         - Data Federation
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/getGroupPrivateNetworkSettingEndpointId
       x-xgen-operation-id-override: getPrivateEndpointId
   /api/atlas/v2/groups/{groupId}/processes:
@@ -41703,6 +43867,8 @@ paths:
       summary: Return All MongoDB Processes in One Project
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupProcesses
   /api/atlas/v2/groups/{groupId}/processes/{processId}:
     get:
@@ -41746,6 +43912,8 @@ paths:
       summary: Return One MongoDB Process by ID
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcess
   /api/atlas/v2/groups/{groupId}/processes/{processId}/{databaseName}/{collectionName}/collStats/measurements:
     get:
@@ -41822,6 +43990,8 @@ paths:
       summary: Return Host-Level Query Latency
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupProcessCollStatMeasurements
       x-xgen-operation-id-override: listProcessMeasurements
   /api/atlas/v2/groups/{groupId}/processes/{processId}/collStats/namespaces:
@@ -41861,6 +44031,8 @@ paths:
       summary: Return Ranked Namespaces from One Host
       tags:
         - Collection Level Metrics
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/getGroupProcessCollStatNamespaces
       x-xgen-method-verb-override:
         customMethod: false
@@ -41914,6 +44086,8 @@ paths:
       summary: Return Available Databases for One MongoDB Process
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupProcessDatabases
       x-xgen-operation-id-override: listDatabases
   /api/atlas/v2/groups/{groupId}/processes/{processId}/databases/{databaseName}:
@@ -41964,6 +44138,8 @@ paths:
       summary: Return One Database for One MongoDB Process
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDatabase
       x-xgen-operation-id-override: getDatabase
   /api/atlas/v2/groups/{groupId}/processes/{processId}/databases/{databaseName}/measurements:
@@ -42040,6 +44216,8 @@ paths:
       summary: Return Measurements for One Database in One MongoDB Process
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDatabaseMeasurements
       x-xgen-operation-id-override: getDatabaseMeasurements
   /api/atlas/v2/groups/{groupId}/processes/{processId}/disks:
@@ -42087,6 +44265,8 @@ paths:
       summary: Return Available Disks for One MongoDB Process
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupProcessDisks
       x-xgen-operation-id-override: listProcessDisks
   /api/atlas/v2/groups/{groupId}/processes/{processId}/disks/{partitionName}:
@@ -42136,6 +44316,8 @@ paths:
       summary: Return Measurements for One Disk
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDisk
       x-xgen-operation-id-override: getProcessDisk
   /api/atlas/v2/groups/{groupId}/processes/{processId}/disks/{partitionName}/measurements:
@@ -42231,6 +44413,8 @@ paths:
       summary: Return Measurements of One Disk for One MongoDB Process
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDiskMeasurements
       x-xgen-operation-id-override: getProcessDiskMeasurements
   /api/atlas/v2/groups/{groupId}/processes/{processId}/measurements:
@@ -42439,6 +44623,8 @@ paths:
       summary: Return Measurements for One MongoDB Process
       tags:
         - Monitoring and Logs
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessMeasurements
       x-xgen-operation-id-override: getProcessMeasurements
   /api/atlas/v2/groups/{groupId}/processes/{processId}/performanceAdvisor/namespaces:
@@ -42503,6 +44689,8 @@ paths:
       summary: Return All Namespaces for One Host
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupProcessPerformanceAdvisorNamespaces
       x-xgen-operation-id-override: listPerformanceAdvisorNamespaces
   /api/atlas/v2/groups/{groupId}/processes/{processId}/performanceAdvisor/slowQueryLogs:
@@ -42602,6 +44790,12 @@ paths:
       summary: Return Slow Queries
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Observability Viewer
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupProcessPerformanceAdvisorSlowQueryLogs
       x-xgen-operation-id-override: listSlowQueryLogs
   /api/atlas/v2/groups/{groupId}/processes/{processId}/performanceAdvisor/suggestedIndexes:
@@ -42690,6 +44884,8 @@ paths:
       summary: Return All Suggested Indexes
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupProcessPerformanceAdvisorSuggestedIndexes
       x-xgen-operation-id-override: listSuggestedIndexes
   /api/atlas/v2/groups/{groupId}/pushBasedLogExport:
@@ -42728,6 +44924,8 @@ paths:
       summary: Disable Push-Based Log Export for One Project
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/deleteGroupPushBasedLogExport
       x-xgen-operation-id-override: deleteLogExport
     get:
@@ -42765,6 +44963,8 @@ paths:
       summary: Return One Push-Based Log Export Configuration in One Project
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/getGroupPushBasedLogExport
       x-xgen-method-verb-override:
         customMethod: false
@@ -42813,6 +45013,8 @@ paths:
       summary: Update One Push-Based Log Export Configuration in One Project
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/updateGroupPushBasedLogExport
       x-xgen-operation-id-override: updateLogExport
     post:
@@ -42858,6 +45060,8 @@ paths:
       summary: Create One Push-Based Log Export Configuration in One Project
       tags:
         - Push-Based Log Export
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/createGroupPushBasedLogExport
       x-xgen-operation-id-override: createLogExport
   /api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}:
@@ -42904,6 +45108,8 @@ paths:
       summary: Load Sample Dataset into One Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/requestGroupSampleDatasetLoad
       x-xgen-method-verb-override:
         customMethod: true
@@ -42949,6 +45155,8 @@ paths:
       summary: Return Status of Sample Dataset Load for One Cluster
       tags:
         - Clusters
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupSampleDatasetLoad
       x-xgen-operation-id-override: getSampleDatasetLoad
   /api/atlas/v2/groups/{groupId}/sandbox/{sandboxConfigId}:generateClusterDescription:
@@ -42981,6 +45189,8 @@ paths:
       summary: Return Cluster Description from Sandbox Template Configuration
       tags:
         - Sandbox
+      x-rolesRequirements:
+        - Organization Project Creator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/generateGroupSandboxClusterDescription
       x-xgen-operation-id-override: generateSandboxClusterDescription
   /api/atlas/v2/groups/{groupId}/serverless:
@@ -43007,7 +45217,7 @@ paths:
             application/vnd.atlas.2023-01-01+json:
               schema:
                 $ref: "#/components/schemas/PaginatedServerlessInstanceDescriptionView"
-              x-sunset: 2027-01-15
+              x-sunset: 2027-01-18
               x-xgen-version: 2023-01-01
           description: OK
           headers:
@@ -43030,6 +45240,8 @@ paths:
       summary: Return All Serverless Instances in One Project
       tags:
         - Serverless Instances
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Instances/operation/listGroupServerlessInstances
       x-xgen-method-verb-override:
         customMethod: false
@@ -43089,6 +45301,8 @@ paths:
       summary: Return All Restore Jobs for One Serverless Instance
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupServerlessBackupRestoreJobs
       x-xgen-operation-id-override: listServerlessRestoreJobs
     post:
@@ -43150,6 +45364,8 @@ paths:
       summary: Create One Restore Job for One Serverless Instance
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupServerlessBackupRestoreJob
       x-xgen-operation-id-override: createServerlessRestoreJob
   /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs/{restoreJobId}:
@@ -43210,6 +45426,8 @@ paths:
       summary: Return One Restore Job for One Serverless Instance
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupServerlessBackupRestoreJob
       x-xgen-operation-id-override: getServerlessRestoreJob
   /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/snapshots:
@@ -43266,6 +45484,8 @@ paths:
       summary: Return All Snapshots of One Serverless Instance
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupServerlessBackupSnapshots
       x-xgen-operation-id-override: listServerlessBackupSnapshots
   /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/snapshots/{snapshotId}:
@@ -43326,6 +45546,8 @@ paths:
       summary: Return One Snapshot of One Serverless Instance
       tags:
         - Cloud Backups
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupServerlessBackupSnapshot
       x-xgen-operation-id-override: getServerlessBackupSnapshot
   /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing:
@@ -43374,6 +45596,8 @@ paths:
       summary: Return Serverless Auto-Indexing Status
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/getGroupServerlessPerformanceAdvisorAutoIndexing
       x-xgen-method-verb-override:
         customMethod: false
@@ -43427,6 +45651,8 @@ paths:
       summary: Set Serverless Auto-Indexing Status
       tags:
         - Performance Advisor
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/setGroupServerlessPerformanceAdvisorAutoIndexing
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -43460,7 +45686,7 @@ paths:
             application/vnd.atlas.2023-01-01+json:
               schema:
                 $ref: "#/components/schemas/ServerlessInstanceDescription"
-              x-sunset: 2027-01-15
+              x-sunset: 2027-01-18
               x-xgen-version: 2023-01-01
           description: OK
           headers:
@@ -43485,6 +45711,8 @@ paths:
       summary: Return One Serverless Instance from One Project
       tags:
         - Serverless Instances
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Instances/operation/getGroupServerlessInstance
       x-xgen-method-verb-override:
         customMethod: false
@@ -43526,6 +45754,8 @@ paths:
       summary: Return All Project Service Accounts
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listGroupServiceAccounts
     post:
       description: Creates one Service Account for the specified Project. The Service Account will automatically be added as an Organization Member to the Organization that the specified Project is a part of.
@@ -43570,6 +45800,8 @@ paths:
       summary: Create One Project Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createGroupServiceAccount
   /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}:
     delete:
@@ -43612,6 +45844,8 @@ paths:
       summary: Remove One Project Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteGroupServiceAccount
     get:
       description: Returns one Service Account in the specified Project.
@@ -43654,6 +45888,8 @@ paths:
       summary: Return One Project Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/getGroupServiceAccount
     patch:
       description: Updates one Service Account in the specified Project.
@@ -43705,6 +45941,8 @@ paths:
       summary: Update One Project Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/updateGroupServiceAccount
   /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}/accessList:
     get:
@@ -43751,6 +45989,8 @@ paths:
       summary: Return All Access List Entries for One Project Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listGroupServiceAccountAccessList
       x-xgen-operation-id-override: listAccessList
     post:
@@ -43812,6 +46052,8 @@ paths:
       summary: Add Access List Entries for One Project Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createGroupServiceAccountAccessList
       x-xgen-operation-id-override: createAccessList
   /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}/accessList/{ipAddress}:
@@ -43864,6 +46106,8 @@ paths:
       summary: Remove One Access List Entry from One Project Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteGroupServiceAccountAccessListEntry
       x-xgen-method-verb-override:
         customMethod: false
@@ -43920,6 +46164,8 @@ paths:
       summary: Create One Project Service Account Secret
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createGroupServiceAccountSecret
       x-xgen-operation-id-override: createGroupSecret
   /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}/secrets/{secretId}:
@@ -43968,6 +46214,8 @@ paths:
       summary: Delete One Project Service Account Secret
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteGroupServiceAccountSecret
       x-xgen-operation-id-override: deleteGroupSecret
   /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}:invite:
@@ -44020,6 +46268,8 @@ paths:
       summary: Assign One Service Account to One Project
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/inviteGroupServiceAccount
   /api/atlas/v2/groups/{groupId}/settings:
     get:
@@ -44055,6 +46305,8 @@ paths:
       summary: Return Project Settings
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupSettings
     patch:
       description: Updates the settings of the specified project. You can update any of the options available. MongoDB cloud only updates the options provided in the request. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -44096,6 +46348,8 @@ paths:
       summary: Update Project Settings
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupSettings
   /api/atlas/v2/groups/{groupId}/standbyLinks:
     get:
@@ -44134,6 +46388,8 @@ paths:
       summary: Return All Standby Links for One Project
       tags:
         - Standby Links
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/listGroupStandbyLinks
     post:
       description: Creates a disaster recovery standby link between an active cluster and a standby cluster. Both clusters must not already be part of a standby link system, must be single-region clusters, and must be in different regions.
@@ -44184,6 +46440,8 @@ paths:
       summary: Create Standby Link
       tags:
         - Standby Links
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/createGroupStandbyLink
   /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}:
     delete:
@@ -44230,6 +46488,8 @@ paths:
       summary: Delete Standby Link
       tags:
         - Standby Links
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/deleteGroupStandbyLink
     get:
       description: Returns detailed information about a specific standby link including status, group ID, and cluster unique IDs.
@@ -44277,6 +46537,8 @@ paths:
       summary: Return One Standby Link
       tags:
         - Standby Links
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/getGroupStandbyLink
   /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}/failovers:
     get:
@@ -44322,6 +46584,8 @@ paths:
       summary: Return All Standby Link Failovers
       tags:
         - Standby Links
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/listGroupStandbyLinkFailovers
       x-xgen-operation-id-override: listStandbyLinkFailovers
     post:
@@ -44380,6 +46644,8 @@ paths:
       summary: Create Standby Link Failover
       tags:
         - Standby Links
+      x-rolesRequirements:
+        - Project Cluster Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/createGroupStandbyLinkFailover
       x-xgen-operation-id-override: createStandbyLinkFailover
   /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}/failovers/{failoverId}:
@@ -44436,8 +46702,71 @@ paths:
       summary: Return One Standby Link Failover
       tags:
         - Standby Links
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/getGroupStandbyLinkFailover
       x-xgen-operation-id-override: getStandbyLinkFailover
+  /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}:inspectFailoverReadiness:
+    get:
+      description: Returns the failover readiness metrics for the specified standby link in the specified project. The response includes the readiness snapshot identifiers, estimated data loss and failover time values. Use this endpoint to assess potential data loss before triggering an unplanned failover.
+      operationId: inspectGroupStandbyLinkFailoverReadiness
+      parameters:
+        - description: Unique 24-hexadecimal digit string that identifies the project.
+          in: path
+          name: groupId
+          required: true
+          schema:
+            pattern: ^[a-fA-F0-9]{24}$
+            type: string
+        - description: Unique 24-hexadecimal digit string that identifies the standby link.
+          in: path
+          name: standbyLinkId
+          required: true
+          schema:
+            pattern: ^[a-fA-F0-9]{24}$
+            type: string
+        - description: Flag that indicates whether to wrap the response in an envelope.
+          in: query
+          name: envelope
+          schema:
+            type: boolean
+        - $ref: "#/components/parameters/pretty"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiStandbyLinkFailoverReadinessResponse"
+              x-xgen-preview:
+                name: standby-links
+              x-xgen-version: preview
+          description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+        "503":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              x-xgen-preview:
+                name: standby-links
+              x-xgen-version: preview
+          description: Service Unavailable.
+      summary: Inspect Failover Readiness for One Standby Link
+      tags:
+        - Standby Links
+      x-rolesRequirements:
+        - Project Read Only
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/inspectGroupStandbyLinkFailoverReadiness
+      x-xgen-operation-id-override: inspectFailoverReadiness
   /api/atlas/v2/groups/{groupId}/streams:
     get:
       description: Returns all stream workspaces for the specified project.
@@ -44474,6 +46803,8 @@ paths:
       summary: Return All Stream Workspaces in One Project
       tags:
         - Streams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamWorkspaces
@@ -44523,6 +46854,10 @@ paths:
       summary: Create One Stream Workspace
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamWorkspace
@@ -44568,6 +46903,10 @@ paths:
       summary: Delete One Stream Workspace
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamWorkspace
@@ -44620,6 +46959,12 @@ paths:
       summary: Return One Stream Workspace
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamWorkspace
@@ -44675,6 +47020,10 @@ paths:
       summary: Update One Stream Workspace
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamWorkspace
@@ -44748,6 +47097,12 @@ paths:
       summary: Download Audit Logs for One Atlas Stream Processing Workspace
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/downloadGroupStreamAuditLogs
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -44795,6 +47150,12 @@ paths:
       summary: Return All Connections of the Stream Workspaces
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamConnections
@@ -44849,6 +47210,9 @@ paths:
       summary: Create One Stream Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamConnection
@@ -44899,6 +47263,9 @@ paths:
       summary: Delete One Stream Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamConnection
       x-xgen-operation-id-override: deleteStreamConnection
     get:
@@ -44945,6 +47312,8 @@ paths:
       summary: Return One Stream Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamConnection
@@ -45005,6 +47374,9 @@ paths:
       summary: Update One Stream Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamConnection
@@ -45073,6 +47445,9 @@ paths:
       summary: Create One Failover Stream Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamConnectionFailoverConnection
@@ -45128,6 +47503,9 @@ paths:
       summary: Create One Stream Processor
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamProcessor
       x-xgen-operation-id-override: createStreamProcessor
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:
@@ -45174,6 +47552,9 @@ paths:
       summary: Delete One Stream Processor
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamProcessor
       x-xgen-operation-id-override: deleteStreamProcessor
     get:
@@ -45223,6 +47604,9 @@ paths:
       summary: Return One Stream Processor
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamProcessor
       x-xgen-operation-id-override: getStreamProcessor
     patch:
@@ -45279,6 +47663,9 @@ paths:
       summary: Update One Stream Processor
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamProcessor
       x-xgen-operation-id-override: updateStreamProcessor
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start:
@@ -45325,6 +47712,9 @@ paths:
       summary: Start One Stream Processor
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/startGroupStreamProcessor
       x-xgen-operation-id-override: startStreamProcessor
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:startWith:
@@ -45353,12 +47743,24 @@ paths:
             schema:
               $ref: "#/components/schemas/StreamsStartStreamProcessorWith"
             x-xgen-version: 2025-03-12
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/StartStreamProcessorWithPreviewView"
+            x-xgen-preview:
+              name: regional-failover
+              public: "false"
+            x-xgen-version: preview
         description: Options for starting a stream processor.
       responses:
         "200":
           content:
             application/vnd.atlas.2025-03-12+json:
               x-xgen-version: 2025-03-12
+            application/vnd.atlas.preview+json:
+              x-xgen-preview:
+                name: regional-failover
+                public: "false"
+              x-xgen-version: preview
           description: OK
           headers:
             RateLimit-Limit:
@@ -45380,6 +47782,9 @@ paths:
       summary: Start One Stream Processor With Options
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/startGroupStreamProcessorWith
       x-xgen-operation-id-override: startStreamProcessorWith
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop:
@@ -45426,6 +47831,9 @@ paths:
       summary: Stop One Stream Processor
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/stopGroupStreamProcessor
       x-xgen-operation-id-override: stopStreamProcessor
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processors:
@@ -45473,6 +47881,9 @@ paths:
       summary: Return All Stream Processors in One Stream Workspace
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamProcessors
       x-xgen-operation-id-override: getStreamProcessors
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}:downloadOperationalLogs:
@@ -45542,6 +47953,12 @@ paths:
       summary: Download Operational Logs for One Atlas Stream Processing Workspace
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/downloadGroupStreamOperationalLogs
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -45592,6 +48009,8 @@ paths:
       summary: Return Account ID and VPC ID for One Project and Region
       tags:
         - Streams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamAccountDetails
       x-xgen-method-verb-override:
         customMethod: false
@@ -45633,6 +48052,8 @@ paths:
       summary: Return All Active Incoming VPC Peering Connections
       tags:
         - Streams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamActiveVpcPeeringConnections
       x-xgen-operation-id-override: listActivePeeringConnections
   /api/atlas/v2/groups/{groupId}/streams/privateLinkConnections:
@@ -45671,6 +48092,8 @@ paths:
       summary: Return All Private Link Connections
       tags:
         - Streams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-changelog:
         2024-10-02: The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamPrivateLinkConnections
@@ -45719,6 +48142,9 @@ paths:
       summary: Create One Private Link Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2024-10-02: The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamPrivateLinkConnection
@@ -45761,6 +48187,9 @@ paths:
       summary: Delete One Private Link Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-changelog:
         2024-10-02: The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamPrivateLinkConnection
@@ -45803,6 +48232,8 @@ paths:
       summary: Return One Private Link Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-changelog:
         2024-10-02: The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamPrivateLinkConnection
@@ -45849,6 +48280,8 @@ paths:
       summary: Return All VPC Peering Connections
       tags:
         - Streams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamVpcPeeringConnections
       x-xgen-operation-id-override: listVpcPeeringConnections
   /api/atlas/v2/groups/{groupId}/streams/vpcPeeringConnections/{id}:
@@ -45888,6 +48321,9 @@ paths:
       summary: Delete One VPC Peering Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamVpcPeeringConnection
       x-xgen-operation-id-override: deleteVpcPeeringConnection
   /api/atlas/v2/groups/{groupId}/streams/vpcPeeringConnections/{id}:accept:
@@ -45934,6 +48370,9 @@ paths:
       summary: Accept One Incoming VPC Peering Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/acceptGroupStreamVpcPeeringConnection
       x-xgen-operation-id-override: acceptVpcPeeringConnection
   /api/atlas/v2/groups/{groupId}/streams/vpcPeeringConnections/{id}:reject:
@@ -45973,6 +48412,9 @@ paths:
       summary: Reject One Incoming VPC Peering Connection
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/rejectGroupStreamVpcPeeringConnection
       x-xgen-operation-id-override: rejectVpcPeeringConnection
   /api/atlas/v2/groups/{groupId}/streams:withSampleConnections:
@@ -46018,6 +48460,10 @@ paths:
       summary: Create One Stream Workspace with Sample Connections
       tags:
         - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Data Access Admin
+        - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/withGroupStreamSampleConnections
       x-xgen-operation-id-override: withStreamSampleConnections
   /api/atlas/v2/groups/{groupId}/teams:
@@ -46059,6 +48505,8 @@ paths:
       summary: Return All Teams in One Project
       tags:
         - Teams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/listGroupTeams
     post:
       description: Adds multiple teams to the specified project. All members of a team share the same project access. MongoDB Cloud limits the number of users to a maximum of 100 teams per project and a maximum of 250 teams per organization. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Access Manager role.
@@ -46107,6 +48555,8 @@ paths:
       summary: Add Multiple Teams to One Project
       tags:
         - Teams
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/addGroupTeams
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -46154,6 +48604,8 @@ paths:
       summary: Remove One Team from One Project
       tags:
         - Teams
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/removeGroupTeam
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -46200,6 +48652,8 @@ paths:
       summary: Return One Team in One Project
       tags:
         - Teams
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/getGroupTeam
     patch:
       description: Updates the project roles assigned to the specified team. You can grant team roles for specific projects and grant project access roles to users in the team. All members of the team share the same project access. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Access Manager role.
@@ -46253,6 +48707,8 @@ paths:
       summary: Update Team Roles in One Project
       tags:
         - Teams
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/updateGroupTeam
   /api/atlas/v2/groups/{groupId}/userSecurity:
     get:
@@ -46288,6 +48744,8 @@ paths:
       summary: Return LDAP or X.509 Configuration
       tags:
         - LDAP Configuration
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/getGroupUserSecurity
       x-xgen-operation-id-override: getUserSecurity
     patch:
@@ -46335,6 +48793,8 @@ paths:
       summary: Update LDAP or X.509 Configuration
       tags:
         - LDAP Configuration
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/updateGroupUserSecurity
       x-xgen-operation-id-override: updateUserSecurity
   /api/atlas/v2/groups/{groupId}/userSecurity/customerX509:
@@ -46373,6 +48833,8 @@ paths:
       summary: Disable Customer-Managed X.509
       tags:
         - X.509 Authentication
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/X.509-Authentication/operation/disableGroupUserSecurityCustomerX509
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -46412,6 +48874,8 @@ paths:
       summary: Remove LDAP User to DN Mapping
       tags:
         - LDAP Configuration
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/deleteGroupUserSecurityLdapUserToDnMapping
       x-xgen-operation-id-override: deleteLdapUserMapping
   /api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify:
@@ -46457,6 +48921,8 @@ paths:
       summary: Verify LDAP Configuration in One Project
       tags:
         - LDAP Configuration
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/verifyGroupUserSecurityLdap
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -46502,6 +48968,8 @@ paths:
       summary: Return Status of LDAP Configuration Verification in One Project
       tags:
         - LDAP Configuration
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/getGroupUserSecurityLdapVerify
       x-xgen-method-verb-override:
         customMethod: false
@@ -46581,6 +49049,8 @@ paths:
       summary: Return All MongoDB Cloud Users in One Project
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listGroupUsers
     post:
       description: |
@@ -46630,6 +49100,8 @@ paths:
       summary: Add One MongoDB Cloud User to One Project
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addGroupUsers
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -46686,6 +49158,8 @@ paths:
       summary: Remove One MongoDB Cloud User from One Project
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeGroupUser
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -46737,6 +49211,8 @@ paths:
       summary: Return One MongoDB Cloud User in One Project
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Project Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/getGroupUser
   /api/atlas/v2/groups/{groupId}/users/{userId}/roles:
     put:
@@ -46788,6 +49264,8 @@ paths:
       summary: Update Project Roles for One MongoDB Cloud User
       tags:
         - Projects
+      x-rolesRequirements:
+        - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupUserRoles
   /api/atlas/v2/groups/{groupId}/users/{userId}:addRole:
     post:
@@ -46847,6 +49325,8 @@ paths:
       summary: Add One Project Role to One MongoDB Cloud User
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addGroupUserRole
   /api/atlas/v2/groups/{groupId}/users/{userId}:removeRole:
     post:
@@ -46906,6 +49386,8 @@ paths:
       summary: Remove One Project Role from One MongoDB Cloud User
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Project Access Manager
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeGroupUserRole
   /api/atlas/v2/groups/{groupId}:migrate:
     post:
@@ -46949,6 +49431,8 @@ paths:
       summary: Migrate One Project to Another Organization
       tags:
         - Projects
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/migrateGroup
   /api/atlas/v2/groups/byName/{groupName}:
     get:
@@ -47131,6 +49615,8 @@ paths:
       summary: Remove One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/deleteOrg
     get:
       description: Returns one organization to which the requesting Service Account or API Key has access. To use this resource, the requesting Service Account or API Key must have the Organization Member role.
@@ -47169,6 +49655,8 @@ paths:
       summary: Return One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrg
     patch:
       description: Updates one organization. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -47214,6 +49702,8 @@ paths:
       summary: Update One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrg
   /api/atlas/v2/orgs/{orgId}/activityFeed:
     get:
@@ -47283,6 +49773,8 @@ paths:
       summary: Return Pre-Filtered Activity Feed Link for One Organization
       tags:
         - Activity Feed
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Activity-Feed/operation/getOrgActivityFeed
   /api/atlas/v2/orgs/{orgId}/aiModelApiKeys:
     get:
@@ -47322,6 +49814,8 @@ paths:
       summary: Return AI Model API Keys for One Organization
       tags:
         - AI Model API Keys
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/listOrgAiModelApiKeys
       x-xgen-operation-id-override: listOrgModelKeys
   /api/atlas/v2/orgs/{orgId}/aiModelApiKeys/{apiKeyId}:
@@ -47366,6 +49860,8 @@ paths:
       summary: Return Single AI Model API Key for One Organization
       tags:
         - AI Model API Keys
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/getOrgAiModelApiKey
       x-xgen-operation-id-override: getOrgModelKey
   /api/atlas/v2/orgs/{orgId}/aiModelRateLimits:
@@ -47406,6 +49902,8 @@ paths:
       summary: Return AI Model Rate Limits for One Organization
       tags:
         - AI Model Rate Limits
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listOrgAiModelRateLimits
       x-xgen-operation-id-override: listOrgModelLimits
   /api/atlas/v2/orgs/{orgId}/aiModelRateLimits/{modelGroupName}:
@@ -47450,6 +49948,8 @@ paths:
       summary: Return Single AI Model Rate Limit for One Organization
       tags:
         - AI Model Rate Limits
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getOrgAiModelRateLimit
       x-xgen-operation-id-override: getOrgModelLimit
   /api/atlas/v2/orgs/{orgId}/apiKeys:
@@ -47492,6 +49992,8 @@ paths:
       summary: Return All Organization API Keys
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/listOrgApiKeys
     post:
       description: Creates one API key for the specified organization. An organization API key grants programmatic access to an organization. You can't use the API key to log into the console. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -47536,6 +50038,8 @@ paths:
       summary: Create One Organization API Key
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/createOrgApiKey
   /api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}:
     delete:
@@ -47579,6 +50083,8 @@ paths:
       summary: Remove One Organization API Key
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/deleteOrgApiKey
     get:
       description: Returns one organization API key. The organization API keys grant programmatic access to an organization. You can't use the API key to log into MongoDB Cloud through the user interface. To use this resource, the requesting Service Account or API Key must have the  Organization Member role.
@@ -47623,6 +50129,8 @@ paths:
       summary: Return One Organization API Key
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/getOrgApiKey
     patch:
       description: Updates one organization API key in the specified organization. The organization API keys  grant programmatic access to an organization. To use this resource, the requesting  API Key must have the Organization Owner role.
@@ -47676,6 +50184,8 @@ paths:
       summary: Update One Organization API Key
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/updateOrgApiKey
   /api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList:
     get:
@@ -47724,6 +50234,8 @@ paths:
       summary: Return All Access List Entries for One Organization API Key
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/listOrgApiKeyAccessListEntries
       x-xgen-method-verb-override:
         customMethod: false
@@ -47898,6 +50410,8 @@ paths:
       summary: Return One Access List Entry for One Organization API Key
       tags:
         - Programmatic API Keys
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/getOrgApiKeyAccessListEntry
       x-xgen-method-verb-override:
         customMethod: false
@@ -47959,6 +50473,8 @@ paths:
       summary: Return Associated Invoices
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgAssociatedInvoices
   /api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage:
     post:
@@ -48002,6 +50518,8 @@ paths:
       summary: Create One Cost Explorer Query Process
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/createOrgBillingCostExplorerUsageProcess
       x-xgen-method-verb-override:
         customMethod: false
@@ -48067,6 +50585,8 @@ paths:
       summary: Return Usage Details for One Cost Explorer Query
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgBillingCostExplorerUsage
       x-xgen-operation-id-override: getCostExplorerUsage
   /api/atlas/v2/orgs/{orgId}/events:
@@ -48145,6 +50665,8 @@ paths:
       summary: Return Events from One Organization
       tags:
         - Events
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/listOrgEvents
   /api/atlas/v2/orgs/{orgId}/events/{eventId}:
     get:
@@ -48199,6 +50721,8 @@ paths:
       summary: Return One Event from One Organization
       tags:
         - Events
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/getOrgEvent
   /api/atlas/v2/orgs/{orgId}/federationSettings:
     get:
@@ -48236,6 +50760,8 @@ paths:
       summary: Return Federation Settings for One Organization
       tags:
         - Federated Authentication
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getOrgFederationSettings
       x-xgen-operation-id-override: getFederationSettings
   /api/atlas/v2/orgs/{orgId}/groups:
@@ -48290,6 +50816,8 @@ paths:
       summary: Return All Projects in One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgGroups
   /api/atlas/v2/orgs/{orgId}/invites:
     get:
@@ -48343,6 +50871,8 @@ paths:
       summary: Return All Invitations in One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/listOrgInvites
     patch:
       deprecated: true
@@ -48394,6 +50924,8 @@ paths:
       summary: Update One Invitation in One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgInvites
     post:
       deprecated: true
@@ -48445,6 +50977,8 @@ paths:
       summary: Create Invitation for One MongoDB Cloud User in One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/createOrgInvite
   /api/atlas/v2/orgs/{orgId}/invites/{invitationId}:
     delete:
@@ -48494,6 +51028,8 @@ paths:
       summary: Remove One Invitation from One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/deleteOrgInvite
     get:
       deprecated: true
@@ -48544,6 +51080,8 @@ paths:
       summary: Return One Invitation in One Organization by Invitation ID
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgInvite
     patch:
       deprecated: true
@@ -48602,6 +51140,8 @@ paths:
       summary: Update One Invitation in One Organization by Invitation ID
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgInviteById
       x-xgen-method-verb-override:
         customMethod: false
@@ -48701,6 +51241,8 @@ paths:
       summary: Return All Invoices for One Organization
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/listOrgInvoices
       x-xgen-operation-id-override: listInvoices
   /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}:
@@ -48757,6 +51299,8 @@ paths:
       summary: Return One Invoice for One Organization
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgInvoice
       x-xgen-operation-id-override: getInvoice
   /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
@@ -48809,6 +51353,8 @@ paths:
       summary: Return One Invoice as CSV for One Organization
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgInvoiceCsv
       x-xgen-operation-id-override: getInvoiceCsv
   /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/lineItems:search:
@@ -48862,6 +51408,8 @@ paths:
       summary: Return All Line Items for One Invoice by Invoice ID
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/searchOrgInvoiceLineItems
       x-xgen-operation-id-override: searchInvoiceLineItems
   /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}:generateAndDownloadReport:
@@ -48918,6 +51466,8 @@ paths:
       summary: Generate and Download Invoice Report
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/generateOrgInvoiceAndDownloadReport
       x-xgen-operation-id-override: generateInvoiceReport
   /api/atlas/v2/orgs/{orgId}/invoices/pending:
@@ -48954,6 +51504,8 @@ paths:
       summary: Return All Pending Invoices for One Organization
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/listOrgInvoicePending
       x-xgen-operation-id-override: listInvoicePending
   /api/atlas/v2/orgs/{orgId}/liveMigrations/availableProjects:
@@ -48994,6 +51546,8 @@ paths:
       summary: Return All Projects Available for Migration
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/listOrgLiveMigrationAvailableProjects
       x-xgen-operation-id-override: listAvailableProjects
   /api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens:
@@ -49029,6 +51583,8 @@ paths:
       summary: Remove One Link-Token
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/deleteOrgLiveMigrationLinkTokens
       x-xgen-operation-id-override: deleteLinkTokens
     post:
@@ -49073,6 +51629,8 @@ paths:
       summary: Create One Link-Token
       tags:
         - Cloud Migration Service
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/createOrgLiveMigrationLinkToken
       x-xgen-operation-id-override: createLinkToken
   /api/atlas/v2/orgs/{orgId}/nonCompliantResources:
@@ -49116,6 +51674,8 @@ paths:
       summary: Return All Non-Compliant Resources
       tags:
         - Resource Policies
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/getOrgNonCompliantResources
       x-xgen-operation-id-override: getNonCompliantResources
   /api/atlas/v2/orgs/{orgId}/resourcePolicies:
@@ -49159,6 +51719,8 @@ paths:
       summary: Return All Atlas Resource Policies
       tags:
         - Resource Policies
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/listOrgResourcePolicies
     post:
       description: Create one Atlas Resource Policy for an organization.
@@ -49211,6 +51773,8 @@ paths:
       summary: Create One Atlas Resource Policy
       tags:
         - Resource Policies
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/createOrgResourcePolicy
   /api/atlas/v2/orgs/{orgId}/resourcePolicies/{resourcePolicyId}:
     delete:
@@ -49259,6 +51823,8 @@ paths:
       summary: Delete One Atlas Resource Policy
       tags:
         - Resource Policies
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/deleteOrgResourcePolicy
     get:
       description: Return one Atlas Resource Policy for an organization.
@@ -49308,6 +51874,8 @@ paths:
       summary: Return One Atlas Resource Policy
       tags:
         - Resource Policies
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/getOrgResourcePolicy
     patch:
       description: Update one Atlas Resource Policy for an organization.
@@ -49370,6 +51938,8 @@ paths:
       summary: Update One Atlas Resource Policy
       tags:
         - Resource Policies
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/updateOrgResourcePolicy
   /api/atlas/v2/orgs/{orgId}/resourcePolicies:validate:
     post:
@@ -49423,6 +51993,8 @@ paths:
       summary: Validate One Atlas Resource Policy
       tags:
         - Resource Policies
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/validateOrgResourcePolicies
       x-xgen-operation-id-override: validateResourcePolicies
   /api/atlas/v2/orgs/{orgId}/sandboxConfig:
@@ -49458,6 +52030,8 @@ paths:
       summary: Return Sandbox Configuration IDs for an Organization
       tags:
         - Sandbox
+      x-rolesRequirements:
+        - Organization Project Creator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/listOrgSandboxConfig
     post:
       description: Create one sandbox configuration for an organization.
@@ -49501,6 +52075,8 @@ paths:
       summary: Create One Sandbox Configuration for an Organization
       tags:
         - Sandbox
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/createOrgSandboxConfig
   /api/atlas/v2/orgs/{orgId}/sandboxConfig/{sandboxConfigId}:
     delete:
@@ -49528,6 +52104,8 @@ paths:
       summary: Delete the Default Sandbox Configuration and Disable Sandbox
       tags:
         - Sandbox
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/deleteOrgSandboxConfig
     get:
       description: Return the default sandbox configuration for an organization.
@@ -49560,6 +52138,8 @@ paths:
       summary: Return Default Sandbox Configuration for One Organization
       tags:
         - Sandbox
+      x-rolesRequirements:
+        - Organization Project Creator
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/getOrgSandboxConfig
     patch:
       description: Update an existing sandbox configuration for an organization.
@@ -49602,6 +52182,8 @@ paths:
       summary: Update an Existing Sandbox Configuration
       tags:
         - Sandbox
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/updateOrgSandboxConfig
   /api/atlas/v2/orgs/{orgId}/serviceAccounts:
     get:
@@ -49639,6 +52221,8 @@ paths:
       summary: Return All Organization Service Accounts
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listOrgServiceAccounts
     post:
       description: Creates one Service Account for the specified Organization.
@@ -49682,6 +52266,8 @@ paths:
       summary: Create One Organization Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createOrgServiceAccount
   /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}:
     delete:
@@ -49723,6 +52309,8 @@ paths:
       summary: Delete One Organization Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteOrgServiceAccount
     get:
       description: Returns the specified Service Account.
@@ -49765,6 +52353,8 @@ paths:
       summary: Return One Organization Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/getOrgServiceAccount
     patch:
       description: Updates the specified Service Account in the specified Organization.
@@ -49816,6 +52406,8 @@ paths:
       summary: Update One Organization Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/updateOrgServiceAccount
   /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/accessList:
     get:
@@ -49862,6 +52454,8 @@ paths:
       summary: Return All Access List Entries for One Organization Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listOrgServiceAccountAccessList
       x-xgen-operation-id-override: listOrgAccessList
     post:
@@ -49923,6 +52517,8 @@ paths:
       summary: Add Access List Entries for One Organization Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createOrgServiceAccountAccessList
       x-xgen-operation-id-override: createOrgAccessList
   /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/accessList/{ipAddress}:
@@ -49975,6 +52571,8 @@ paths:
       summary: Remove One Access List Entry from One Organization Service Account
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteOrgServiceAccountAccessListEntry
       x-xgen-method-verb-override:
         customMethod: true
@@ -50024,6 +52622,8 @@ paths:
       summary: Return All Service Account Project Assignments
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/getOrgServiceAccountGroups
       x-xgen-operation-id-override: getServiceAccountGroups
   /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/secrets:
@@ -50077,6 +52677,8 @@ paths:
       summary: Create One Organization Service Account Secret
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createOrgServiceAccountSecret
       x-xgen-operation-id-override: createOrgSecret
   /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/secrets/{secretId}:
@@ -50125,6 +52727,8 @@ paths:
       summary: Delete One Organization Service Account Secret
       tags:
         - Service Accounts
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteOrgServiceAccountSecret
       x-xgen-operation-id-override: deleteOrgSecret
   /api/atlas/v2/orgs/{orgId}/settings:
@@ -50161,6 +52765,8 @@ paths:
       summary: Return Settings for One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgSettings
     patch:
       description: Updates the organization's settings. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -50204,6 +52810,8 @@ paths:
       summary: Update Settings for One Organization
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgSettings
   /api/atlas/v2/orgs/{orgId}/teams:
     get:
@@ -50247,6 +52855,8 @@ paths:
       summary: Return All Teams in One Organization
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/listOrgTeams
     post:
       description: Creates one team in the specified organization. Teams enable you to grant project access roles to MongoDB Cloud users. MongoDB Cloud limits the number of teams to a maximum of 250 teams per organization. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -50295,6 +52905,8 @@ paths:
       summary: Create One Team in One Organization
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/createOrgTeam
   /api/atlas/v2/orgs/{orgId}/teams/{teamId}:
     delete:
@@ -50340,6 +52952,8 @@ paths:
       summary: Remove One Team from One Organization
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/deleteOrgTeam
     get:
       description: Returns one team that you identified using its unique 24-hexadecimal digit ID. This team belongs to one organization. Teams enable you to grant project access roles to MongoDB Cloud users. To use this resource, the requesting Service Account or API Key must have the Organization Member role.
@@ -50386,6 +53000,8 @@ paths:
       summary: Return One Team by ID
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/getOrgTeam
     patch:
       description: Renames one team in the specified organization. Teams enable you to grant project access roles to MongoDB Cloud users. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -50441,6 +53057,8 @@ paths:
       summary: Rename One Team
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/renameOrgTeam
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -50523,6 +53141,8 @@ paths:
       summary: Return All MongoDB Cloud Users Assigned to One Team
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listOrgTeamUsers
       x-xgen-operation-id-override: listTeamUsers
     post:
@@ -50586,6 +53206,8 @@ paths:
       summary: Assign MongoDB Cloud Users in One Organization to One Team
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/addOrgTeamUsers
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -50647,6 +53269,8 @@ paths:
       summary: Remove One MongoDB Cloud User from One Team
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/removeOrgTeamUserFromTeam
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -50708,6 +53332,8 @@ paths:
       summary: Add One MongoDB Cloud User to One Team
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addOrgTeamUser
   /api/atlas/v2/orgs/{orgId}/teams/{teamId}:removeUser:
     post:
@@ -50765,6 +53391,8 @@ paths:
       summary: Remove One MongoDB Cloud User from One Team
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeOrgTeamUser
   /api/atlas/v2/orgs/{orgId}/teams/byName/{teamName}:
     get:
@@ -50811,6 +53439,8 @@ paths:
       summary: Return One Team by Name
       tags:
         - Teams
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/getOrgTeamByName
       x-xgen-operation-id-override: getTeamByName
   /api/atlas/v2/orgs/{orgId}/users:
@@ -50877,6 +53507,8 @@ paths:
       summary: Return All MongoDB Cloud Users in One Organization
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listOrgUsers
     post:
       description: |-
@@ -50925,6 +53557,8 @@ paths:
       summary: Add One MongoDB Cloud User to One Organization
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/createOrgUser
   /api/atlas/v2/orgs/{orgId}/users/{userId}:
     delete:
@@ -50978,6 +53612,8 @@ paths:
       summary: Remove One MongoDB Cloud User from One Organization
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeOrgUser
       x-xgen-method-verb-override:
         customMethod: "True"
@@ -51029,6 +53665,8 @@ paths:
       summary: Return One MongoDB Cloud User in One Organization
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/getOrgUser
     patch:
       description: |-
@@ -51087,6 +53725,8 @@ paths:
       summary: Update One MongoDB Cloud User in One Organization
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/updateOrgUser
   /api/atlas/v2/orgs/{orgId}/users/{userId}/roles:
     put:
@@ -51138,6 +53778,8 @@ paths:
       summary: Update Organization Roles for One MongoDB Cloud User
       tags:
         - Organizations
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgUserRoles
   /api/atlas/v2/orgs/{orgId}/users/{userId}:addRole:
     post:
@@ -51199,6 +53841,8 @@ paths:
       summary: Add One Organization Role to One MongoDB Cloud User
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addOrgUserRole
       x-xgen-operation-id-override: addOrgRole
   /api/atlas/v2/orgs/{orgId}/users/{userId}:removeRole:
@@ -51259,6 +53903,8 @@ paths:
       summary: Remove One Organization Role from One MongoDB Cloud User
       tags:
         - MongoDB Cloud Users
+      x-rolesRequirements:
+        - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeOrgUserRole
       x-xgen-operation-id-override: removeOrgRole
   /api/atlas/v2/rateLimits:
@@ -51319,7 +53965,7 @@ paths:
             application/vnd.atlas.preview+json:
               schema:
                 $ref: "#/components/schemas/PaginatedRateLimitEndpointSets"
-              x-sunset: 2026-04-19
+              x-sunset: 2026-04-21
               x-xgen-preview:
                 name: rate-limit
                 public: "false"
@@ -51395,7 +54041,7 @@ paths:
             application/vnd.atlas.preview+json:
               schema:
                 $ref: "#/components/schemas/RateLimitEndpointSetResponse"
-              x-sunset: 2026-04-19
+              x-sunset: 2026-04-21
               x-xgen-preview:
                 name: rate-limit
                 public: "false"
@@ -51456,6 +54102,8 @@ paths:
       summary: Return All Stock Keeping Units
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/listSkus
   /api/atlas/v2/skus/{skuId}:
     get:
@@ -51497,6 +54145,8 @@ paths:
       summary: Return One Stock Keeping Unit
       tags:
         - Invoices
+      x-rolesRequirements:
+        - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getSku
   /api/atlas/v2/unauth/controlPlaneIPAddresses:
     get:
@@ -51742,6 +54392,8 @@ tags:
     name: Limit Description
   - description: Returns, edits, and removes maintenance windows. The maintenance procedure that MongoDB Cloud performs requires at least one replica set election during the maintenance window per replica set. You can defer a scheduled maintenance event for a project up to two times. Deferred maintenance events occur during your preferred maintenance window exactly one week after the previously scheduled date and time.
     name: Maintenance Windows
+  - description: Returns, creates, updates, and removes metric integration configurations for a project.
+    name: Metric Integrations
   - description: Returns, adds, and edits MongoDB Cloud users.
     name: MongoDB Cloud Users
   - description: Returns database deployment monitoring and logging data.

--- a/tools/codegen/atlasapispec/raw-multi-version-api-spec.yml
+++ b/tools/codegen/atlasapispec/raw-multi-version-api-spec.yml
@@ -2161,6 +2161,203 @@ components:
                         - DEFAULT
                     type: string
             type: object
+        ApiAtlasCollectionRestoreCollectionStateResponse:
+            description: Collection-level state within a collection restore job.
+            properties:
+                effectiveTargetNamespace:
+                    description: Actual target namespace after restore (e.g. after conflict rename).
+                    readOnly: true
+                    type: string
+                restoredDocuments:
+                    description: Number of documents restored so far.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                sourceNamespace:
+                    description: Source namespace that was requested to restore.
+                    readOnly: true
+                    type: string
+                state:
+                    description: Current state of this collection within the restore job.
+                    enum:
+                        - NOT_STARTED
+                        - IN_PROGRESS
+                        - FINALIZING
+                        - NOT_FOUND
+                        - UNSUPPORTED
+                        - SUCCESSFUL
+                        - ROLLBACK
+                        - NOT_RESTORED
+                        - FAILED
+                        - INDEX_BUILD_FAILED
+                    readOnly: true
+                    type: string
+                targetNamespace:
+                    description: Requested target namespace for the restored collection.
+                    readOnly: true
+                    type: string
+                totalDocuments:
+                    description: Total document count for this collection.
+                    format: int64
+                    readOnly: true
+                    type: integer
+            type: object
+        ApiAtlasCollectionRestoreJobRequest:
+            description: Request body for creating a collection restore job.
+            properties:
+                collectionSuffix:
+                    description: Optional suffix applied to restored collection names.
+                    type: string
+                collections:
+                    description: List of collections to restore (up to 100 items).
+                    items:
+                        $ref: '#/components/schemas/ApiAtlasRestoreNamespaceView'
+                    maxItems: 100
+                    type: array
+                databaseSuffix:
+                    description: Optional suffix applied to restored database names.
+                    type: string
+                databases:
+                    description: List of databases to restore (up to 100 items).
+                    items:
+                        $ref: '#/components/schemas/ApiAtlasRestoreNamespaceView'
+                    maxItems: 100
+                    type: array
+                indexStrategy:
+                    description: Strategy for restoring indexes (all, none, or all except TTL).
+                    enum:
+                        - ALL
+                        - NONE
+                        - ALL_EXCEPT_TTL
+                    type: string
+                oplogInc:
+                    description: Oplog increment for point-in-time restore.
+                    format: int32
+                    type: integer
+                oplogTs:
+                    description: Oplog timestamp (seconds part) for point-in-time restore.
+                    format: int32
+                    type: integer
+                overwriteStrategy:
+                    description: Strategy for overwriting existing data (new if exists or overwrite if exists).
+                    enum:
+                        - NEW_IF_EXISTS
+                        - OVERWRITE_IF_EXISTS
+                    type: string
+                pointInTimeUtcSeconds:
+                    description: Point-in-time restore time in seconds since UNIX epoch.
+                    format: int32
+                    type: integer
+                snapshotId:
+                    description: ID of the snapshot to restore.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                targetClusterName:
+                    description: Target cluster name.
+                    type: string
+                targetGroupId:
+                    description: Unique 24-hexadecimal digit string that identifies the target group.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+            required:
+                - indexStrategy
+                - overwriteStrategy
+                - targetClusterName
+                - targetGroupId
+            type: object
+        ApiAtlasCollectionRestoreJobResponse:
+            description: Collection restore job summary including the list of databases and collections in the restore scope (up to 100 items each).
+            properties:
+                collectionSuffix:
+                    description: Suffix applied to restored collection names.
+                    type: string
+                collections:
+                    description: List of collections in the restore scope (up to 100 items).
+                    items:
+                        $ref: '#/components/schemas/ApiAtlasRestoreNamespaceView'
+                    maxItems: 100
+                    type: array
+                createdAt:
+                    description: Date and time when the restore job was created (ISO 8601 format in UTC).
+                    format: date-time
+                    readOnly: true
+                    type: string
+                databaseSuffix:
+                    description: Suffix applied to restored database names.
+                    type: string
+                databases:
+                    description: List of databases in the restore scope (up to 100 items).
+                    items:
+                        $ref: '#/components/schemas/ApiAtlasRestoreNamespaceView'
+                    maxItems: 100
+                    type: array
+                errorMessage:
+                    description: Error message when the job has failed or been canceled.
+                    readOnly: true
+                    type: string
+                finishedAt:
+                    description: Date and time when the restore job finished (ISO 8601 format in UTC).
+                    format: date-time
+                    readOnly: true
+                    type: string
+                id:
+                    description: Unique 24-hexadecimal digit string that identifies the collection restore job.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    readOnly: true
+                    type: string
+                indexStrategy:
+                    description: Strategy for restoring indexes (all, none, or all except TTL).
+                    enum:
+                        - ALL
+                        - NONE
+                        - ALL_EXCEPT_TTL
+                    type: string
+                oplogInc:
+                    description: Oplog increment for point-in-time restore.
+                    format: int32
+                    type: integer
+                oplogTs:
+                    description: Oplog timestamp (seconds part) for point-in-time restore.
+                    format: int32
+                    type: integer
+                overwriteStrategy:
+                    description: Strategy for overwriting existing data (new if exists or overwrite if exists).
+                    enum:
+                        - NEW_IF_EXISTS
+                        - OVERWRITE_IF_EXISTS
+                    type: string
+                pointInTimeUtcSeconds:
+                    description: Point-in-time restore time in seconds since UNIX epoch.
+                    format: int32
+                    type: integer
+                snapshotId:
+                    description: Unique 24-hexadecimal digit string that identifies the snapshot being restored.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                state:
+                    description: Current state of the collection restore job.
+                    enum:
+                        - INITIALIZING
+                        - IN_PROGRESS
+                        - FINALIZING
+                        - SUCCESSFUL
+                        - CANCELED
+                        - FAILED
+                    readOnly: true
+                    type: string
+                targetClusterName:
+                    description: Human-readable label that identifies the target cluster.
+                    type: string
+                targetGroupId:
+                    description: Unique 24-hexadecimal digit string that identifies the target group.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+            type: object
         ApiAtlasDataLakeAWSRegionView:
             description: Atlas Data Federation AWS Regions.
             enum:
@@ -2521,6 +2718,18 @@ components:
                     example: v1
                     readOnly: true
                     type: string
+            type: object
+        ApiAtlasRestoreNamespaceView:
+            description: Source and optional target namespace for a restore.
+            properties:
+                sourceNamespace:
+                    description: Namespace requested to restore (e.g. database name or `database.collection`).
+                    type: string
+                targetNamespace:
+                    description: Requested target namespace for the restored data; if empty, source namespace is used.
+                    type: string
+            required:
+                - sourceNamespace
             type: object
         ApiAtlasSnapshotScheduleView:
             properties:
@@ -3048,6 +3257,14 @@ components:
                     description: Name of the database this policy applies to.
                     readOnly: true
                     type: string
+                effectiveState:
+                    description: Current effective state of the policy.
+                    enum:
+                        - ACTIVE
+                        - PAUSING
+                        - PAUSED
+                    readOnly: true
+                    type: string
                 id:
                     description: Unique identifier of the policy.
                     example: 32b6e34b3d91647abb20e7b8
@@ -3062,7 +3279,6 @@ components:
                         - ACTIVE
                         - PAUSING
                         - PAUSED
-                        - DELETED
                     readOnly: true
                     type: string
                 targetCollection:
@@ -3072,6 +3288,7 @@ components:
             required:
                 - action
                 - dbName
+                - effectiveState
                 - id
                 - schedule
                 - state
@@ -3351,6 +3568,39 @@ components:
             required:
                 - instanceSize
                 - nodeCount
+            type: object
+        ApiStandbyLinkFailoverReadinessResponse:
+            description: Response body containing a standby link failover readiness snapshot for assessing potential data loss before an unplanned failover.
+            properties:
+                estimatedDataLossSeconds:
+                    description: Best-effort estimate of potential data loss in seconds if failover is triggered now.
+                    example: 3
+                    format: double
+                    readOnly: true
+                    type: number
+                estimatedFailoverTimeSeconds:
+                    description: Best-effort estimate of total expected recovery time in seconds, including Atlas-side failover overhead.
+                    example: 45
+                    format: double
+                    readOnly: true
+                    type: number
+                groupId:
+                    description: Unique 24-hexadecimal digit string that identifies the project that owns the standby link.
+                    example: 69af15ed46c6ab2dbf1c3d0e
+                    pattern: ^([a-f0-9]{24})$
+                    readOnly: true
+                    type: string
+                standbyLinkId:
+                    description: Unique 24-hexadecimal digit string that identifies the standby link described by this readiness snapshot.
+                    example: 6655f1f77bcf86cd79943901
+                    pattern: ^([a-f0-9]{24})$
+                    readOnly: true
+                    type: string
+            required:
+                - estimatedDataLossSeconds
+                - estimatedFailoverTimeSeconds
+                - groupId
+                - standbyLinkId
             type: object
         ApiStandbyLinkFailoverRequest:
             description: Request to initiate a failover operation.
@@ -7170,6 +7420,9 @@ components:
             enum:
                 - PENDING_INVOICE_OVER_THRESHOLD
                 - DAILY_BILL_OVER_THRESHOLD
+                - DAILY_BILLING_CHANGE_OVER_THRESHOLD
+                - WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+                - MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
             example: PENDING_INVOICE_OVER_THRESHOLD
             externalDocs:
                 description: Atlas Alert Event Types
@@ -7185,6 +7438,12 @@ components:
                 - PENDING_INVOICE_OVER_THRESHOLD
                 - DAILY_BILL_UNDER_THRESHOLD
                 - DAILY_BILL_OVER_THRESHOLD
+                - DAILY_BILLING_CHANGE_NORMAL
+                - DAILY_BILLING_CHANGE_OVER_THRESHOLD
+                - WEEKLY_BILLING_CHANGE_NORMAL
+                - WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+                - MONTHLY_BILLING_CHANGE_NORMAL
+                - MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
             example: CREDIT_CARD_CURRENT
             title: Billing Event Types
             type: string
@@ -11314,6 +11573,7 @@ components:
                             - Legacy Backup
                             - AI Models
                             - Automated Embedding
+                            - Native Reranking
                             - Flex Consulting
                             - Support
                             - Credits
@@ -14141,6 +14401,7 @@ components:
                             - FTS_INDEX_DELETION_FAILED
                             - FTS_INDEX_BUILD_COMPLETE
                             - FTS_INDEX_BUILD_FAILED
+                            - FTS_INDEX_CLEANED_UP
                             - FTS_INDEX_STALE
                             - FTS_INDEXES_RESTORE_FAILED
                             - FTS_INDEXES_SYNONYM_MAPPING_INVALID
@@ -14208,6 +14469,8 @@ components:
                             - COMPUTE_AUTO_SCALE_INITIATED_ANALYTICS
                             - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_BASE
                             - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_ANALYTICS
+                            - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_BASE
+                            - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_ANALYTICS
                             - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE
                             - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_ANALYTICS
                             - COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE
@@ -14343,6 +14606,9 @@ components:
                             - CREDIT_CARD_ABOUT_TO_EXPIRE
                             - PENDING_INVOICE_OVER_THRESHOLD
                             - DAILY_BILL_OVER_THRESHOLD
+                            - DAILY_BILLING_CHANGE_OVER_THRESHOLD
+                            - WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+                            - MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
                           title: Billing Event Types
                           type: string
                         - enum:
@@ -14385,6 +14651,7 @@ components:
                             - FTS_INDEX_DELETION_FAILED
                             - FTS_INDEX_BUILD_COMPLETE
                             - FTS_INDEX_BUILD_FAILED
+                            - FTS_INDEX_CLEANED_UP
                             - FTS_INDEX_STALE
                             - FTS_INDEXES_RESTORE_FAILED
                             - FTS_INDEXES_SYNONYM_MAPPING_INVALID
@@ -14477,6 +14744,8 @@ components:
                             - PREDICTIVE_COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE
                             - PREDICTIVE_COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE
                             - CLUSTER_AUTO_SHARDING_INITIATED
+                            - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_BASE
+                            - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_ANALYTICS
                           title: Auto Scaling Audit Types
                           type: string
                         - enum:
@@ -14645,6 +14914,7 @@ components:
                             - CLUSTER_CONNECTION_CREATE_COLLECTION
                             - CLUSTER_CONNECTION_SAMPLE_COLLECTION_FIELD_NAMES
                             - CLUSTER_CONNECTION_SAMPLE_COLLECTION_FIELD_NAMES_AND_TYPES
+                            - CLUSTER_CONNECTION_FIND_DOCUMENTS
                             - CLUSTER_CONNECTION_GET_NAMESPACES_AND_PROJECT_SQL_SCHEMA_DATA
                           title: Cluster Connection Audit Types
                           type: string
@@ -14934,6 +15204,13 @@ components:
                           title: Query Shape Event Types
                           type: string
                         - enum:
+                            - SHARD_KEY_ANALYSIS_STARTED
+                            - SHARD_KEY_ANALYSIS_FINISHED
+                            - QUERY_SAMPLING_STARTED
+                            - QUERY_SAMPLING_STOPPED
+                          title: Shard Key Advisor Event Types
+                          type: string
+                        - enum:
                             - MONGOTUNE_INFO
                             - MONGOTUNE_ALERT
                           title: Mongotune Event Types
@@ -15110,6 +15387,10 @@ components:
                             - SUPPORT_EMAILS_SENT_FAILURE
                           title: Support Event Types
                           type: string
+                        - enum:
+                            - AI_MODELS_USAGE_TIER_UPDATED
+                          title: Ai Models Event Types
+                          type: string
                     type: object
                 groupId:
                     description: Unique 24-hexadecimal digit string that identifies the project in which the event occurred. The `eventId` identifies the specific event.
@@ -15174,10 +15455,10 @@ components:
             title: Any Other Events
             type: object
         DefaultGroupLimitResponse:
-            description: Description of a user-configurable, project-level limit.
+            description: General information about a project-level, user-configured limit, including its name, maximum value, default value, and a description.
             properties:
-                defaultValue:
-                    description: Default value for this limit. Returns null if no default value exists.
+                defaultLimit:
+                    description: Default limit value. Returns null if no default exists.
                     format: int32
                     readOnly: true
                     type: integer
@@ -15185,8 +15466,8 @@ components:
                     description: Human-friendly description of what the limit controls.
                     readOnly: true
                     type: string
-                maximumValue:
-                    description: Maximum value for this limit. Returns null if no maximum value exists.
+                maximumLimit:
+                    description: Maximum limit value. Returns null if no maximum exists.
                     format: int32
                     readOnly: true
                     type: integer
@@ -15300,6 +15581,83 @@ components:
                     writeOnly: true
             type: object
             writeOnly: true
+        DeprecatedStreamProcessorMetricThreshold:
+            deprecated: true
+            description: 'Threshold value that triggers an alert. Deprecated: use `metricThreshold` instead.'
+            discriminator:
+                mapping:
+                    STREAM_PROCESSOR_CHANGE_STREAM_LAG: '#/components/schemas/TimeMetricThresholdView'
+                    STREAM_PROCESSOR_DLQ_MESSAGE_COUNT: '#/components/schemas/DLQRawMetricThresholdView'
+                    STREAM_PROCESSOR_KAFKA_LAG: '#/components/schemas/KafkaRawMetricThresholdView'
+                    STREAM_PROCESSOR_OUTPUT_MESSAGE_COUNT: '#/components/schemas/RawMetricThresholdView'
+                propertyName: metricName
+            oneOf:
+                - $ref: '#/components/schemas/KafkaRawMetricThresholdView'
+                - $ref: '#/components/schemas/TimeMetricThresholdView'
+                - $ref: '#/components/schemas/DLQRawMetricThresholdView'
+                - $ref: '#/components/schemas/RawMetricThresholdView'
+            properties:
+                metricName:
+                    description: Human-readable label that identifies the metric against which MongoDB Cloud checks the configured `metricThreshold.threshold`.
+                    type: string
+                mode:
+                    description: MongoDB Cloud computes the current metric value as an average.
+                    enum:
+                        - AVERAGE
+                    type: string
+                operator:
+                    description: Comparison operator to apply when checking the current metric value.
+                    enum:
+                        - LESS_THAN
+                        - GREATER_THAN
+                    type: string
+                threshold:
+                    description: Value of metric that, when exceeded, triggers an alert.
+                    format: double
+                    type: number
+                units:
+                    description: Element used to express the quantity. This can be an element of time, storage capacity, and the like.
+                    enum:
+                        - bits
+                        - Kbits
+                        - Mbits
+                        - Gbits
+                        - bytes
+                        - KB
+                        - MB
+                        - GB
+                        - TB
+                        - PB
+                        - nsec
+                        - msec
+                        - sec
+                        - min
+                        - hours
+                        - million minutes
+                        - days
+                        - requests
+                        - 1000 requests
+                        - tokens
+                        - million tokens
+                        - pixels
+                        - billion pixels
+                        - GB seconds
+                        - GB hours
+                        - GB days
+                        - RPU
+                        - thousand RPU
+                        - million RPU
+                        - WPU
+                        - thousand WPU
+                        - million WPU
+                        - count
+                        - thousand
+                        - million
+                        - billion
+                    type: string
+            required:
+                - metricName
+            type: object
         Destination:
             description: Document that describes the destination of the migration.
             properties:
@@ -15412,6 +15770,24 @@ components:
                 - frequencyType
                 - retentionUnit
                 - retentionValue
+            type: object
+        DiskBackupCollectionResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                name:
+                    description: Human-readable label that identifies the collection in the database within the snapshot.
+                    readOnly: true
+                    type: string
+            required:
+                - name
             type: object
         DiskBackupCopyPolicyItem:
             description: Specifications for one copy policy item.
@@ -15556,6 +15932,24 @@ components:
                     type: string
             required:
                 - zoneId
+            type: object
+        DiskBackupDatabaseResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                name:
+                    description: Human-readable label that identifies the database within the snapshot.
+                    readOnly: true
+                    type: string
+            required:
+                - name
             type: object
         DiskBackupExportJob:
             properties:
@@ -17705,6 +18099,12 @@ components:
                     - PENDING_INVOICE_OVER_THRESHOLD
                     - DAILY_BILL_UNDER_THRESHOLD
                     - DAILY_BILL_OVER_THRESHOLD
+                    - DAILY_BILLING_CHANGE_NORMAL
+                    - DAILY_BILLING_CHANGE_OVER_THRESHOLD
+                    - WEEKLY_BILLING_CHANGE_NORMAL
+                    - WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+                    - MONTHLY_BILLING_CHANGE_NORMAL
+                    - MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
                   title: Billing Event Types
                   type: string
                 - enum:
@@ -17717,6 +18117,7 @@ components:
                     - CLUSTER_CONNECTION_CREATE_COLLECTION
                     - CLUSTER_CONNECTION_SAMPLE_COLLECTION_FIELD_NAMES
                     - CLUSTER_CONNECTION_SAMPLE_COLLECTION_FIELD_NAMES_AND_TYPES
+                    - CLUSTER_CONNECTION_FIND_DOCUMENTS
                     - CLUSTER_CONNECTION_GET_NAMESPACES_AND_PROJECT_SQL_SCHEMA_DATA
                   title: Cluster Connection Audit Types
                   type: string
@@ -18040,6 +18441,8 @@ components:
                     - ENCRYPTION_AT_REST_CONFIGURATION_VALIDATION_FAILED
                     - ENCRYPTION_AT_REST_CONFIGURATION_VALIDATION_SUCCEEDED
                     - ENCRYPTION_AT_REST_KEY_ROTATION_STARTED
+                    - ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_CREATED
+                    - ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_DELETED
                     - NDS_SET_IMAGE_OVERRIDES
                     - NDS_SET_CHEF_TARBALL_URI
                     - RESTRICTED_EMPLOYEE_ACCESS_BYPASS
@@ -18151,6 +18554,9 @@ components:
                     - OTEL_LOG_STREAMING_ENABLED
                     - OTEL_LOG_STREAMING_CONFIGURATION_UPDATED
                     - OTEL_LOG_STREAMING_DISABLED
+                    - OTEL_METRIC_INTEGRATION_ENABLED
+                    - OTEL_METRIC_INTEGRATION_CONFIGURATION_UPDATED
+                    - OTEL_METRIC_INTEGRATION_DISABLED
                     - AZURE_CLUSTER_PREFERRED_STORAGE_TYPE_UPDATED
                     - CONTAINER_DELETED
                     - REGIONALIZED_PRIVATE_ENDPOINT_MODE_ENABLED
@@ -18199,6 +18605,7 @@ components:
                     - SHADOW_CLUSTER_REPLAY_STATUS_UPDATE
                     - NODE_HIDDEN_BY_ADMIN
                     - NODE_UNHIDDEN_BY_ADMIN
+                    - CLUSTER_CREATED_VIA_ANIS
                   title: Atlas Audit Types
                   type: string
                 - enum:
@@ -18225,6 +18632,8 @@ components:
                     - COMPUTE_AUTO_SCALE_INITIATED_ANALYTICS
                     - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_BASE
                     - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_ANALYTICS
+                    - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_BASE
+                    - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_ANALYTICS
                     - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE
                     - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_ANALYTICS
                     - COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE
@@ -18441,6 +18850,13 @@ components:
                     - QUERY_SHAPE_BLOCKED
                     - QUERY_SHAPE_UNBLOCKED
                   title: Query Shape Event Types
+                  type: string
+                - enum:
+                    - SHARD_KEY_ANALYSIS_STARTED
+                    - SHARD_KEY_ANALYSIS_FINISHED
+                    - QUERY_SAMPLING_STARTED
+                    - QUERY_SAMPLING_STOPPED
+                  title: Shard Key Advisor Event Types
                   type: string
                 - enum:
                     - AI_MODELS_API_KEY_CREATED
@@ -18665,6 +19081,12 @@ components:
                     - ORG_INVOICE_OVER_THRESHOLD
                     - ORG_DAILY_BILL_UNDER_THRESHOLD
                     - ORG_DAILY_BILL_OVER_THRESHOLD
+                    - ORG_DAILY_BILLING_CHANGE_NORMAL
+                    - ORG_DAILY_BILLING_CHANGE_OVER_THRESHOLD
+                    - ORG_WEEKLY_BILLING_CHANGE_NORMAL
+                    - ORG_WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+                    - ORG_MONTHLY_BILLING_CHANGE_NORMAL
+                    - ORG_MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
                     - ORG_GROUP_CHARGES_UNDER_THRESHOLD
                     - ORG_GROUP_CHARGES_OVER_THRESHOLD
                     - ORG_TWO_FACTOR_AUTH_REQUIRED
@@ -18701,6 +19123,7 @@ components:
                     - SANDBOX_TEMPLATE_UPDATED
                     - ORGANIZATION_VOYAGE_SETTINGS_CREATED
                     - ORGANIZATION_VOYAGE_SETTINGS_DELETED
+                    - PROJECT_CREATED_VIA_ANIS
                   title: Org Event Types
                   type: string
                 - enum:
@@ -18766,6 +19189,10 @@ components:
                     - RESOURCE_POLICY_DELETED
                     - RESOURCE_POLICY_VIOLATED
                   title: Atlas Resource Policy Audit Types
+                  type: string
+                - enum:
+                    - AI_MODELS_USAGE_TIER_UPDATED
+                  title: Ai Models Event Types
                   type: string
             type: object
         EventViewForNdsGroup:
@@ -23006,6 +23433,7 @@ components:
                 - PORT
                 - HOSTNAME_AND_PORT
                 - REPLICA_SET_NAME
+                - ATLAS_NODE_TYPE
             example: HOSTNAME
             title: Host Matcher Fields
             type: string
@@ -23169,6 +23597,7 @@ components:
                     SEARCH_OPCOUNTER_GETMORE: '#/components/schemas/RawMetricAlertView'
                     SEARCH_OPCOUNTER_INSERT: '#/components/schemas/RawMetricAlertView'
                     SEARCH_OPCOUNTER_UPDATE: '#/components/schemas/RawMetricAlertView'
+                    SEARCH_PROCESS_THROTTLING: '#/components/schemas/RawMetricAlertView'
                     SEARCH_REPLICATION_LAG: '#/components/schemas/TimeMetricAlertView'
                     SWAP_USAGE_FREE: '#/components/schemas/DataMetricAlertView'
                     SWAP_USAGE_USED: '#/components/schemas/DataMetricAlertView'
@@ -23544,6 +23973,7 @@ components:
                     SEARCH_OPCOUNTER_GETMORE: '#/components/schemas/RawMetricEventView'
                     SEARCH_OPCOUNTER_INSERT: '#/components/schemas/RawMetricEventView'
                     SEARCH_OPCOUNTER_UPDATE: '#/components/schemas/RawMetricEventView'
+                    SEARCH_PROCESS_THROTTLING: '#/components/schemas/RawMetricEventView'
                     SEARCH_REPLICATION_LAG: '#/components/schemas/TimeMetricEventView'
                     SWAP_USAGE_FREE: '#/components/schemas/DataMetricEventView'
                     SWAP_USAGE_USED: '#/components/schemas/DataMetricEventView'
@@ -23838,6 +24268,7 @@ components:
                     SEARCH_OPCOUNTER_GETMORE: '#/components/schemas/SearchOpCounterGetMoreRawMetricThresholdView'
                     SEARCH_OPCOUNTER_INSERT: '#/components/schemas/SearchOpCounterInsertRawMetricThresholdView'
                     SEARCH_OPCOUNTER_UPDATE: '#/components/schemas/SearchOpCounterUpdateRawMetricThresholdView'
+                    SEARCH_PROCESS_THROTTLING: '#/components/schemas/SearchProcessThrottlingRawMetricThresholdView'
                     SEARCH_REPLICATION_LAG: '#/components/schemas/SearchReplicationLagTimeMetricThresholdView'
                     SWAP_USAGE_FREE: '#/components/schemas/SwapUsageFreeDataMetricThresholdView'
                     SWAP_USAGE_USED: '#/components/schemas/SwapUsageUsedDataMetricThresholdView'
@@ -23996,6 +24427,7 @@ components:
                 - $ref: '#/components/schemas/MaxSystemNetworkOutDataMetricThresholdView'
                 - $ref: '#/components/schemas/SearchIndexSizeDataMetricThresholdView'
                 - $ref: '#/components/schemas/SearchMaxFieldsIndexedRawMetricThresholdView'
+                - $ref: '#/components/schemas/SearchProcessThrottlingRawMetricThresholdView'
                 - $ref: '#/components/schemas/SearchNumberOfFieldsInIndexRawMetricThresholdView'
                 - $ref: '#/components/schemas/SearchMaxNgramFieldsIndexedRawMetricThresholdView'
                 - $ref: '#/components/schemas/SearchReplicationLagTimeMetricThresholdView'
@@ -26045,6 +26477,7 @@ components:
                     - PORT
                     - HOSTNAME_AND_PORT
                     - REPLICA_SET_NAME
+                    - ATLAS_NODE_TYPE
                   title: Host Matcher Fields
                   type: string
                 - enum:
@@ -27164,6 +27597,170 @@ components:
                     type: number
             readOnly: true
             type: object
+        MetricIntegrationRequest:
+            description: Request schema for creating a metric integration.
+            properties:
+                aggregationTemporality:
+                    description: The temporality to send to the metric integration.
+                    enum:
+                        - DELTA
+                        - CUMULATIVE
+                    type: string
+                endpoint:
+                    description: OpenTelemetry collector endpoint URL. Must use HTTPS.
+                    example: https://otel-collector.example.com:4318/v1/metrics
+                    maxLength: 2048
+                    type: string
+                headers:
+                    description: HTTP headers for authentication and configuration. Total size limit 2KB.
+                    items:
+                        $ref: '#/components/schemas/Header'
+                    maxItems: 10
+                    minItems: 1
+                    type: array
+                integrationType:
+                    description: Type of metric integration. Identifies which protocol will be used for the integration. This value cannot be modified after the integration is created.
+                    enum:
+                        - OTEL
+                    type: string
+                metricSelection:
+                    description: Array of metric categories to export. Determines which types of metrics are sent to the integration.
+                    items:
+                        enum:
+                            - ATLAS_STREAM_PROCESSING
+                        type: string
+                    maxItems: 30
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                providerType:
+                    description: The provider type for the metric integration. Identifies the third-party service provider.
+                    enum:
+                        - CUSTOM
+                        - DYNATRACE
+                        - NEW_RELIC
+                    type: string
+            required:
+                - aggregationTemporality
+                - endpoint
+                - headers
+                - integrationType
+                - metricSelection
+                - providerType
+            title: Metric Integration Request
+            type: object
+        MetricIntegrationResponse:
+            description: Response schema for metric integration operations.
+            properties:
+                aggregationTemporality:
+                    description: The temporality to send to the metric integration.
+                    enum:
+                        - DELTA
+                        - CUMULATIVE
+                    type: string
+                endpoint:
+                    description: OpenTelemetry collector endpoint URL.
+                    example: https://otel-collector.example.com:4318/v1/metrics
+                    maxLength: 2048
+                    type: string
+                headers:
+                    description: HTTP headers for authentication and configuration. Header values are redacted in responses.
+                    items:
+                        $ref: '#/components/schemas/Header'
+                    maxItems: 10
+                    minItems: 1
+                    type: array
+                integrationType:
+                    description: Type of metric integration. Identifies which protocol will be used for the integration.
+                    enum:
+                        - OTEL
+                    type: string
+                metricIntegrationId:
+                    description: Unique hexadecimal digit string that identifies the metric integration configuration.
+                    example: 507f1f77bcf86cd799439011
+                    maxLength: 24
+                    minLength: 24
+                    readOnly: true
+                    type: string
+                metricSelection:
+                    description: Array of metric categories to export. Determines which types of metrics are sent to the integration.
+                    items:
+                        enum:
+                            - ATLAS_STREAM_PROCESSING
+                        type: string
+                    maxItems: 30
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                providerType:
+                    description: The provider type for the metric integration. Identifies the third-party service provider.
+                    enum:
+                        - CUSTOM
+                        - DYNATRACE
+                        - NEW_RELIC
+                    type: string
+            required:
+                - aggregationTemporality
+                - endpoint
+                - headers
+                - integrationType
+                - metricIntegrationId
+                - metricSelection
+                - providerType
+            title: Metric Integration Response
+            type: object
+        MetricIntegrationUpdateRequest:
+            description: Request schema for updating a metric integration.
+            properties:
+                aggregationTemporality:
+                    description: The temporality to send to the metric integration.
+                    enum:
+                        - DELTA
+                        - CUMULATIVE
+                    type: string
+                endpoint:
+                    description: OpenTelemetry collector endpoint URL. Must use HTTPS.
+                    example: https://otel-collector.example.com:4318/v1/metrics
+                    maxLength: 2048
+                    type: string
+                headers:
+                    description: HTTP headers for authentication and configuration. Total size limit 2KB.
+                    items:
+                        $ref: '#/components/schemas/Header'
+                    maxItems: 10
+                    minItems: 1
+                    type: array
+                integrationType:
+                    description: Type of metric integration. Identifies which protocol will be used for the integration. This value cannot be modified after the integration is created.
+                    enum:
+                        - OTEL
+                    type: string
+                metricSelection:
+                    description: Array of metric categories to export. Determines which types of metrics are sent to the integration.
+                    items:
+                        enum:
+                            - ATLAS_STREAM_PROCESSING
+                        type: string
+                    maxItems: 30
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                providerType:
+                    description: The provider type for the metric integration. Identifies the third-party service provider.
+                    enum:
+                        - CUSTOM
+                        - DYNATRACE
+                        - NEW_RELIC
+                    type: string
+            required:
+                - aggregationTemporality
+                - endpoint
+                - headers
+                - integrationType
+                - metricSelection
+                - providerType
+            title: Metric Integration Update Request
+            type: object
         MetricsMeasurement:
             properties:
                 dataPoints:
@@ -27732,6 +28329,8 @@ components:
                 - ENCRYPTION_AT_REST_CONFIGURATION_VALIDATION_FAILED
                 - ENCRYPTION_AT_REST_CONFIGURATION_VALIDATION_SUCCEEDED
                 - ENCRYPTION_AT_REST_KEY_ROTATION_STARTED
+                - ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_CREATED
+                - ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_DELETED
                 - NDS_SET_IMAGE_OVERRIDES
                 - NDS_SET_CHEF_TARBALL_URI
                 - RESTRICTED_EMPLOYEE_ACCESS_BYPASS
@@ -27843,6 +28442,9 @@ components:
                 - OTEL_LOG_STREAMING_ENABLED
                 - OTEL_LOG_STREAMING_CONFIGURATION_UPDATED
                 - OTEL_LOG_STREAMING_DISABLED
+                - OTEL_METRIC_INTEGRATION_ENABLED
+                - OTEL_METRIC_INTEGRATION_CONFIGURATION_UPDATED
+                - OTEL_METRIC_INTEGRATION_DISABLED
                 - AZURE_CLUSTER_PREFERRED_STORAGE_TYPE_UPDATED
                 - CONTAINER_DELETED
                 - REGIONALIZED_PRIVATE_ENDPOINT_MODE_ENABLED
@@ -27891,6 +28493,7 @@ components:
                 - SHADOW_CLUSTER_REPLAY_STATUS_UPDATE
                 - NODE_HIDDEN_BY_ADMIN
                 - NODE_UNHIDDEN_BY_ADMIN
+                - CLUSTER_CREATED_VIA_ANIS
             example: CLUSTER_CREATED
             title: Atlas Audit Types
             type: string
@@ -28100,6 +28703,8 @@ components:
                 - COMPUTE_AUTO_SCALE_INITIATED_ANALYTICS
                 - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_BASE
                 - COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_ANALYTICS
+                - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_BASE
+                - COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_ANALYTICS
                 - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE
                 - COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_ANALYTICS
                 - COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE
@@ -29935,6 +30540,12 @@ components:
                 - ORG_INVOICE_OVER_THRESHOLD
                 - ORG_DAILY_BILL_UNDER_THRESHOLD
                 - ORG_DAILY_BILL_OVER_THRESHOLD
+                - ORG_DAILY_BILLING_CHANGE_NORMAL
+                - ORG_DAILY_BILLING_CHANGE_OVER_THRESHOLD
+                - ORG_WEEKLY_BILLING_CHANGE_NORMAL
+                - ORG_WEEKLY_BILLING_CHANGE_OVER_THRESHOLD
+                - ORG_MONTHLY_BILLING_CHANGE_NORMAL
+                - ORG_MONTHLY_BILLING_CHANGE_OVER_THRESHOLD
                 - ORG_GROUP_CHARGES_UNDER_THRESHOLD
                 - ORG_GROUP_CHARGES_OVER_THRESHOLD
                 - ORG_TWO_FACTOR_AUTH_REQUIRED
@@ -29971,6 +30582,7 @@ components:
                 - SANDBOX_TEMPLATE_UPDATED
                 - ORGANIZATION_VOYAGE_SETTINGS_CREATED
                 - ORGANIZATION_VOYAGE_SETTINGS_DELETED
+                - PROJECT_CREATED_VIA_ANIS
             example: ORG_CREATED
             title: Org Event Types
             type: string
@@ -31023,6 +31635,58 @@ components:
             required:
                 - results
             type: object
+        PaginatedApiAtlasCollectionRestoreCollectionStateView:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/ApiAtlasCollectionRestoreCollectionStateResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
+        PaginatedApiAtlasCollectionRestoreJobView:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/ApiAtlasCollectionRestoreJobResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
         PaginatedApiAtlasDatabaseUserView:
             description: List of MongoDB Database users granted access to databases in the specified project.
             properties:
@@ -31039,6 +31703,58 @@ components:
                     description: List of returned documents that MongoDB Cloud provides when completing this request.
                     items:
                         $ref: '#/components/schemas/CloudDatabaseUser'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
+        PaginatedApiAtlasDiskBackupCollectionView:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/DiskBackupCollectionResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
+        PaginatedApiAtlasDiskBackupDatabaseView:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/DiskBackupDatabaseResponse'
                     readOnly: true
                     type: array
                 totalCount:
@@ -32268,6 +32984,32 @@ components:
                     description: List of returned documents that MongoDB Cloud provides when completing this request.
                     items:
                         $ref: '#/components/schemas/LogIntegrationResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
+        PaginatedMetricIntegrationResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/MetricIntegrationResponse'
                     readOnly: true
                     type: array
                 totalCount:
@@ -34984,6 +35726,10 @@ components:
                         enum:
                             - S3_LOG_EXPORT
                         type: string
+                    useLegacyPathStructure:
+                        description: 'When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.'
+                        nullable: true
+                        type: boolean
                   type: object
             description: Request schema for creating or updating an S3 log export integration.
             required:
@@ -35021,6 +35767,10 @@ components:
                         enum:
                             - S3_LOG_EXPORT
                         type: string
+                    useLegacyPathStructure:
+                        description: 'When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.'
+                        nullable: true
+                        type: boolean
                   type: object
             description: Details to integrate S3 log export with one Atlas project.
             required:
@@ -35945,6 +36695,31 @@ components:
                 - metricName
             type: object
         SearchOpCounterUpdateRawMetricThresholdView:
+            properties:
+                metricName:
+                    description: Human-readable label that identifies the metric against which MongoDB Cloud checks the configured `metricThreshold.threshold`.
+                    type: string
+                mode:
+                    description: MongoDB Cloud computes the current metric value as an average.
+                    enum:
+                        - AVERAGE
+                    type: string
+                operator:
+                    description: Comparison operator to apply when checking the current metric value.
+                    enum:
+                        - LESS_THAN
+                        - GREATER_THAN
+                    type: string
+                threshold:
+                    description: Value of metric that, when exceeded, triggers an alert.
+                    format: double
+                    type: number
+                units:
+                    $ref: '#/components/schemas/RawMetricUnits'
+            required:
+                - metricName
+            type: object
+        SearchProcessThrottlingRawMetricThresholdView:
             properties:
                 metricName:
                     description: Human-readable label that identifies the metric against which MongoDB Cloud checks the configured `metricThreshold.threshold`.
@@ -37705,6 +38480,41 @@ components:
                 - type
             title: Splunk Log Export Integration Response
             type: object
+        StartStreamProcessorWithPreviewView:
+            description: A request to start a stream processor.
+            properties:
+                failover:
+                    $ref: '#/components/schemas/StreamsStartProcessorFailover'
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                resumeFromCheckpoint:
+                    description: When true or not specified, the stream processor resumes from its last checkpoint. When false, the stream processor starts fresh.
+                    type: boolean
+                startAtOperationTime:
+                    description: The operation time after which the change stream source should begin reporting. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+                    externalDocs:
+                        description: ISO 8601
+                        url: https://en.wikipedia.org/wiki/ISO_8601
+                    format: date-time
+                    type: string
+                tier:
+                    description: Selected tier for the Stream Workspace. Configures Memory / VCPU allowances.
+                    enum:
+                        - SP50
+                        - SP30
+                        - SP10
+                        - SP5
+                        - SP2
+                    title: Stream Workspace Tier
+                    type: string
+            type: object
         StateReason:
             description: State reason of the Job. This is set when the job state is "Failed".
             properties:
@@ -38086,6 +38896,8 @@ components:
                     items:
                         $ref: '#/components/schemas/StreamsMatcher'
                     type: array
+                metricThreshold:
+                    $ref: '#/components/schemas/StreamProcessorMetricThreshold'
                 notifications:
                     description: List that contains the targets that MongoDB Cloud sends notifications.
                     items:
@@ -38096,7 +38908,7 @@ components:
                 severityOverride:
                     $ref: '#/components/schemas/EventSeverity'
                 threshold:
-                    $ref: '#/components/schemas/StreamProcessorMetricThreshold'
+                    $ref: '#/components/schemas/DeprecatedStreamProcessorMetricThreshold'
                 updated:
                     description: Date and time when someone last updated this alert configuration. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     externalDocs:
@@ -38800,16 +39612,18 @@ components:
                     description: |-
                         Vendor that manages the cloud service. The list of supported vendor values is:
                         - AWS
-                        -- MSK for AWS MSK Kafka clusters
-                        -- CONFLUENT for Confluent Kafka clusters on AWS
-                        -- KINESIS for AWS Kinesis Data Streams
+                        -- `MSK` for AWS MSK Kafka clusters
+                        -- `CONFLUENT` for Confluent Kafka clusters on AWS
+                        -- `KINESIS` for AWS Kinesis Data Streams
 
                         - Azure
-                        -- EVENTHUB for Azure EventHub.
-                        -- CONFLUENT for Confluent Kafka clusters on Azure
+                        -- `EVENTHUB` for Azure EventHub.
+                        -- `CONFLUENT` for Confluent Kafka clusters on Azure
+                        -- `AZURE_BLOB_STORAGE` for Azure Blob Storage
 
                         - GCP
-                        -- CONFLUENT for Confluent Kafka clusters on GCP
+                        -- `CONFLUENT` for Confluent Kafka clusters on GCP
+                        -- `PUBSUB` for Google Cloud Pub/Sub
 
                         **NOTE** Omitting the vendor field will default to using the GENERIC vendor.
                     type: string
@@ -38847,6 +39661,16 @@ components:
                     items:
                         $ref: '#/components/schemas/Document'
                     type: array
+                tier:
+                    description: Selected tier for the Stream Workspace. Configures Memory / VCPU allowances.
+                    enum:
+                        - SP50
+                        - SP30
+                        - SP10
+                        - SP5
+                        - SP2
+                    title: Stream Workspace Tier
+                    type: string
             type: object
         StreamsProcessorWithStats:
             description: An atlas stream processor with optional stats.
@@ -38915,7 +39739,7 @@ components:
                 - state
             type: object
         StreamsPublicPrivateLinkNetworking:
-            description: Networking configuration for connections that support `PUBLIC` and `PRIVATE_LINK` access types.
+            description: Networking configuration for connections that support `PUBLIC` and `PRIVATE_LINK` access types. For GCP connections, use `PRIVATE_LINK` for GCP Private Service Connect (PSC).
             properties:
                 access:
                     $ref: '#/components/schemas/StreamsPublicPrivateLinkNetworkingAccess'
@@ -38933,7 +39757,7 @@ components:
             description: Information about networking access.
             properties:
                 connectionId:
-                    description: The ID of the Private Link connection. Required for `PRIVATE_LINK` type.
+                    description: The ID of the Private Link connection. Required for `PRIVATE_LINK` type. For GCP connections using Private Service Connect (PSC), this is the PSC connection ID.
                     example: 32b6e34b3d91647abb20e7b8
                     pattern: ^([a-f0-9]{24})$
                     type: string
@@ -38947,7 +39771,7 @@ components:
                     readOnly: true
                     type: array
                 type:
-                    description: Selected networking type. Either `PUBLIC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
+                    description: Selected networking type. Either `PUBLIC` or `PRIVATE_LINK`. Defaults to `PUBLIC`. For AWS, Azure, and GCP connections, use `PRIVATE_LINK` for AWS PrivateLink, Azure Private Link, or GCP Private Service Connect (PSC) respectively.
                     enum:
                         - PUBLIC
                         - PRIVATE_LINK
@@ -39012,6 +39836,25 @@ components:
                 - provider
                 - schemaRegistryAuthentication
                 - schemaRegistryUrls
+            type: object
+        StreamsStartProcessorFailover:
+            description: Failover options for starting a stream processor.
+            properties:
+                dryRun:
+                    description: If true, simulates the operation without making any changes.
+                    type: boolean
+                mode:
+                    description: 'Strategy for the processor: GRACEFUL - attempt to stop the processor, error if processor cannot be stopped. if stop was successful, start the processor in the new region with the latest checkpoint.  FORCED - attempt to stop the processor, proceed to starting the processor in the new region with checkpoints disabled regardless of whether or not the stop succeeds.'
+                    enum:
+                        - GRACEFUL
+                        - FORCED
+                    type: string
+                region:
+                    description: Cloud provider region where the stream processor should be started in failover mode. The region must be a valid region for the stream processor's cloud provider and must be included in the tenant's configured failover regions, or it may be the tenant's default (primary) region.
+                    example: VIRGINIA_USA
+                    type: string
+            required:
+                - region
             type: object
         StreamsStartStreamProcessorWith:
             description: A request to start a stream processor.
@@ -40822,6 +41665,7 @@ components:
                             - Legacy Backup
                             - AI Models
                             - Automated Embedding
+                            - Native Reranking
                             - Flex Consulting
                             - Support
                             - Credits
@@ -42417,7 +43261,7 @@ info:
     termsOfService: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
     title: MongoDB Atlas Administration API
     version: "2.0"
-    x-xgen-sha: 89ed99cad2b18e0be76ec5ab02184ba4c31b13c7
+    x-xgen-sha: a19351f3e69de146edafd83d797e6e9d118f6e8e
 openapi: 3.0.1
 paths:
     /api/atlas/v2:
@@ -42577,11 +43421,25 @@ paths:
             parameters:
                 - $ref: '#/components/parameters/envelope'
                 - $ref: '#/components/parameters/pretty'
-                - description: Human-readable label that identifies the user-managed limit whose description you want to retrieve.
+                - description: Identifies the user-managed limit.
                   in: path
                   name: limitName
                   required: true
                   schema:
+                    enum:
+                        - MONGODB_USERS
+                        - NUM_CLUSTERS
+                        - NUM_SERVERLESS_MTMS
+                        - NUM_USER_CUSTOM_ROLES
+                        - MAX_NETWORK_PERMISSION_ENTRIES
+                        - MAX_CROSS_REGION_NETWORK_PERMISSION_ENTRIES
+                        - MAX_NODES_PER_PRIVATELINK_REGION
+                        - BYTES_PROCESSED_QUERY
+                        - BYTES_PROCESSED_DAILY
+                        - BYTES_PROCESSED_WEEKLY
+                        - BYTES_PROCESSED_MONTHLY
+                        - NUM_PRIVATE_SERVICE_CONNECTIONS_PER_REGION_GROUP
+                        - GCP_PSC_NAT_SUBNET_MASK
                     type: string
             responses:
                 "200":
@@ -42598,8 +43456,6 @@ paths:
                             $ref: '#/components/headers/HeaderRateLimitLimit'
                         RateLimit-Remaining:
                             $ref: '#/components/headers/HeaderRateLimitRemaining'
-                "400":
-                    $ref: '#/components/responses/badRequest'
                 "401":
                     $ref: '#/components/responses/unauthorized'
                 "403":
@@ -42648,6 +43504,9 @@ paths:
             summary: Return All Event Types
             tags:
                 - Events
+            x-rolesRequirements:
+                - Organization Member
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/listEventTypes
     /api/atlas/v2/federationSettings/{federationSettingsId}:
         delete:
@@ -42681,6 +43540,8 @@ paths:
             summary: Delete One Federation Settings Instance
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/deleteFederationSetting
     /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs:
         get:
@@ -42719,6 +43580,8 @@ paths:
             summary: Return All Organization Configurations from One Federation
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/listFederationSettingConnectedOrgConfigs
             x-xgen-operation-id-override: listConnectedOrgConfigs
     /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}:
@@ -42762,6 +43625,8 @@ paths:
             summary: Remove One Organization Configuration from One Federation
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/removeFederationSettingConnectedOrgConfig
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -42809,6 +43674,8 @@ paths:
             summary: Return One Organization Configuration from One Federation
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingConnectedOrgConfig
             x-xgen-operation-id-override: getConnectedOrgConfig
         patch:
@@ -42860,6 +43727,8 @@ paths:
             summary: Update One Organization Configuration in One Federation
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/updateFederationSettingConnectedOrgConfig
             x-xgen-operation-id-override: updateConnectedOrgConfig
     /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings:
@@ -42898,6 +43767,8 @@ paths:
             summary: Return All Role Mappings from One Organization
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/listFederationSettingConnectedOrgConfigRoleMappings
             x-xgen-operation-id-override: listRoleMappings
         post:
@@ -42942,6 +43813,8 @@ paths:
             summary: Create One Role Mapping in One Organization Configuration
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/createFederationSettingConnectedOrgConfigRoleMapping
             x-xgen-operation-id-override: createRoleMapping
     /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}:
@@ -42986,6 +43859,8 @@ paths:
             summary: Remove One Role Mapping from One Organization
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/deleteFederationSettingConnectedOrgConfigRoleMapping
             x-xgen-operation-id-override: deleteRoleMapping
         get:
@@ -43031,6 +43906,8 @@ paths:
             summary: Return One Role Mapping from One Organization
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingConnectedOrgConfigRoleMapping
             x-xgen-operation-id-override: getRoleMapping
         put:
@@ -43083,6 +43960,8 @@ paths:
             summary: Update One Role Mapping in One Organization
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/updateFederationSettingConnectedOrgConfigRoleMapping
             x-xgen-operation-id-override: updateRoleMapping
     /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders:
@@ -43144,6 +44023,8 @@ paths:
             summary: Return All Identity Providers in One Federation
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/listFederationSettingIdentityProviders
             x-xgen-operation-id-override: listIdentityProviders
         post:
@@ -43190,6 +44071,8 @@ paths:
             summary: Create One Identity Provider
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/createFederationSettingIdentityProvider
             x-xgen-operation-id-override: createIdentityProvider
     /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}:
@@ -43235,6 +44118,8 @@ paths:
             summary: Delete One Identity Provider
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/deleteFederationSettingIdentityProvider
             x-xgen-operation-id-override: deleteIdentityProvider
         get:
@@ -43283,6 +44168,8 @@ paths:
             summary: Return One Identity Provider by ID
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingIdentityProvider
             x-xgen-operation-id-override: getIdentityProvider
         patch:
@@ -43348,6 +44235,8 @@ paths:
             summary: Update One Identity Provider
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/updateFederationSettingIdentityProvider
             x-xgen-operation-id-override: updateIdentityProvider
     /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/jwks:
@@ -43393,6 +44282,8 @@ paths:
             summary: Revoke JWKS from One OIDC Identity Provider
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/revokeFederationSettingIdentityProviderJwks
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -43435,6 +44326,8 @@ paths:
             summary: Return Metadata of One Identity Provider
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getFederationSettingIdentityProviderMetadata
             x-xgen-method-verb-override:
                 customMethod: false
@@ -43565,6 +44458,8 @@ paths:
             summary: Remove One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/deleteGroup
         get:
             description: Returns details about the specified project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -43601,6 +44496,8 @@ paths:
             summary: Return One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroup
         patch:
             description: Updates the human-readable label that identifies the specified project, or the tags associated with the project. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -43644,6 +44541,8 @@ paths:
             summary: Update One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroup
     /api/atlas/v2/groups/{groupId}/access:
         post:
@@ -43698,6 +44597,8 @@ paths:
             summary: Add One MongoDB Cloud User to One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/addGroupAccessUser
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -43743,6 +44644,8 @@ paths:
             summary: Return All Project IP Access List Entries
             tags:
                 - Project IP Access List
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-changelog:
                 "2025-05-08": Corrects an issue where the endpoint would include Atlas internal entries.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/listGroupAccessListEntries
@@ -43800,6 +44703,8 @@ paths:
             summary: Add Entries to Project IP Access List
             tags:
                 - Project IP Access List
+            x-rolesRequirements:
+                - Project Network Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/createGroupAccessListEntry
             x-xgen-method-verb-override:
                 customMethod: false
@@ -43853,6 +44758,8 @@ paths:
             summary: Remove One Entry from One Project IP Access List
             tags:
                 - Project IP Access List
+            x-rolesRequirements:
+                - Project Network Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/deleteGroupAccessListEntry
             x-xgen-method-verb-override:
                 customMethod: false
@@ -43902,6 +44809,8 @@ paths:
             summary: Return One Project IP Access List Entry
             tags:
                 - Project IP Access List
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/getGroupAccessListEntry
             x-xgen-method-verb-override:
                 customMethod: false
@@ -43951,6 +44860,8 @@ paths:
             summary: Return Status of One Project IP Access List Entry
             tags:
                 - Project IP Access List
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Project-IP-Access-List/operation/getGroupAccessListStatus
             x-xgen-operation-id-override: getAccessListStatus
     /api/atlas/v2/groups/{groupId}/activityFeed:
@@ -44030,6 +44941,8 @@ paths:
             summary: Return Pre-Filtered Activity Feed Link for One Project
             tags:
                 - Activity Feed
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Activity-Feed/operation/getGroupActivityFeed
     /api/atlas/v2/groups/{groupId}/aiModelApiKeys:
         get:
@@ -44069,6 +44982,8 @@ paths:
             summary: Return AI Model API Keys for One Group
             tags:
                 - AI Model API Keys
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/listGroupAiModelApiKeys
             x-xgen-operation-id-override: listGroupModelKeys
         post:
@@ -44118,6 +45033,8 @@ paths:
             summary: Create New AI Model API Key
             tags:
                 - AI Model API Keys
+            x-rolesRequirements:
+                - Project Model Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/createGroupAiModelApiKey
             x-xgen-operation-id-override: createModelApiKey
     /api/atlas/v2/groups/{groupId}/aiModelApiKeys/{apiKeyId}:
@@ -44162,6 +45079,8 @@ paths:
             summary: Delete Existing AI Model API Key
             tags:
                 - AI Model API Keys
+            x-rolesRequirements:
+                - Project Model Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/deleteGroupAiModelApiKey
             x-xgen-operation-id-override: deleteModelApiKey
         get:
@@ -44205,6 +45124,8 @@ paths:
             summary: Return Single AI Model API Key for One Group
             tags:
                 - AI Model API Keys
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/getGroupAiModelApiKey
             x-xgen-operation-id-override: getGroupModelKey
         patch:
@@ -44260,6 +45181,8 @@ paths:
             summary: Update Existing AI Model API Key
             tags:
                 - AI Model API Keys
+            x-rolesRequirements:
+                - Project Model Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/updateGroupAiModelApiKey
             x-xgen-operation-id-override: updateModelApiKey
     /api/atlas/v2/groups/{groupId}/aiModelRateLimits:
@@ -44300,6 +45223,8 @@ paths:
             summary: Return AI Model Rate Limits for One Group
             tags:
                 - AI Model Rate Limits
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listGroupAiModelRateLimits
             x-xgen-operation-id-override: listGroupModelLimits
     /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:
@@ -44344,6 +45269,8 @@ paths:
             summary: Return Single AI Model Rate Limit for One Group
             tags:
                 - AI Model Rate Limits
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getGroupAiModelRateLimit
             x-xgen-operation-id-override: getGroupModelLimit
         patch:
@@ -44399,6 +45326,8 @@ paths:
             summary: Update AI Model Rate Limit
             tags:
                 - AI Model Rate Limits
+            x-rolesRequirements:
+                - Project Model Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/updateGroupAiModelRateLimit
             x-xgen-operation-id-override: updateModelRateLimit
     /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:reset:
@@ -44443,6 +45372,8 @@ paths:
             summary: Reset AI Model Rate Limit for One Model Group
             tags:
                 - AI Model Rate Limits
+            x-rolesRequirements:
+                - Project Model Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimit
             x-xgen-operation-id-override: resetModelRateLimit
     /api/atlas/v2/groups/{groupId}/aiModelRateLimits:reset:
@@ -44479,6 +45410,8 @@ paths:
             summary: Reset AI Model Rate Limits for Group
             tags:
                 - AI Model Rate Limits
+            x-rolesRequirements:
+                - Project Model Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimits
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -44524,6 +45457,8 @@ paths:
             summary: Return All Alert Configurations in One Project
             tags:
                 - Alert Configurations
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/listGroupAlertConfigs
             x-xgen-operation-id-override: listAlertConfigs
         post:
@@ -44571,6 +45506,8 @@ paths:
             summary: Create One Alert Configuration in One Project
             tags:
                 - Alert Configurations
+            x-rolesRequirements:
+                - Project Alerts Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/createGroupAlertConfig
             x-xgen-operation-id-override: createAlertConfig
     /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}:
@@ -44619,6 +45556,8 @@ paths:
             summary: Remove One Alert Configuration from One Project
             tags:
                 - Alert Configurations
+            x-rolesRequirements:
+                - Project Alerts Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/deleteGroupAlertConfig
             x-xgen-operation-id-override: deleteAlertConfig
         get:
@@ -44668,6 +45607,8 @@ paths:
             summary: Return One Alert Configuration from One Project
             tags:
                 - Alert Configurations
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/getGroupAlertConfig
             x-xgen-operation-id-override: getAlertConfig
         patch:
@@ -44726,6 +45667,8 @@ paths:
             summary: Toggle State of One Alert Configuration in One Project
             tags:
                 - Alert Configurations
+            x-rolesRequirements:
+                - Project Alerts Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/toggleGroupAlertConfig
             x-xgen-method-verb-override:
                 customMethod: true
@@ -44789,6 +45732,8 @@ paths:
             summary: Update One Alert Configuration in One Project
             tags:
                 - Alert Configurations
+            x-rolesRequirements:
+                - Project Alerts Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/updateGroupAlertConfig
             x-xgen-operation-id-override: updateAlertConfig
     /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}/alerts:
@@ -44842,6 +45787,8 @@ paths:
             summary: Return All Open Alerts for One Alert Configuration
             tags:
                 - Alerts
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/getGroupAlertConfigAlerts
             x-xgen-operation-id-override: getAlertConfigAlerts
     /api/atlas/v2/groups/{groupId}/alerts:
@@ -44895,6 +45842,8 @@ paths:
             summary: Return All Alerts from One Project
             tags:
                 - Alerts
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/listGroupAlerts
             x-xgen-operation-id-override: listAlerts
     /api/atlas/v2/groups/{groupId}/alerts/{alertId}:
@@ -44944,6 +45893,8 @@ paths:
             summary: Return One Alert from One Project
             tags:
                 - Alerts
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/getGroupAlert
             x-xgen-operation-id-override: getAlert
         patch:
@@ -45009,6 +45960,8 @@ paths:
             summary: Acknowledge One Alert from One Project
             tags:
                 - Alerts
+            x-rolesRequirements:
+                - Project Alerts Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alerts/operation/acknowledgeGroupAlert
             x-xgen-method-verb-override:
                 customMethod: true
@@ -45064,6 +46017,8 @@ paths:
             summary: Return All Alert Configurations Set for One Alert
             tags:
                 - Alert Configurations
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/getGroupAlertAlertConfigs
             x-xgen-operation-id-override: getAlertConfigs
     /api/atlas/v2/groups/{groupId}/apiKeys:
@@ -45106,6 +46061,8 @@ paths:
             summary: Return All Organization API Keys Assigned to One Project
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/listGroupApiKeys
         post:
             description: Creates and assigns the specified organization API key to the specified project. Users with the Project Owner role in the project associated with the API key can use the organization API key to access the resources. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Access Manager role.
@@ -45147,6 +46104,8 @@ paths:
             summary: Create and Assign One Organization API Key to One Project
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/createGroupApiKey
     /api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}:
         delete:
@@ -45192,6 +46151,8 @@ paths:
             summary: Unassign One Organization API Key from One Project
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/removeGroupApiKey
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -45248,6 +46209,8 @@ paths:
             summary: Update Organization API Key Roles for One Project
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/updateGroupApiKeyRoles
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -45301,6 +46264,8 @@ paths:
             summary: Assign One Organization API Key to One Project
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/addGroupApiKey
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -45339,6 +46304,8 @@ paths:
             summary: Return Auditing Configuration for One Project
             tags:
                 - Auditing
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Auditing/operation/getGroupAuditLog
         patch:
             description: Updates the auditing configuration for the specified project. The auditing configuration defines the events that MongoDB Cloud records in the audit log. To use this resource, the requesting Service Account or API Key must have the Project Owner role. This feature isn't available for `M0`, `M2`, `M5`, or serverless clusters.
@@ -45382,6 +46349,8 @@ paths:
             summary: Update Auditing Configuration for One Project
             tags:
                 - Auditing
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Auditing/operation/updateGroupAuditLog
             x-xgen-operation-id-override: updateAuditLog
     /api/atlas/v2/groups/{groupId}/awsCustomDNS:
@@ -45418,6 +46387,8 @@ paths:
             summary: Return One Custom DNS Configuration for Atlas Clusters on AWS
             tags:
                 - AWS Clusters DNS
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AWS-Clusters-DNS/operation/getGroupAwsCustomDns
             x-xgen-operation-id-override: getAwsCustomDns
         patch:
@@ -45460,6 +46431,8 @@ paths:
             summary: Update State of One Custom DNS Configuration for Atlas Clusters on AWS
             tags:
                 - AWS Clusters DNS
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AWS-Clusters-DNS/operation/toggleGroupAwsCustomDns
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -45510,6 +46483,8 @@ paths:
             summary: Return Object Storage Private Endpoints for Cloud Backups for One Cloud Provider in One Project
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupBackupPrivateEndpoints
             x-xgen-operation-id-override: listBackupPrivateEndpoints
         post:
@@ -45564,6 +46539,8 @@ paths:
             summary: Create One Object Storage Private Endpoint for Cloud Backups for One Cloud Provider in One Project
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupBackupPrivateEndpoint
             x-xgen-operation-id-override: createBackupPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/backup/{cloudProvider}/privateEndpoints/{endpointId}:
@@ -45613,6 +46590,8 @@ paths:
             summary: Delete One Object Storage Private Endpoint for Cloud Backups for One Cloud Provider from One Project
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupBackupPrivateEndpoint
             x-xgen-operation-id-override: deleteBackupPrivateEndpoint
         get:
@@ -45663,6 +46642,8 @@ paths:
             summary: Return One Object Storage Private Endpoint for Cloud Backups for One Cloud Provider in One Project
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupBackupPrivateEndpoint
             x-xgen-operation-id-override: getBackupPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/backup/exportBuckets:
@@ -45707,6 +46688,8 @@ paths:
             summary: Return All Snapshot Export Buckets
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupBackupExportBuckets
             x-xgen-operation-id-override: listExportBuckets
         post:
@@ -45838,6 +46821,8 @@ paths:
             summary: Create One Snapshot Export Bucket
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupBackupExportBucket
             x-xgen-operation-id-override: createExportBucket
     /api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}:
@@ -45881,6 +46866,8 @@ paths:
             summary: Delete One Snapshot Export Bucket
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupBackupExportBucket
             x-xgen-operation-id-override: deleteExportBucket
         get:
@@ -45976,6 +46963,8 @@ paths:
             summary: Return One Snapshot Export Bucket
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupBackupExportBucket
             x-xgen-operation-id-override: getExportBucket
         patch:
@@ -46029,6 +47018,8 @@ paths:
             summary: Update One Export Bucket Private Networking Settings
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupBackupExportBucket
             x-xgen-operation-id-override: updateBackupExportBucket
     /api/atlas/v2/groups/{groupId}/backupCompliancePolicy:
@@ -46065,6 +47056,8 @@ paths:
             summary: Disable Backup Compliance Policy Settings
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/disableGroupBackupCompliancePolicy
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -46108,6 +47101,8 @@ paths:
             summary: Return Backup Compliance Policy Settings
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupBackupCompliancePolicy
             x-xgen-operation-id-override: getCompliancePolicy
         put:
@@ -46168,6 +47163,8 @@ paths:
             summary: Update Backup Compliance Policy Settings
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupBackupCompliancePolicy
             x-xgen-operation-id-override: updateCompliancePolicy
     /api/atlas/v2/groups/{groupId}/cloudProviderAccess:
@@ -46204,6 +47201,8 @@ paths:
             summary: Return All Cloud Provider Access Roles
             tags:
                 - Cloud Provider Access
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/listGroupCloudProviderAccess
             x-xgen-operation-id-override: listCloudProviderAccess
         post:
@@ -46249,6 +47248,8 @@ paths:
             summary: Create One Cloud Provider Access Role
             tags:
                 - Cloud Provider Access
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/createGroupCloudProviderAccess
             x-xgen-operation-id-override: createCloudProviderAccess
     /api/atlas/v2/groups/{groupId}/cloudProviderAccess/{cloudProvider}/{roleId}:
@@ -46302,6 +47303,8 @@ paths:
             summary: Deauthorize One Cloud Provider Access Role
             tags:
                 - Cloud Provider Access
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/deauthorizeGroupCloudProviderAccessRole
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -46348,6 +47351,8 @@ paths:
             summary: Return One Cloud Provider Access Role
             tags:
                 - Cloud Provider Access
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/getGroupCloudProviderAccess
             x-xgen-operation-id-override: getCloudProviderAccess
         patch:
@@ -46404,6 +47409,8 @@ paths:
             summary: Authorize One Cloud Provider Access Role
             tags:
                 - Cloud Provider Access
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/authorizeGroupCloudProviderAccessRole
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -46474,6 +47481,8 @@ paths:
             summary: Return All Clusters in One Project
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/listGroupClusters
             x-xgen-operation-id-override: listClusters
         post:
@@ -46716,6 +47725,8 @@ paths:
             summary: Create One Cluster in One Project
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Cluster Creator
             x-xgen-changelog:
                 "2025-06-05": Fixed a bug that previously permitted users to configure multiple regionConfigs for the same region and cloud provider within a replicationSpec
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createGroupCluster
@@ -46777,6 +47788,8 @@ paths:
             summary: Remove One Cluster from One Project
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/deleteGroupCluster
             x-xgen-operation-id-override: deleteCluster
         get:
@@ -46849,6 +47862,8 @@ paths:
             summary: Return One Cluster from One Project
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupCluster
             x-xgen-operation-id-override: getCluster
         patch:
@@ -46940,6 +47955,9 @@ paths:
             summary: Update One Cluster in One Project
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Cluster Manager
+                - Project Replica Set Manager
             x-xgen-changelog:
                 "2025-06-05": Fixed a bug that previously permitted users to configure multiple regionConfigs for the same region and cloud provider within a replicationSpec
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/updateGroupCluster
@@ -47037,6 +48055,8 @@ paths:
             summary: Return Cluster-Level Query Latency
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupClusterCollStatMeasurements
             x-xgen-operation-id-override: listCollStatMeasurements
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/{clusterView}/collStats/namespaces:
@@ -47092,6 +48112,8 @@ paths:
             summary: Return Ranked Namespaces from One Cluster
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/getGroupClusterCollStatNamespaces
             x-xgen-method-verb-override:
                 customMethod: false
@@ -47141,6 +48163,8 @@ paths:
             summary: Return Auto Scaling Configuration for One Sharded Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/autoGroupClusterScalingConfiguration
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -47189,6 +48213,8 @@ paths:
             summary: Return All Snapshot Export Jobs
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupExports
             x-xgen-operation-id-override: listBackupExports
         post:
@@ -47241,6 +48267,8 @@ paths:
             summary: Create One Snapshot Export Job
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Export Operator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupClusterBackupExport
             x-xgen-operation-id-override: createBackupExport
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports/{exportId}:
@@ -47291,6 +48319,8 @@ paths:
             summary: Return One Snapshot Export Job
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupExport
             x-xgen-operation-id-override: getBackupExport
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs:
@@ -47337,6 +48367,8 @@ paths:
             summary: Return All Restore Jobs for One Cluster
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupRestoreJobs
             x-xgen-operation-id-override: listBackupRestoreJobs
         post:
@@ -47393,6 +48425,9 @@ paths:
             summary: Create One Restore Job of One Cluster
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Export Operator
+                - Project Backup Recovery Operator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupClusterBackupRestoreJob
             x-xgen-operation-id-override: createBackupRestoreJob
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs/{restoreJobId}:
@@ -47445,6 +48480,9 @@ paths:
             summary: Cancel One Restore Job for One Cluster
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Export Operator
+                - Project Backup Recovery Operator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/cancelGroupClusterBackupRestoreJob
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -47497,6 +48535,8 @@ paths:
             summary: Return One Restore Job for One Cluster
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupRestoreJob
             x-xgen-operation-id-override: getBackupRestoreJob
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule:
@@ -47546,6 +48586,8 @@ paths:
             summary: Remove All Cloud Backup Schedules
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupClusterBackupSchedule
             x-xgen-operation-id-override: deleteClusterBackupSchedule
         get:
@@ -47593,6 +48635,8 @@ paths:
             summary: Return One Cloud Backup Schedule
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSchedule
             x-xgen-method-verb-override:
                 customMethod: "False"
@@ -47658,6 +48702,8 @@ paths:
             summary: Update Cloud Backup Schedule for One Cluster
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupClusterBackupSchedule
             x-xgen-operation-id-override: updateBackupSchedule
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots:
@@ -47678,6 +48724,24 @@ paths:
                   schema:
                     pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
                     type: string
+                - description: Desired point in time, expressed as the number of seconds that have elapsed since the UNIX epoch. If specified, returns the closest snapshot created before that point in time. Mutually exclusive with `oplogTs` and `oplogInc`.
+                  in: query
+                  name: pointInTimeUtcSeconds
+                  schema:
+                    format: int64
+                    type: integer
+                - description: Oplog timestamp that represents the desired point in time. This is the first part of an Oplog timestamp. Must be used with `oplogInc`. Mutually exclusive with `pointInTimeUtcSeconds`.
+                  in: query
+                  name: oplogTs
+                  schema:
+                    format: int64
+                    type: integer
+                - description: Oplog operation number that represents the desired point in time. This is the second part of an Oplog timestamp. Must be used with `oplogTs`. Mutually exclusive with `pointInTimeUtcSeconds`.
+                  in: query
+                  name: oplogInc
+                  schema:
+                    format: int64
+                    type: integer
             responses:
                 "200":
                     content:
@@ -47706,6 +48770,8 @@ paths:
             summary: Return All Replica Set Cloud Backups
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshots
             x-xgen-operation-id-override: listBackupSnapshots
         post:
@@ -47760,6 +48826,8 @@ paths:
             summary: Take One On-Demand Snapshot
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Creator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/takeGroupClusterBackupSnapshots
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -47813,6 +48881,8 @@ paths:
             summary: Remove One Replica Set Cloud Backup
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupClusterBackupSnapshot
             x-xgen-operation-id-override: deleteClusterBackupSnapshot
         get:
@@ -47864,6 +48934,8 @@ paths:
             summary: Return One Replica Set Cloud Backup
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshot
             x-xgen-operation-id-override: getClusterBackupSnapshot
         patch:
@@ -47922,8 +48994,260 @@ paths:
             summary: Update Expiration Date for One Cloud Backup
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupClusterBackupSnapshot
             x-xgen-operation-id-override: updateBackupSnapshot
+    /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases:
+        get:
+            description: Returns the list of databases that exist in the specified snapshot. Use this to discover namespaces before creating a collection restore job. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+            operationId: listGroupClusterBackupSnapshotDatabases
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/includeCount'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+                  in: path
+                  name: snapshotId
+                  required: true
+                  schema:
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiAtlasDiskBackupDatabaseView'
+                            x-xgen-preview:
+                                name: snapshot-namespaces
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Databases in One Snapshot
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshotDatabases
+            x-xgen-operation-id-override: listBackupSnapshotDatabases
+    /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases/{databaseName}:
+        get:
+            description: Returns one database that exists in the specified snapshot. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+            operationId: getGroupClusterBackupSnapshotDatabase
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+                  in: path
+                  name: snapshotId
+                  required: true
+                  schema:
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                - description: Human-readable label that identifies the database.
+                  in: path
+                  name: databaseName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/DiskBackupDatabaseResponse'
+                            x-xgen-preview:
+                                name: snapshot-namespaces
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Database in One Snapshot
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshotDatabase
+            x-xgen-operation-id-override: getBackupSnapshotDatabase
+    /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases/{databaseName}/collections:
+        get:
+            description: Returns the list of collections in the specified database that exist in the snapshot. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+            operationId: listGroupClusterBackupSnapshotDatabaseCollections
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/includeCount'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+                  in: path
+                  name: snapshotId
+                  required: true
+                  schema:
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                - description: Human-readable label that identifies the database.
+                  in: path
+                  name: databaseName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiAtlasDiskBackupCollectionView'
+                            x-xgen-preview:
+                                name: snapshot-namespaces
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Collections in One Database in One Snapshot
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshotDatabaseCollections
+            x-xgen-operation-id-override: listSnapshotDatabaseCollections
+    ? /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}/databases/{databaseName}/collections/{collectionName}
+    :   get:
+            description: Returns one collection that exists in the specified database in the snapshot. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+            operationId: getGroupClusterBackupSnapshotDatabaseCollection
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the desired snapshot.
+                  in: path
+                  name: snapshotId
+                  required: true
+                  schema:
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                - description: Human-readable label that identifies the database.
+                  in: path
+                  name: databaseName
+                  required: true
+                  schema:
+                    type: string
+                - description: Human-readable label that identifies the collection.
+                  in: path
+                  name: collectionName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/DiskBackupCollectionResponse'
+                            x-xgen-preview:
+                                name: snapshot-namespaces
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Collection in One Database in One Snapshot
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshotDatabaseCollection
+            x-xgen-operation-id-override: getSnapshotDatabaseCollection
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/shardedCluster/{snapshotId}:
         delete:
             description: Removes one snapshot of one sharded cluster from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
@@ -47970,6 +49294,8 @@ paths:
             summary: Remove One Sharded Cluster Cloud Backup
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/deleteGroupClusterBackupSnapshotShardedCluster
             x-xgen-operation-id-override: deleteBackupShardedCluster
         get:
@@ -48021,6 +49347,8 @@ paths:
             summary: Return One Sharded Cluster Cloud Backup
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterBackupSnapshotShardedCluster
             x-xgen-operation-id-override: getBackupShardedCluster
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/shardedClusters:
@@ -48066,6 +49394,8 @@ paths:
             summary: Return All Sharded Cluster Cloud Backups
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterBackupSnapshotShardedClusters
             x-xgen-operation-id-override: listBackupShardedClusters
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backupCheckpoints:
@@ -48113,6 +49443,8 @@ paths:
             summary: Return All Legacy Backup Checkpoints
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/listGroupClusterBackupCheckpoints
             x-xgen-operation-id-override: listClusterBackupCheckpoints
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backupCheckpoints/{checkpointId}:
@@ -48166,6 +49498,8 @@ paths:
             summary: Return One Legacy Backup Checkpoint
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterBackupCheckpoint
             x-xgen-operation-id-override: getClusterBackupCheckpoint
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned:
@@ -48210,6 +49544,8 @@ paths:
             summary: Return Pinned Namespaces
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupClusterCollStatPinnedNamespaces
             x-xgen-method-verb-override:
                 customMethod: true
@@ -48275,6 +49611,8 @@ paths:
             summary: Add Pinned Namespaces
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/updateGroupClusterCollStatPinnedNamespaces
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -48340,6 +49678,8 @@ paths:
             summary: Pin Namespaces
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/pinGroupClusterCollStatPinnedNamespaces
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -48394,11 +49734,327 @@ paths:
             summary: Unpin Namespaces
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/unpinGroupClusterCollStatUnpinNamespaces
             x-xgen-method-verb-override:
                 customMethod: "True"
                 verb: unpinNamespaces
             x-xgen-operation-id-override: unpinNamespaces
+    /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs:
+        get:
+            description: Returns all collection restore jobs for one cluster from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+            operationId: listGroupClusterCollectionRestoreJobs
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster with the collection restore jobs you want to return.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiAtlasCollectionRestoreJobView'
+                            x-xgen-preview:
+                                name: collection-restore-jobs
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Collection Restore Jobs for One Cluster
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterCollectionRestoreJobs
+            x-xgen-operation-id-override: listCollectionRestoreJobs
+        post:
+            description: Creates one collection-level restore job for one cluster from the specified project. Collection-level restores allow restoring specific databases or collections from a snapshot or point-in-time. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role or Project Backup Recovery Operator role.
+            operationId: createGroupClusterCollectionRestoreJob
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the source cluster for the restore.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/ApiAtlasCollectionRestoreJobRequest'
+                        x-xgen-preview:
+                            name: collection-restore-jobs
+                        x-xgen-version: preview
+                description: Creates one collection-level restore job for one cluster from the specified project.
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiAtlasCollectionRestoreJobResponse'
+                            x-xgen-preview:
+                                name: collection-restore-jobs
+                            x-xgen-version: preview
+                    description: Created
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "409":
+                    $ref: '#/components/responses/conflict'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Create One Collection Restore Job
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Recovery Operator
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupClusterCollectionRestoreJob
+            x-xgen-operation-id-override: createCollectionRestoreJob
+    /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs/{jobId}:
+        get:
+            description: Returns one collection restore job for one cluster from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+            operationId: getGroupClusterCollectionRestoreJob
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster with the collection restore jobs you want to return.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the collection restore job to return.
+                  in: path
+                  name: jobId
+                  required: true
+                  schema:
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiAtlasCollectionRestoreJobResponse'
+                            x-xgen-preview:
+                                name: collection-restore-jobs
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Collection Restore Job for One Cluster
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterCollectionRestoreJob
+            x-xgen-operation-id-override: getCollectionRestoreJob
+    /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs/{jobId}/collections:
+        get:
+            description: 'Returns all collection-level restore states for one collection restore job from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role. Note: If the restore job is in the INITIALIZING state, this endpoint returns an empty list because collection-level states have not yet been created.'
+            operationId: listGroupClusterCollectionRestoreJobCollections
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster with the collection restore job you want to return.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the collection restore job.
+                  in: path
+                  name: jobId
+                  required: true
+                  schema:
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                - description: Collection-level state to filter by.
+                  in: query
+                  name: state
+                  schema:
+                    description: Current state of this collection within the restore job.
+                    enum:
+                        - NOT_STARTED
+                        - IN_PROGRESS
+                        - FINALIZING
+                        - NOT_FOUND
+                        - UNSUPPORTED
+                        - SUCCESSFUL
+                        - ROLLBACK
+                        - NOT_RESTORED
+                        - FAILED
+                        - INDEX_BUILD_FAILED
+                    type: string
+                - description: Source namespace to filter by (e.g. `db.collection`).
+                  in: query
+                  name: sourceNamespace
+                  schema:
+                    type: string
+                - description: Target namespace to filter by (e.g. `db.collection`).
+                  in: query
+                  name: targetNamespace
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiAtlasCollectionRestoreCollectionStateView'
+                            x-xgen-preview:
+                                name: collection-restore-jobs
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Collection States for One Collection Restore Job
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupClusterCollectionRestoreJobCollections
+            x-xgen-operation-id-override: listRestoreJobCollections
+    /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collectionRestoreJobs/{jobId}/collections/{sourceNamespace}:
+        get:
+            description: Returns one collection-level restore state for one collection restore job from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Backup Manager role.
+            operationId: getGroupClusterCollectionRestoreJobCollection
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Human-readable label that identifies the cluster with the collection restore job you want to return.
+                  in: path
+                  name: clusterName
+                  required: true
+                  schema:
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the collection restore job.
+                  in: path
+                  name: jobId
+                  required: true
+                  schema:
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                - description: Source namespace that identifies the collection to return (e.g. `db.collection`).
+                  in: path
+                  name: sourceNamespace
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiAtlasCollectionRestoreCollectionStateResponse'
+                            x-xgen-preview:
+                                name: collection-restore-jobs
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Collection State for One Collection Restore Job
+            tags:
+                - Cloud Backups
+            x-rolesRequirements:
+                - Project Backup Manager
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupClusterCollectionRestoreJobCollection
+            x-xgen-operation-id-override: getRestoreJobCollection
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes:
         post:
             deprecated: true
@@ -48456,6 +50112,8 @@ paths:
             summary: Create One Atlas Search Index
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/createGroupClusterFtsIndex
             x-xgen-operation-id-override: createClusterFtsIndex
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}:
@@ -48519,6 +50177,11 @@ paths:
             summary: Return All Atlas Search Indexes for One Collection
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Search Index Editor
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/listGroupClusterFtsIndex
             x-xgen-method-verb-override:
                 customMethod: false
@@ -48577,6 +50240,8 @@ paths:
             summary: Remove One Atlas Search Index
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterFtsIndex
             x-xgen-operation-id-override: deleteClusterFtsIndex
         get:
@@ -48631,6 +50296,11 @@ paths:
             summary: Return One Atlas Search Index
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Search Index Editor
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterFtsIndex
             x-xgen-operation-id-override: getClusterFtsIndex
         patch:
@@ -48696,6 +50366,8 @@ paths:
             summary: Update One Atlas Search Index
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterFtsIndex
             x-xgen-operation-id-override: updateClusterFtsIndex
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites:
@@ -48768,6 +50440,8 @@ paths:
             summary: Return One Managed Namespace in One Global Cluster
             tags:
                 - Global Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/getGroupClusterGlobalWrites
             x-xgen-operation-id-override: getClusterGlobalWrites
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping:
@@ -48840,6 +50514,8 @@ paths:
             summary: Remove All Custom Zone Mappings from One Global Cluster
             tags:
                 - Global Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/deleteGroupClusterGlobalWriteCustomZoneMapping
             x-xgen-operation-id-override: deleteCustomZoneMapping
         post:
@@ -48927,6 +50603,8 @@ paths:
             summary: Add One Custom Zone Mapping to One Global Cluster
             tags:
                 - Global Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/createGroupClusterGlobalWriteCustomZoneMapping
             x-xgen-operation-id-override: createCustomZoneMapping
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces:
@@ -49011,6 +50689,8 @@ paths:
             summary: Remove One Managed Namespace from One Global Cluster
             tags:
                 - Global Clusters
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/deleteGroupClusterGlobalWriteManagedNamespaces
             x-xgen-operation-id-override: deleteManagedNamespaces
         post:
@@ -49100,6 +50780,8 @@ paths:
             summary: Create One Managed Namespace in One Global Cluster
             tags:
                 - Global Clusters
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters/operation/createGroupClusterGlobalWriteManagedNamespace
             x-xgen-operation-id-override: createManagedNamespace
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index:
@@ -49211,6 +50893,8 @@ paths:
                     $ref: '#/components/responses/forbidden'
                 "404":
                     $ref: '#/components/responses/notFound'
+                "409":
+                    $ref: '#/components/responses/conflict'
                 "429":
                     $ref: '#/components/responses/tooManyRequests'
                 "500":
@@ -49218,8 +50902,12 @@ paths:
             summary: Create One Rolling Index
             tags:
                 - Rolling Index
+            x-rolesRequirements:
+                - Project Data Access Admin
+                - Project Index Manager
             x-xgen-changelog:
                 "2025-05-08": Corrects an issue where the endpoint would allow a rolling index build to be initiated while there was already an index build in progress. The endpoint now returns 400 if an index build is already in progress.
+                "2026-04-06": Corrects an issue where index creation was throwing a 500 error instead of a 409 error when there was an existing index with the same name.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rolling-Index/operation/createGroupClusterIndexRollingIndex
             x-xgen-method-verb-override:
                 customMethod: false
@@ -49275,6 +50963,8 @@ paths:
             summary: Return All Lifecycle Management Policies for One Cluster
             tags:
                 - Lifecycle Management
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/listGroupClusterLifecycleManagementPolicies
             x-xgen-operation-id-override: listLifecycleManagementPolicies
         post:
@@ -49338,6 +51028,8 @@ paths:
             summary: Create One Lifecycle Management Policy
             tags:
                 - Lifecycle Management
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/createGroupClusterLifecycleManagementPolicy
             x-xgen-operation-id-override: createLifecycleManagementPolicy
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/lifecycleManagementPolicies/{policyId}:
@@ -49395,6 +51087,8 @@ paths:
             summary: Delete One Lifecycle Management Policy
             tags:
                 - Lifecycle Management
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/deleteGroupClusterLifecycleManagementPolicy
             x-xgen-operation-id-override: deleteLifecycleManagementPolicy
         get:
@@ -49451,6 +51145,8 @@ paths:
             summary: Return One Lifecycle Management Policy
             tags:
                 - Lifecycle Management
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/getGroupClusterLifecycleManagementPolicy
             x-xgen-operation-id-override: getLifecycleManagementPolicy
         patch:
@@ -49521,6 +51217,8 @@ paths:
             summary: Update One Lifecycle Management Policy
             tags:
                 - Lifecycle Management
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Lifecycle-Management/operation/updateGroupClusterLifecycleManagementPolicy
             x-xgen-operation-id-override: updateLifecycleManagementPolicy
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives:
@@ -49570,6 +51268,8 @@ paths:
             summary: Return All Online Archives for One Cluster
             tags:
                 - Online Archive
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/listGroupClusterOnlineArchives
             x-xgen-operation-id-override: listOnlineArchives
         post:
@@ -49626,6 +51326,8 @@ paths:
             summary: Create One Online Archive
             tags:
                 - Online Archive
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-changelog:
                 "2023-08-02": If 'criteria':'DATE' is specified, then you must specify 'DATE' values in partition fields
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/createGroupClusterOnlineArchive
@@ -49679,6 +51381,8 @@ paths:
             summary: Remove One Online Archive
             tags:
                 - Online Archive
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/deleteGroupClusterOnlineArchive
             x-xgen-operation-id-override: deleteOnlineArchive
         get:
@@ -49733,6 +51437,8 @@ paths:
             summary: Return One Online Archive
             tags:
                 - Online Archive
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/getGroupClusterOnlineArchive
             x-xgen-operation-id-override: getOnlineArchive
         patch:
@@ -49796,6 +51502,8 @@ paths:
             summary: Update One Online Archive
             tags:
                 - Online Archive
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/updateGroupClusterOnlineArchive
             x-xgen-operation-id-override: updateOnlineArchive
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz:
@@ -49867,6 +51575,11 @@ paths:
             summary: Download Online Archive Query Logs
             tags:
                 - Online Archive
+            x-rolesRequirements:
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/downloadGroupClusterOnlineArchiveQueryLogs
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -49918,6 +51631,10 @@ paths:
             summary: End One Outage Simulation
             tags:
                 - Cluster Outage Simulation
+            x-rolesRequirements:
+                - Project Cluster Manager
+                - Project Cluster Resilience Tester
+                - Project Replica Set Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cluster-Outage-Simulation/operation/endGroupClusterOutageSimulation
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -49968,6 +51685,8 @@ paths:
             summary: Return One Outage Simulation
             tags:
                 - Cluster Outage Simulation
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cluster-Outage-Simulation/operation/getGroupClusterOutageSimulation
             x-xgen-method-verb-override:
                 customMethod: false
@@ -50025,6 +51744,10 @@ paths:
             summary: Start One Outage Simulation
             tags:
                 - Cluster Outage Simulation
+            x-rolesRequirements:
+                - Project Cluster Manager
+                - Project Cluster Resilience Tester
+                - Project Replica Set Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cluster-Outage-Simulation/operation/startGroupClusterOutageSimulation
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -50071,6 +51794,8 @@ paths:
             summary: Return All Suggested Indexes to Drop
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupClusterPerformanceAdvisorDropIndexSuggestions
             x-xgen-operation-id-override: listDropIndexSuggestions
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/performanceAdvisor/schemaAdvice:
@@ -50114,6 +51839,8 @@ paths:
             summary: Return Schema Advice
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupClusterPerformanceAdvisorSchemaAdvice
             x-xgen-operation-id-override: listSchemaAdvice
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/performanceAdvisor/suggestedIndexes:
@@ -50196,6 +51923,8 @@ paths:
             summary: Return All Suggested Indexes
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupClusterPerformanceAdvisorSuggestedIndexes
             x-xgen-operation-id-override: listClusterSuggestedIndexes
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs:
@@ -50249,6 +51978,8 @@ paths:
             summary: Return Advanced Configuration Options for One Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupClusterProcessArgs
             x-xgen-operation-id-override: getProcessArgs
         patch:
@@ -50313,6 +52044,8 @@ paths:
             summary: Update Advanced Configuration Options for One Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/updateGroupClusterProcessArgs
             x-xgen-operation-id-override: updateProcessArgs
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/queryShapeInsights/{queryShapeHash}/details:
@@ -50397,6 +52130,8 @@ paths:
             summary: Return Query Shape Details
             tags:
                 - Query Shape Insights
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/getGroupClusterQueryShapeInsightDetails
             x-xgen-operation-id-override: getQueryShapeDetails
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/queryShapeInsights/summaries:
@@ -50544,6 +52279,8 @@ paths:
             summary: Return Query Statistic Summaries
             tags:
                 - Query Shape Insights
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/listGroupClusterQueryShapeInsightSummaries
             x-xgen-operation-id-override: listQueryShapeSummaries
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/queryShapes:
@@ -50600,6 +52337,8 @@ paths:
             summary: Return All Query Shapes
             tags:
                 - Query Shape Insights
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/listGroupClusterQueryShapes
             x-xgen-operation-id-override: listClusterQueryShapes
             x-xgen-version: "2025-03-12"
@@ -50653,6 +52392,8 @@ paths:
             summary: Return One Query Shape
             tags:
                 - Query Shape Insights
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/getGroupClusterQueryShape
             x-xgen-operation-id-override: getClusterQueryShape
             x-xgen-version: "2025-03-12"
@@ -50712,6 +52453,8 @@ paths:
             summary: Update Query Shape Rejection Status
             tags:
                 - Query Shape Insights
+            x-rolesRequirements:
+                - Project Data Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Query-Shape-Insights/operation/updateGroupClusterQueryShape
             x-xgen-operation-id-override: updateClusterQueryShape
             x-xgen-version: "2025-03-12"
@@ -50757,6 +52500,8 @@ paths:
             summary: Test Failover for One Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/restartGroupClusterPrimaries
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -50820,6 +52565,8 @@ paths:
             summary: Return All Legacy Backup Restore Jobs
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/listGroupClusterRestoreJobs
             x-xgen-operation-id-override: listClusterRestoreJobs
         post:
@@ -50875,6 +52622,8 @@ paths:
             summary: Create One Legacy Backup Restore Job
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/createGroupClusterRestoreJob
             x-xgen-operation-id-override: createClusterRestoreJob
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs/{jobId}:
@@ -50934,6 +52683,8 @@ paths:
             summary: Return One Legacy Backup Restore Job
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterRestoreJob
             x-xgen-operation-id-override: getClusterRestoreJob
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment:
@@ -50990,6 +52741,8 @@ paths:
             summary: Delete Search Nodes
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterSearchDeployment
             x-xgen-operation-id-override: deleteClusterSearchDeployment
         get:
@@ -51044,6 +52797,8 @@ paths:
             summary: Return All Search Nodes
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-changelog:
                 "2025-03-12": Updates the return of the API when no nodes exist, the endpoint returns 200 with an empty JSON ({}) instead of 400.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterSearchDeployment
@@ -51110,6 +52865,8 @@ paths:
             summary: Update Search Nodes
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterSearchDeployment
             x-xgen-operation-id-override: updateClusterSearchDeployment
         post:
@@ -51179,6 +52936,8 @@ paths:
             summary: Create Search Nodes
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/createGroupClusterSearchDeployment
             x-xgen-operation-id-override: createClusterSearchDeployment
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes:
@@ -51236,6 +52995,11 @@ paths:
             summary: Return All Atlas Search Indexes for One Cluster
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Search Index Editor
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/listGroupClusterSearchIndexes
             x-xgen-operation-id-override: listClusterSearchIndexes
         post:
@@ -51292,6 +53056,8 @@ paths:
             summary: Create One Atlas Search Index
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/createGroupClusterSearchIndex
             x-xgen-operation-id-override: createClusterSearchIndex
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}:
@@ -51361,6 +53127,11 @@ paths:
             summary: Return All Atlas Search Indexes for One Collection
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Search Index Editor
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/listGroupClusterSearchIndex
             x-xgen-method-verb-override:
                 customMethod: false
@@ -51428,6 +53199,8 @@ paths:
             summary: Remove One Atlas Search Index by Name
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterSearchIndexByName
             x-xgen-method-verb-override:
                 customMethod: true
@@ -51496,6 +53269,11 @@ paths:
             summary: Return One Atlas Search Index by Name
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Search Index Editor
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterSearchIndexByName
             x-xgen-method-verb-override:
                 customMethod: true
@@ -51573,6 +53351,8 @@ paths:
             summary: Update One Atlas Search Index by Name
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterSearchIndexByName
             x-xgen-method-verb-override:
                 customMethod: true
@@ -51629,6 +53409,8 @@ paths:
             summary: Remove One Atlas Search Index by ID
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/deleteGroupClusterSearchIndex
             x-xgen-operation-id-override: deleteClusterSearchIndex
         get:
@@ -51689,6 +53471,11 @@ paths:
             summary: Return One Atlas Search Index by ID
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Search Index Editor
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/getGroupClusterSearchIndex
             x-xgen-operation-id-override: getClusterSearchIndex
         patch:
@@ -51752,6 +53539,8 @@ paths:
             summary: Update One Atlas Search Index by ID
             tags:
                 - Atlas Search
+            x-rolesRequirements:
+                - Project Search Index Editor
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Atlas-Search/operation/updateGroupClusterSearchIndex
             x-xgen-operation-id-override: updateClusterSearchIndex
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule:
@@ -51802,6 +53591,8 @@ paths:
             summary: Return One Snapshot Schedule
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterSnapshotSchedule
             x-xgen-operation-id-override: getClusterSnapshotSchedule
         patch:
@@ -51860,6 +53651,8 @@ paths:
             summary: Update Snapshot Schedule for One Cluster
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/updateGroupClusterSnapshotSchedule
             x-xgen-operation-id-override: updateClusterSnapshotSchedule
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots:
@@ -51920,6 +53713,8 @@ paths:
             summary: Return All Legacy Backup Snapshots
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/listGroupClusterSnapshots
             x-xgen-operation-id-override: listClusterSnapshots
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}:
@@ -51974,6 +53769,8 @@ paths:
             summary: Remove One Legacy Backup Snapshot
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/deleteGroupClusterSnapshot
             x-xgen-operation-id-override: deleteClusterSnapshot
         get:
@@ -52027,6 +53824,8 @@ paths:
             summary: Return One Legacy Backup Snapshot
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/getGroupClusterSnapshot
             x-xgen-operation-id-override: getClusterSnapshot
         patch:
@@ -52087,6 +53886,8 @@ paths:
             summary: Update Expiration Date for One Legacy Backup Snapshot
             tags:
                 - Legacy Backup
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Legacy-Backup/operation/updateGroupClusterSnapshot
             x-xgen-operation-id-override: updateClusterSnapshot
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/status:
@@ -52130,6 +53931,8 @@ paths:
             summary: Return Status of All Cluster Operations
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupClusterStatus
             x-xgen-operation-id-override: getClusterStatus
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:grantMongoDBEmployeeAccess:
@@ -52183,6 +53986,8 @@ paths:
             summary: Grant MongoDB Employee Cluster Access for One Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Support Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/grantGroupClusterMongoDbEmployeeAccess
             x-xgen-operation-id-override: grantMongoEmployeeAccess
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion:
@@ -52235,6 +54040,8 @@ paths:
             summary: Pin Feature Compatibility Version for One Cluster in One Project
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/pinGroupClusterFeatureCompatibilityVersion
             x-xgen-operation-id-override: pinFeatureCompatibilityVersion
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:revokeMongoDBEmployeeAccess:
@@ -52280,6 +54087,8 @@ paths:
             summary: Revoke MongoDB Employee Cluster Access for One Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Support Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/revokeGroupClusterMongoDbEmployeeAccess
             x-xgen-operation-id-override: revokeMongoEmployeeAccess
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion:
@@ -52327,6 +54136,8 @@ paths:
             summary: Unpin Feature Compatibility Version for One Cluster in One Project
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/unpinGroupClusterFeatureCompatibilityVersion
             x-xgen-operation-id-override: unpinFeatureCompatibilityVersion
     /api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz:
@@ -52410,6 +54221,12 @@ paths:
             summary: Download Logs for One Cluster Host in One Project
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Cluster Log Viewer
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/downloadGroupClusterLog
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -52464,6 +54281,8 @@ paths:
             summary: Return All Cloud Provider Regions
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/listGroupClusterProviderRegions
             x-xgen-operation-id-override: listClusterProviderRegions
     /api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade:
@@ -52516,6 +54335,8 @@ paths:
             summary: Upgrade One Shared-Tier Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/upgradeGroupClusterTenantUpgrade
             x-xgen-method-verb-override:
                 customMethod: true
@@ -52576,6 +54397,8 @@ paths:
             summary: Upgrade One Shared-Tier Cluster to One Serverless Instance
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/upgradeGroupClusterTenantUpgradeToServerless
             x-xgen-method-verb-override:
                 customMethod: true
@@ -52614,6 +54437,8 @@ paths:
             summary: Return All Metric Names
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupCollStatMetrics
             x-xgen-operation-id-override: listCollStatMetrics
     /api/atlas/v2/groups/{groupId}/containers:
@@ -52664,6 +54489,8 @@ paths:
             summary: Return All Network Peering Containers in One Project for One Cloud Provider
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/listGroupContainers
         post:
             description: Creates one new network peering container in the specified project. MongoDB Cloud can deploy Network Peering connections in a network peering container. GCP can have one container per project. AWS and Azure can have one container per cloud provider region. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -52709,6 +54536,8 @@ paths:
             summary: Create One Network Peering Container
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/createGroupContainer
     /api/atlas/v2/groups/{groupId}/containers/{containerId}:
         delete:
@@ -52754,6 +54583,8 @@ paths:
             summary: Remove One Network Peering Container
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/deleteGroupContainer
         get:
             description: Returns details about one network peering container in one specified project. Network peering containers contain network peering connections. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -52796,6 +54627,8 @@ paths:
             summary: Return One Network Peering Container
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/getGroupContainer
         patch:
             description: Updates the network details and labels of one specified network peering container in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -52849,6 +54682,8 @@ paths:
             summary: Update One Network Peering Container
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/updateGroupContainer
     /api/atlas/v2/groups/{groupId}/containers/all:
         get:
@@ -52887,6 +54722,8 @@ paths:
             summary: Return All Network Peering Containers in One Project
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/listGroupContainerAll
             x-xgen-method-verb-override:
                 customMethod: "False"
@@ -52927,6 +54764,8 @@ paths:
             summary: Return All Custom Roles in One Project
             tags:
                 - Custom Database Roles
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/listGroupCustomDbRoleRoles
             x-xgen-operation-id-override: listCustomDbRoles
         post:
@@ -52973,6 +54812,9 @@ paths:
             summary: Create One Custom Role
             tags:
                 - Custom Database Roles
+            x-rolesRequirements:
+                - Project Database Access Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/createGroupCustomDbRoleRole
             x-xgen-operation-id-override: createCustomDbRole
     /api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}:
@@ -53017,6 +54859,9 @@ paths:
             summary: Remove One Custom Role from One Project
             tags:
                 - Custom Database Roles
+            x-rolesRequirements:
+                - Project Database Access Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/deleteGroupCustomDbRoleRole
             x-xgen-operation-id-override: deleteCustomDbRole
         get:
@@ -53058,6 +54903,8 @@ paths:
             summary: Return One Custom Role in One Project
             tags:
                 - Custom Database Roles
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/getGroupCustomDbRoleRole
             x-xgen-operation-id-override: getCustomDbRole
         patch:
@@ -53110,6 +54957,9 @@ paths:
             summary: Update One Custom Role in One Project
             tags:
                 - Custom Database Roles
+            x-rolesRequirements:
+                - Project Database Access Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/updateGroupCustomDbRoleRole
             x-xgen-operation-id-override: updateCustomDbRole
     /api/atlas/v2/groups/{groupId}/dataFederation:
@@ -53157,6 +55007,8 @@ paths:
             summary: Return All Federated Database Instances in One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/listGroupDataFederation
             x-xgen-operation-id-override: listDataFederation
         post:
@@ -53207,6 +55059,8 @@ paths:
             summary: Create One Federated Database Instance in One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createGroupDataFederation
             x-xgen-operation-id-override: createDataFederation
     /api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}:
@@ -53247,6 +55101,8 @@ paths:
             summary: Remove One Federated Database Instance from One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/deleteGroupDataFederation
             x-xgen-operation-id-override: deleteDataFederation
         get:
@@ -53289,6 +55145,8 @@ paths:
             summary: Return One Federated Database Instance in One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/getGroupDataFederation
             x-xgen-operation-id-override: getDataFederation
         patch:
@@ -53345,6 +55203,8 @@ paths:
             summary: Update One Federated Database Instance in One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/updateGroupDataFederation
             x-xgen-operation-id-override: updateDataFederation
     /api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits:
@@ -53389,6 +55249,8 @@ paths:
             summary: Return All Query Limits for One Federated Database Instance
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/listGroupDataFederationLimits
             x-xgen-operation-id-override: listDataFederationLimits
     /api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}:
@@ -53449,6 +55311,8 @@ paths:
             summary: Delete One Query Limit for One Federated Database Instance
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/deleteGroupDataFederationLimit
             x-xgen-operation-id-override: deleteDataFederationLimit
         get:
@@ -53509,6 +55373,8 @@ paths:
             summary: Return One Federated Database Instance Query Limit for One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/getGroupDataFederationLimit
             x-xgen-operation-id-override: getDataFederationLimit
         patch:
@@ -53577,6 +55443,8 @@ paths:
             summary: Configure One Query Limit for One Federated Database Instance
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/setGroupDataFederationLimit
             x-xgen-method-verb-override:
                 customMethod: true
@@ -53642,6 +55510,11 @@ paths:
             summary: Download Query Logs for One Federated Database Instance
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/downloadGroupDataFederationQueryLogs
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -53684,6 +55557,8 @@ paths:
             summary: Return All Database Users in One Project
             tags:
                 - Database Users
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/listGroupDatabaseUsers
             x-xgen-operation-id-override: listDatabaseUsers
         post:
@@ -53824,6 +55699,9 @@ paths:
             summary: Create One Database User in One Project
             tags:
                 - Database Users
+            x-rolesRequirements:
+                - Project Database Access Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/createGroupDatabaseUser
             x-xgen-operation-id-override: createDatabaseUser
     /api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}:
@@ -53884,6 +55762,9 @@ paths:
             summary: Remove One Database User from One Project
             tags:
                 - Database Users
+            x-rolesRequirements:
+                - Project Database Access Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/deleteGroupDatabaseUser
             x-xgen-operation-id-override: deleteDatabaseUser
         get:
@@ -53945,6 +55826,8 @@ paths:
             summary: Return One Database User from One Project
             tags:
                 - Database Users
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/getGroupDatabaseUser
             x-xgen-operation-id-override: getDatabaseUser
         patch:
@@ -54017,6 +55900,9 @@ paths:
             summary: Update One Database User in One Project
             tags:
                 - Database Users
+            x-rolesRequirements:
+                - Project Database Access Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users/operation/updateGroupDatabaseUser
             x-xgen-operation-id-override: updateDatabaseUser
     /api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs:
@@ -54064,6 +55950,8 @@ paths:
             summary: Return All X.509 Certificates Assigned to One Database User
             tags:
                 - X.509 Authentication
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/X.509-Authentication/operation/listGroupDatabaseUserCerts
             x-xgen-operation-id-override: listDatabaseUserCerts
         post:
@@ -54125,6 +56013,8 @@ paths:
             summary: Create One X.509 Certificate for One Database User
             tags:
                 - X.509 Authentication
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/X.509-Authentication/operation/createGroupDatabaseUserCert
             x-xgen-operation-id-override: createDatabaseUserCert
     /api/atlas/v2/groups/{groupId}/dbAccessHistory/clusters/{clusterName}:
@@ -54207,6 +56097,9 @@ paths:
             summary: Return Database Access History for One Cluster by Cluster Name
             tags:
                 - Access Tracking
+            x-rolesRequirements:
+                - Project Cluster Log Viewer
+                - Project Database Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Access-Tracking/operation/getGroupDbAccessHistoryCluster
             x-xgen-operation-id-override: getAccessHistoryCluster
     /api/atlas/v2/groups/{groupId}/dbAccessHistory/processes/{hostname}:
@@ -54286,6 +56179,9 @@ paths:
             summary: Return Database Access History for One Cluster by Hostname
             tags:
                 - Access Tracking
+            x-rolesRequirements:
+                - Project Cluster Log Viewer
+                - Project Database Access Admin
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Access-Tracking/operation/getGroupDbAccessHistoryProcess
             x-xgen-operation-id-override: getAccessHistoryProcess
     /api/atlas/v2/groups/{groupId}/encryptionAtRest:
@@ -54325,6 +56221,8 @@ paths:
             summary: Return One Configuration for Encryption at Rest Using Customer-Managed Keys for One Project
             tags:
                 - Encryption at Rest using Customer Key Management
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/getGroupEncryptionAtRest
             x-xgen-operation-id-override: getEncryptionAtRest
         patch:
@@ -54383,6 +56281,8 @@ paths:
             summary: Update Encryption at Rest Configuration in One Project
             tags:
                 - Encryption at Rest using Customer Key Management
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/updateGroupEncryptionAtRest
             x-xgen-operation-id-override: updateEncryptionAtRest
     /api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints:
@@ -54431,6 +56331,8 @@ paths:
             summary: Return Private Endpoints for Encryption at Rest Using Customer Key Management for One Cloud Provider in One Project
             tags:
                 - Encryption at Rest using Customer Key Management
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/listGroupEncryptionAtRestPrivateEndpoints
             x-xgen-operation-id-override: listRestPrivateEndpoints
         post:
@@ -54482,6 +56384,8 @@ paths:
             summary: Create One Private Endpoint for Encryption at Rest Using Customer Key Management for One Cloud Provider in One Project
             tags:
                 - Encryption at Rest using Customer Key Management
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/createGroupEncryptionAtRestPrivateEndpoint
             x-xgen-operation-id-override: createRestPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints/{endpointId}:
@@ -54532,6 +56436,8 @@ paths:
             summary: Delete One Private Endpoint for Encryption at Rest Using Customer Key Management for One Cloud Provider from One Project
             tags:
                 - Encryption at Rest using Customer Key Management
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/requestGroupEncryptionAtRestPrivateEndpointDeletion
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -54586,6 +56492,8 @@ paths:
             summary: Return One Private Endpoint for Encryption at Rest Using Customer Key Management for One Cloud Provider in One Project
             tags:
                 - Encryption at Rest using Customer Key Management
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Encryption-at-Rest-using-Customer-Key-Management/operation/getGroupEncryptionAtRestPrivateEndpoint
             x-xgen-operation-id-override: getRestPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/events:
@@ -54683,6 +56591,8 @@ paths:
             summary: Return Events from One Project
             tags:
                 - Events
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/listGroupEvents
     /api/atlas/v2/groups/{groupId}/events/{eventId}:
         get:
@@ -54737,6 +56647,8 @@ paths:
             summary: Return One Event from One Project
             tags:
                 - Events
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/getGroupEvent
     /api/atlas/v2/groups/{groupId}/flexClusters:
         get:
@@ -54777,6 +56689,8 @@ paths:
             summary: Return All Flex Clusters from One Project
             tags:
                 - Flex Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/listGroupFlexClusters
             x-xgen-operation-id-override: listFlexClusters
         post:
@@ -54825,6 +56739,8 @@ paths:
             summary: Create One Flex Cluster in One Project
             tags:
                 - Flex Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/createGroupFlexCluster
             x-xgen-operation-id-override: createFlexCluster
     /api/atlas/v2/groups/{groupId}/flexClusters/{name}:
@@ -54870,6 +56786,8 @@ paths:
             summary: Remove One Flex Cluster from One Project
             tags:
                 - Flex Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/deleteGroupFlexCluster
             x-xgen-operation-id-override: deleteFlexCluster
         get:
@@ -54916,6 +56834,8 @@ paths:
             summary: Return One Flex Cluster from One Project
             tags:
                 - Flex Clusters
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/getGroupFlexCluster
             x-xgen-operation-id-override: getFlexCluster
         patch:
@@ -54969,6 +56889,8 @@ paths:
             summary: Update One Flex Cluster in One Project
             tags:
                 - Flex Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/updateGroupFlexCluster
             x-xgen-operation-id-override: updateFlexCluster
     /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/download:
@@ -55023,6 +56945,8 @@ paths:
             summary: Download One Flex Cluster Snapshot
             tags:
                 - Flex Snapshots
+            x-rolesRequirements:
+                - Project Backup Export Operator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Snapshots/operation/downloadGroupFlexClusterBackup
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -55073,6 +56997,8 @@ paths:
             summary: Return All Restore Jobs for One Flex Cluster
             tags:
                 - Flex Restore Jobs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Restore-Jobs/operation/listGroupFlexClusterBackupRestoreJobs
             x-xgen-operation-id-override: listFlexRestoreJobs
         post:
@@ -55126,6 +57052,8 @@ paths:
             summary: Create One Restore Job for One Flex Cluster
             tags:
                 - Flex Restore Jobs
+            x-rolesRequirements:
+                - Project Backup Recovery Operator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Restore-Jobs/operation/createGroupFlexClusterBackupRestoreJob
             x-xgen-operation-id-override: createFlexRestoreJob
     /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/restoreJobs/{restoreJobId}:
@@ -55178,6 +57106,8 @@ paths:
             summary: Return One Restore Job for One Flex Cluster
             tags:
                 - Flex Restore Jobs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Restore-Jobs/operation/getGroupFlexClusterBackupRestoreJob
             x-xgen-operation-id-override: getFlexRestoreJob
     /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/snapshots:
@@ -55226,6 +57156,8 @@ paths:
             summary: Return All Snapshots for One Flex Cluster
             tags:
                 - Flex Snapshots
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Snapshots/operation/listGroupFlexClusterBackupSnapshots
             x-xgen-operation-id-override: listFlexBackupSnapshots
     /api/atlas/v2/groups/{groupId}/flexClusters/{name}/backup/snapshots/{snapshotId}:
@@ -55278,6 +57210,8 @@ paths:
             summary: Return One Snapshot for One Flex Cluster
             tags:
                 - Flex Snapshots
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Snapshots/operation/getGroupFlexClusterBackupSnapshot
             x-xgen-operation-id-override: getFlexBackupSnapshot
     /api/atlas/v2/groups/{groupId}/flexClusters:tenantUpgrade:
@@ -55327,6 +57261,8 @@ paths:
             summary: Upgrade One Flex Cluster
             tags:
                 - Flex Clusters
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters/operation/tenantGroupFlexClusterUpgrade
             x-xgen-operation-id-override: tenantUpgrade
     /api/atlas/v2/groups/{groupId}/hosts/{processId}/fts/metrics:
@@ -55365,6 +57301,8 @@ paths:
             summary: Return All Atlas Search Metric Types for One Process
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupHostFtsMetrics
             x-xgen-operation-id-override: listHostFtsMetrics
     /api/atlas/v2/groups/{groupId}/hosts/{processId}/fts/metrics/indexes/{databaseName}/{collectionName}/{indexName}/measurements:
@@ -55433,6 +57371,8 @@ paths:
             summary: Return Atlas Search Metrics for One Index in One Namespace
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupHostFtsMetricIndexMeasurements
             x-xgen-operation-id-override: getIndexMeasurements
     /api/atlas/v2/groups/{groupId}/hosts/{processId}/fts/metrics/indexes/{databaseName}/{collectionName}/measurements:
@@ -55500,6 +57440,8 @@ paths:
             summary: Return All Atlas Search Index Metrics for One Namespace
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupHostFtsMetricIndexMeasurements
             x-xgen-method-verb-override:
                 customMethod: false
@@ -55569,6 +57511,8 @@ paths:
             summary: Return Atlas Search Hardware and Status Metrics
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupHostFtsMetricMeasurements
             x-xgen-operation-id-override: listMeasurements
     /api/atlas/v2/groups/{groupId}/integrations:
@@ -55610,6 +57554,8 @@ paths:
             summary: Return All Active Third-Party Service Integrations
             tags:
                 - Third-Party Integrations
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/listGroupIntegrations
     /api/atlas/v2/groups/{groupId}/integrations/{integrationType}:
         delete:
@@ -55663,6 +57609,8 @@ paths:
             summary: Remove One Third-Party Service Integration
             tags:
                 - Third-Party Integrations
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-changelog:
                 "2026-01-07": Log export to S3, Splunk, and Datadog is not supported by this API.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/deleteGroupIntegration
@@ -55719,6 +57667,8 @@ paths:
             summary: Return One Third-Party Service Integration
             tags:
                 - Third-Party Integrations
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-changelog:
                 "2026-01-07": Log export to S3, Splunk, and Datadog is not supported by this API.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/getGroupIntegration
@@ -55787,6 +57737,8 @@ paths:
             summary: Create One Third-Party Service Integration
             tags:
                 - Third-Party Integrations
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-changelog:
                 "2026-01-07": Log export to S3, Splunk, and Datadog is not supported by this API.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/createGroupIntegration
@@ -55853,6 +57805,8 @@ paths:
             summary: Update One Third-Party Service Integration
             tags:
                 - Third-Party Integrations
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-changelog:
                 "2026-01-07": Log export to S3, Splunk, and Datadog is not supported by this API.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/updateGroupIntegration
@@ -55900,6 +57854,8 @@ paths:
             summary: Return All Invitations in One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listGroupInvites
         patch:
             deprecated: true
@@ -55945,6 +57901,8 @@ paths:
             summary: Update One Invitation in One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupInvites
         post:
             deprecated: true
@@ -55988,6 +57946,8 @@ paths:
             summary: Create Invitation for One MongoDB Cloud User in One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/createGroupInvite
     /api/atlas/v2/groups/{groupId}/invites/{invitationId}:
         delete:
@@ -56029,6 +57989,8 @@ paths:
             summary: Remove One Invitation from One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/deleteGroupInvite
         get:
             deprecated: true
@@ -56072,6 +58034,8 @@ paths:
             summary: Return One Invitation in One Project by Invitation ID
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupInvite
         patch:
             deprecated: true
@@ -56123,6 +58087,8 @@ paths:
             summary: Update One Invitation in One Project by Invitation ID
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupInviteById
             x-xgen-method-verb-override:
                 customMethod: false
@@ -56162,6 +58128,8 @@ paths:
             summary: Return All IP Addresses for One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupIpAddresses
     /api/atlas/v2/groups/{groupId}/limits:
         get:
@@ -56203,6 +58171,8 @@ paths:
             summary: Return All Limits for One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listGroupLimits
     /api/atlas/v2/groups/{groupId}/limits/{limitName}:
         delete:
@@ -56276,6 +58246,8 @@ paths:
             summary: Remove One Project Limit
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/deleteGroupLimit
         get:
             description: Returns the specified limit for the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -56350,6 +58322,8 @@ paths:
             summary: Return One Limit for One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupLimit
         patch:
             description: |-
@@ -56434,6 +58408,8 @@ paths:
             summary: Set One Project Limit
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/setGroupLimit
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -56501,6 +58477,8 @@ paths:
             summary: Create One Migration for One Local Managed Cluster to MongoDB Atlas
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/createGroupLiveMigration
     /api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}:
         get:
@@ -56537,6 +58515,8 @@ paths:
             summary: Return One Migration Job
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/getGroupLiveMigration
     /api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover:
         put:
@@ -56573,6 +58553,8 @@ paths:
             summary: Cut Over One Migrated Cluster
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/cutoverGroupLiveMigration
             x-xgen-method-verb-override:
                 customMethod: true
@@ -56630,6 +58612,8 @@ paths:
             summary: Validate One Migration Request
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/validateGroupLiveMigrations
             x-xgen-method-verb-override:
                 customMethod: true
@@ -56677,6 +58661,8 @@ paths:
             summary: Return One Migration Validation Job
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/getGroupLiveMigrationValidateStatus
             x-xgen-method-verb-override:
                 customMethod: true
@@ -56726,6 +58712,8 @@ paths:
             summary: Return All Active Log Integrations
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/listGroupLogIntegrations
         post:
             description: Creates a new log integration configuration identified by a unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
@@ -56769,6 +58757,8 @@ paths:
             summary: Create One Log Integration
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/createGroupLogIntegration
     /api/atlas/v2/groups/{groupId}/logIntegrations/{id}:
         delete:
@@ -56810,6 +58800,8 @@ paths:
             summary: Remove One Log Integration
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/deleteGroupLogIntegration
         get:
             description: Returns the configuration for one log integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
@@ -56852,6 +58844,8 @@ paths:
             summary: Return One Log Integration
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/getGroupLogIntegration
         put:
             description: Updates the configuration for one log integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
@@ -56901,6 +58895,8 @@ paths:
             summary: Update One Log Integration
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/updateGroupLogIntegration
     /api/atlas/v2/groups/{groupId}/maintenanceWindow:
         delete:
@@ -56935,6 +58931,8 @@ paths:
             summary: Reset One Maintenance Window for One Project
             tags:
                 - Maintenance Windows
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/resetGroupMaintenanceWindow
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -56973,6 +58971,8 @@ paths:
             summary: Return One Maintenance Window for One Project
             tags:
                 - Maintenance Windows
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/getGroupMaintenanceWindow
             x-xgen-operation-id-override: getMaintenanceWindow
         patch:
@@ -57014,6 +59014,8 @@ paths:
             summary: Update One Maintenance Window for One Project
             tags:
                 - Maintenance Windows
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/updateGroupMaintenanceWindow
             x-xgen-operation-id-override: updateMaintenanceWindow
     /api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer:
@@ -57049,6 +59051,8 @@ paths:
             summary: Toggle Automatic Deferral of Maintenance for One Project
             tags:
                 - Maintenance Windows
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/toggleGroupMaintenanceWindowAutoDefer
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -57087,6 +59091,8 @@ paths:
             summary: Defer One Maintenance Window for One Project
             tags:
                 - Maintenance Windows
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/deferGroupMaintenanceWindow
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -57125,6 +59131,8 @@ paths:
             summary: Return Managed Slow Operation Threshold Status
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/getGroupManagedSlowMs
             x-xgen-operation-id-override: getManagedSlowMs
     /api/atlas/v2/groups/{groupId}/managedSlowMs/disable:
@@ -57159,6 +59167,8 @@ paths:
             summary: Disable Managed Slow Operation Threshold
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/disableGroupManagedSlowMs
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -57195,10 +59205,270 @@ paths:
             summary: Enable Managed Slow Operation Threshold
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/enableGroupManagedSlowMs
             x-xgen-method-verb-override:
                 customMethod: true
             x-xgen-operation-id-override: enableManagedSlowMs
+    /api/atlas/v2/groups/{groupId}/metricIntegrations:
+        get:
+            description: Returns all metric integration configurations for the project. Optionally filter by integration type and provider type. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+            operationId: listGroupMetricIntegrations
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/includeCount'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - description: Optional filter by integration type (e.g., `OTEL`). When specified, `providerType` must also be specified.
+                  in: query
+                  name: integrationType
+                  schema:
+                    type: string
+                - description: Optional filter by provider type (e.g., `CUSTOM`). When specified, `integrationType` must also be specified.
+                  in: query
+                  name: providerType
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedMetricIntegrationResponse'
+                            x-xgen-preview:
+                                name: metric-integrations
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Active Metric Integrations
+            tags:
+                - Metric Integrations
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/listGroupMetricIntegrations
+        post:
+            description: Creates a new metric integration configuration identified by a unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+            operationId: createGroupMetricIntegration
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/MetricIntegrationRequest'
+                        x-xgen-preview:
+                            name: metric-integrations
+                            public: "false"
+                        x-xgen-version: preview
+                description: Metric integration configuration to create.
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/MetricIntegrationResponse'
+                            x-xgen-preview:
+                                name: metric-integrations
+                                public: "false"
+                            x-xgen-version: preview
+                    description: Created
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Create One Metric Integration
+            tags:
+                - Metric Integrations
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/createGroupMetricIntegration
+    /api/atlas/v2/groups/{groupId}/metricIntegrations/{metricIntegrationId}:
+        delete:
+            description: Removes the configuration for one metric integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+            operationId: deleteGroupMetricIntegration
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Unique identifier of the metric integration configuration.
+                  in: path
+                  name: metricIntegrationId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            x-xgen-preview:
+                                name: metric-integrations
+                                public: "false"
+                            x-xgen-version: preview
+                    description: This endpoint does not return a response body.
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Remove One Metric Integration
+            tags:
+                - Metric Integrations
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/deleteGroupMetricIntegration
+        get:
+            description: Returns the configuration for one metric integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+            operationId: getGroupMetricIntegration
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Unique identifier of the metric integration configuration.
+                  in: path
+                  name: metricIntegrationId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/MetricIntegrationResponse'
+                            x-xgen-preview:
+                                name: metric-integrations
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Metric Integration
+            tags:
+                - Metric Integrations
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/getGroupMetricIntegration
+        put:
+            description: Updates the configuration for one metric integration identified by its unique ID. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+            operationId: updateGroupMetricIntegration
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/pretty'
+                - description: Unique identifier of the metric integration configuration.
+                  in: path
+                  name: metricIntegrationId
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/MetricIntegrationUpdateRequest'
+                        x-xgen-preview:
+                            name: metric-integrations
+                            public: "false"
+                        x-xgen-version: preview
+                description: Updated metric integration configuration.
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/MetricIntegrationResponse'
+                            x-xgen-preview:
+                                name: metric-integrations
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Update One Metric Integration
+            tags:
+                - Metric Integrations
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Metric-Integrations/operation/updateGroupMetricIntegration
     /api/atlas/v2/groups/{groupId}/mongoDBVersions:
         get:
             description: Returns the MongoDB Long Term Support Major Versions available to new clusters in this project.
@@ -57270,6 +59540,8 @@ paths:
             summary: Return All Available MongoDB LTS Versions for Clusters in One Project
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupMongoDbVersions
             x-xgen-operation-id-override: getMongoDbVersions
     /api/atlas/v2/groups/{groupId}/peers:
@@ -57321,6 +59593,8 @@ paths:
             summary: Return All Network Peering Connections in One Project
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/listGroupPeers
         post:
             description: Creates one new network peering connection in the specified project. Network peering allows multiple cloud-hosted applications to securely connect to the same project. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Network Access Manager role. To learn more about considerations and prerequisites, see the Network Peering Documentation.
@@ -57369,6 +59643,8 @@ paths:
             summary: Create One Network Peering Connection
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Network Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/createGroupPeer
     /api/atlas/v2/groups/{groupId}/peers/{peerId}:
         delete:
@@ -57413,6 +59689,8 @@ paths:
             summary: Remove One Network Peering Connection
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Network Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/deleteGroupPeer
         get:
             description: Returns details about one specified network peering connection in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
@@ -57456,6 +59734,8 @@ paths:
             summary: Return One Network Peering Connection in One Project
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/getGroupPeer
         patch:
             description: Updates one specified network peering connection in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Network Access Manager role.
@@ -57508,6 +59788,8 @@ paths:
             summary: Update One Network Peering Connection
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Network Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/updateGroupPeer
     /api/atlas/v2/groups/{groupId}/pipelines:
         get:
@@ -57548,6 +59830,8 @@ paths:
             summary: Return All Data Lake Pipelines in One Project
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/listGroupPipelines
             x-xgen-operation-id-override: listPipelines
         post:
@@ -57596,6 +59880,8 @@ paths:
             summary: Create One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/createGroupPipeline
             x-xgen-operation-id-override: createPipeline
     /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}:
@@ -57638,6 +59924,8 @@ paths:
             summary: Remove One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/deleteGroupPipeline
             x-xgen-operation-id-override: deletePipeline
         get:
@@ -57684,6 +59972,8 @@ paths:
             summary: Return One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipeline
             x-xgen-operation-id-override: getPipeline
         patch:
@@ -57738,6 +60028,8 @@ paths:
             summary: Update One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/updateGroupPipeline
             x-xgen-operation-id-override: updatePipeline
     /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/availableSchedules:
@@ -57787,6 +60079,8 @@ paths:
             summary: Return All Ingestion Schedules for One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipelineAvailableSchedules
             x-xgen-operation-id-override: getAvailablePipelineSchedules
     /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/availableSnapshots:
@@ -57843,6 +60137,8 @@ paths:
             summary: Return All Backup Snapshots for One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipelineAvailableSnapshots
             x-xgen-operation-id-override: getAvailablePipelineSnapshots
     /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause:
@@ -57890,6 +60186,8 @@ paths:
             summary: Pause One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/pauseGroupPipeline
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -57939,6 +60237,8 @@ paths:
             summary: Resume One Data Lake Pipeline
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/resumeGroupPipeline
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -57997,6 +60297,8 @@ paths:
             summary: Return All Data Lake Pipeline Runs in One Project
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/listGroupPipelineRuns
             x-xgen-operation-id-override: listPipelineRuns
     /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/runs/{pipelineRunId}:
@@ -58052,6 +60354,8 @@ paths:
             summary: Delete One Pipeline Run Dataset
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/deleteGroupPipelineRun
             x-xgen-operation-id-override: deletePipelineRun
         get:
@@ -58106,6 +60410,8 @@ paths:
             summary: Return One Data Lake Pipeline Run
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/getGroupPipelineRun
             x-xgen-operation-id-override: getPipelineRun
     /api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger:
@@ -58160,6 +60466,8 @@ paths:
             summary: Trigger On-Demand Snapshot Ingestion
             tags:
                 - Data Lake Pipelines
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Lake-Pipelines/operation/triggerGroupPipeline
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -58213,6 +60521,8 @@ paths:
             summary: Return All Private Endpoint Services for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/listGroupPrivateEndpointEndpointService
             x-xgen-operation-id-override: listPrivateEndpointService
     /api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}:
@@ -58267,6 +60577,8 @@ paths:
             summary: Remove One Private Endpoint Service for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/deleteGroupPrivateEndpointEndpointService
             x-xgen-operation-id-override: deletePrivateEndpointService
         get:
@@ -58322,6 +60634,8 @@ paths:
             summary: Return One Private Endpoint Service for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/getGroupPrivateEndpointEndpointService
             x-xgen-operation-id-override: getPrivateEndpointService
     /api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint:
@@ -58389,6 +60703,8 @@ paths:
             summary: Create One Private Endpoint for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/createGroupPrivateEndpointEndpointServiceEndpoint
             x-xgen-operation-id-override: createPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint/{endpointId}:
@@ -58450,6 +60766,8 @@ paths:
             summary: Remove One Private Endpoint for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/deleteGroupPrivateEndpointEndpointServiceEndpoint
             x-xgen-operation-id-override: deletePrivateEndpoint
         get:
@@ -58512,6 +60830,8 @@ paths:
             summary: Return One Private Endpoint for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/getGroupPrivateEndpointEndpointServiceEndpoint
             x-xgen-operation-id-override: getPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService:
@@ -58560,6 +60880,8 @@ paths:
             summary: Create One Private Endpoint Service for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/createGroupPrivateEndpointEndpointService
             x-xgen-operation-id-override: createPrivateEndpointService
     /api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService/{endpointServiceId}:
@@ -58612,6 +60934,8 @@ paths:
             summary: Update One Private Endpoint Service for One Provider
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/updateGroupPrivateEndpointEndpointService
             x-xgen-operation-id-override: updatePrivateEndpointService
     /api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode:
@@ -58648,6 +60972,8 @@ paths:
             summary: Return Regionalized Private Endpoint Status
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/getGroupPrivateEndpointRegionalMode
             x-xgen-method-verb-override:
                 customMethod: false
@@ -58695,6 +61021,8 @@ paths:
             summary: Toggle Regionalized Private Endpoint Status
             tags:
                 - Private Endpoint Services
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Private-Endpoint-Services/operation/toggleGroupPrivateEndpointRegionalMode
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -58749,6 +61077,8 @@ paths:
             summary: Return All Private Endpoints for One Serverless Instance
             tags:
                 - Serverless Private Endpoints
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/listGroupPrivateEndpointServerlessInstanceEndpoint
             x-xgen-operation-id-override: listServerlessPrivateEndpoint
         post:
@@ -58809,6 +61139,8 @@ paths:
             summary: Create One Private Endpoint for One Serverless Instance
             tags:
                 - Serverless Private Endpoints
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/createGroupPrivateEndpointServerlessInstanceEndpoint
             x-xgen-operation-id-override: createServerlessPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}:
@@ -58863,6 +61195,8 @@ paths:
             summary: Remove One Private Endpoint for One Serverless Instance
             tags:
                 - Serverless Private Endpoints
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/deleteGroupPrivateEndpointServerlessInstanceEndpoint
             x-xgen-operation-id-override: deleteServerlessPrivateEndpoint
         get:
@@ -58918,6 +61252,8 @@ paths:
             summary: Return One Private Endpoint for One Serverless Instance
             tags:
                 - Serverless Private Endpoints
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/getGroupPrivateEndpointServerlessInstanceEndpoint
             x-xgen-operation-id-override: getServerlessPrivateEndpoint
         patch:
@@ -58980,6 +61316,8 @@ paths:
             summary: Update One Private Endpoint for One Serverless Instance
             tags:
                 - Serverless Private Endpoints
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Private-Endpoints/operation/updateGroupPrivateEndpointServerlessInstanceEndpoint
             x-xgen-operation-id-override: updateServerlessPrivateEndpoint
     /api/atlas/v2/groups/{groupId}/privateIpMode:
@@ -59020,6 +61358,8 @@ paths:
             summary: Verify Connect via Peering-Only Mode for One Project
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/verifyGroupPrivateIpMode
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -59071,6 +61411,8 @@ paths:
             summary: Disable Connect via Peering-Only Mode for One Project
             tags:
                 - Network Peering
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/disableGroupPrivateIpModePeering
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -59115,6 +61457,8 @@ paths:
             summary: Return All Federated Database Instance and Online Archive Private Endpoints in One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/listGroupPrivateNetworkSettingEndpointIds
             x-xgen-operation-id-override: listPrivateEndpointIds
         post:
@@ -59162,6 +61506,8 @@ paths:
             summary: Create One Federated Database Instance and Online Archive Private Endpoint for One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createGroupPrivateNetworkSettingEndpointId
             x-xgen-operation-id-override: createPrivateEndpointId
     /api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds/{endpointId}:
@@ -59203,6 +61549,8 @@ paths:
             summary: Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/deleteGroupPrivateNetworkSettingEndpointId
             x-xgen-operation-id-override: deletePrivateEndpointId
         get:
@@ -59247,6 +61595,8 @@ paths:
             summary: Return One Federated Database Instance and Online Archive Private Endpoint in One Project
             tags:
                 - Data Federation
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/getGroupPrivateNetworkSettingEndpointId
             x-xgen-operation-id-override: getPrivateEndpointId
     /api/atlas/v2/groups/{groupId}/processes:
@@ -59286,6 +61636,8 @@ paths:
             summary: Return All MongoDB Processes in One Project
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupProcesses
     /api/atlas/v2/groups/{groupId}/processes/{processId}:
         get:
@@ -59329,6 +61681,8 @@ paths:
             summary: Return One MongoDB Process by ID
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcess
     /api/atlas/v2/groups/{groupId}/processes/{processId}/{databaseName}/{collectionName}/collStats/measurements:
         get:
@@ -59405,6 +61759,8 @@ paths:
             summary: Return Host-Level Query Latency
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/listGroupProcessCollStatMeasurements
             x-xgen-operation-id-override: listProcessMeasurements
     /api/atlas/v2/groups/{groupId}/processes/{processId}/collStats/namespaces:
@@ -59444,6 +61800,8 @@ paths:
             summary: Return Ranked Namespaces from One Host
             tags:
                 - Collection Level Metrics
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Collection-Level-Metrics/operation/getGroupProcessCollStatNamespaces
             x-xgen-method-verb-override:
                 customMethod: false
@@ -59497,6 +61855,8 @@ paths:
             summary: Return Available Databases for One MongoDB Process
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupProcessDatabases
             x-xgen-operation-id-override: listDatabases
     /api/atlas/v2/groups/{groupId}/processes/{processId}/databases/{databaseName}:
@@ -59547,6 +61907,8 @@ paths:
             summary: Return One Database for One MongoDB Process
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDatabase
             x-xgen-operation-id-override: getDatabase
     /api/atlas/v2/groups/{groupId}/processes/{processId}/databases/{databaseName}/measurements:
@@ -59623,6 +61985,8 @@ paths:
             summary: Return Measurements for One Database in One MongoDB Process
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDatabaseMeasurements
             x-xgen-operation-id-override: getDatabaseMeasurements
     /api/atlas/v2/groups/{groupId}/processes/{processId}/disks:
@@ -59670,6 +62034,8 @@ paths:
             summary: Return Available Disks for One MongoDB Process
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/listGroupProcessDisks
             x-xgen-operation-id-override: listProcessDisks
     /api/atlas/v2/groups/{groupId}/processes/{processId}/disks/{partitionName}:
@@ -59719,6 +62085,8 @@ paths:
             summary: Return Measurements for One Disk
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDisk
             x-xgen-operation-id-override: getProcessDisk
     /api/atlas/v2/groups/{groupId}/processes/{processId}/disks/{partitionName}/measurements:
@@ -59814,6 +62182,8 @@ paths:
             summary: Return Measurements of One Disk for One MongoDB Process
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessDiskMeasurements
             x-xgen-operation-id-override: getProcessDiskMeasurements
     /api/atlas/v2/groups/{groupId}/processes/{processId}/measurements:
@@ -60022,6 +62392,8 @@ paths:
             summary: Return Measurements for One MongoDB Process
             tags:
                 - Monitoring and Logs
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Monitoring-and-Logs/operation/getGroupProcessMeasurements
             x-xgen-operation-id-override: getProcessMeasurements
     /api/atlas/v2/groups/{groupId}/processes/{processId}/performanceAdvisor/namespaces:
@@ -60086,6 +62458,8 @@ paths:
             summary: Return All Namespaces for One Host
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupProcessPerformanceAdvisorNamespaces
             x-xgen-operation-id-override: listPerformanceAdvisorNamespaces
     /api/atlas/v2/groups/{groupId}/processes/{processId}/performanceAdvisor/slowQueryLogs:
@@ -60185,6 +62559,12 @@ paths:
             summary: Return Slow Queries
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Observability Viewer
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupProcessPerformanceAdvisorSlowQueryLogs
             x-xgen-operation-id-override: listSlowQueryLogs
     /api/atlas/v2/groups/{groupId}/processes/{processId}/performanceAdvisor/suggestedIndexes:
@@ -60273,6 +62653,8 @@ paths:
             summary: Return All Suggested Indexes
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/listGroupProcessPerformanceAdvisorSuggestedIndexes
             x-xgen-operation-id-override: listSuggestedIndexes
     /api/atlas/v2/groups/{groupId}/pushBasedLogExport:
@@ -60311,6 +62693,8 @@ paths:
             summary: Disable Push-Based Log Export for One Project
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/deleteGroupPushBasedLogExport
             x-xgen-operation-id-override: deleteLogExport
         get:
@@ -60348,6 +62732,8 @@ paths:
             summary: Return One Push-Based Log Export Configuration in One Project
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/getGroupPushBasedLogExport
             x-xgen-method-verb-override:
                 customMethod: false
@@ -60396,6 +62782,8 @@ paths:
             summary: Update One Push-Based Log Export Configuration in One Project
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/updateGroupPushBasedLogExport
             x-xgen-operation-id-override: updateLogExport
         post:
@@ -60441,6 +62829,8 @@ paths:
             summary: Create One Push-Based Log Export Configuration in One Project
             tags:
                 - Push-Based Log Export
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/createGroupPushBasedLogExport
             x-xgen-operation-id-override: createLogExport
     /api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}:
@@ -60487,6 +62877,8 @@ paths:
             summary: Load Sample Dataset into One Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/requestGroupSampleDatasetLoad
             x-xgen-method-verb-override:
                 customMethod: true
@@ -60532,6 +62924,8 @@ paths:
             summary: Return Status of Sample Dataset Load for One Cluster
             tags:
                 - Clusters
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getGroupSampleDatasetLoad
             x-xgen-operation-id-override: getSampleDatasetLoad
     /api/atlas/v2/groups/{groupId}/sandbox/{sandboxConfigId}:generateClusterDescription:
@@ -60564,6 +62958,8 @@ paths:
             summary: Return Cluster Description from Sandbox Template Configuration
             tags:
                 - Sandbox
+            x-rolesRequirements:
+                - Organization Project Creator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/generateGroupSandboxClusterDescription
             x-xgen-operation-id-override: generateSandboxClusterDescription
     /api/atlas/v2/groups/{groupId}/serverless:
@@ -60590,7 +62986,7 @@ paths:
                         application/vnd.atlas.2023-01-01+json:
                             schema:
                                 $ref: '#/components/schemas/PaginatedServerlessInstanceDescriptionView'
-                            x-sunset: "2027-01-15"
+                            x-sunset: "2027-01-18"
                             x-xgen-version: "2023-01-01"
                     description: OK
                     headers:
@@ -60613,6 +63009,8 @@ paths:
             summary: Return All Serverless Instances in One Project
             tags:
                 - Serverless Instances
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Instances/operation/listGroupServerlessInstances
             x-xgen-method-verb-override:
                 customMethod: false
@@ -60672,6 +63070,8 @@ paths:
             summary: Return All Restore Jobs for One Serverless Instance
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupServerlessBackupRestoreJobs
             x-xgen-operation-id-override: listServerlessRestoreJobs
         post:
@@ -60733,6 +63133,8 @@ paths:
             summary: Create One Restore Job for One Serverless Instance
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/createGroupServerlessBackupRestoreJob
             x-xgen-operation-id-override: createServerlessRestoreJob
     /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs/{restoreJobId}:
@@ -60793,6 +63195,8 @@ paths:
             summary: Return One Restore Job for One Serverless Instance
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupServerlessBackupRestoreJob
             x-xgen-operation-id-override: getServerlessRestoreJob
     /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/snapshots:
@@ -60849,6 +63253,8 @@ paths:
             summary: Return All Snapshots of One Serverless Instance
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/listGroupServerlessBackupSnapshots
             x-xgen-operation-id-override: listServerlessBackupSnapshots
     /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/snapshots/{snapshotId}:
@@ -60909,6 +63315,8 @@ paths:
             summary: Return One Snapshot of One Serverless Instance
             tags:
                 - Cloud Backups
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/getGroupServerlessBackupSnapshot
             x-xgen-operation-id-override: getServerlessBackupSnapshot
     /api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing:
@@ -60957,6 +63365,8 @@ paths:
             summary: Return Serverless Auto-Indexing Status
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/getGroupServerlessPerformanceAdvisorAutoIndexing
             x-xgen-method-verb-override:
                 customMethod: false
@@ -61010,6 +63420,8 @@ paths:
             summary: Set Serverless Auto-Indexing Status
             tags:
                 - Performance Advisor
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Performance-Advisor/operation/setGroupServerlessPerformanceAdvisorAutoIndexing
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -61043,7 +63455,7 @@ paths:
                         application/vnd.atlas.2023-01-01+json:
                             schema:
                                 $ref: '#/components/schemas/ServerlessInstanceDescription'
-                            x-sunset: "2027-01-15"
+                            x-sunset: "2027-01-18"
                             x-xgen-version: "2023-01-01"
                     description: OK
                     headers:
@@ -61068,6 +63480,8 @@ paths:
             summary: Return One Serverless Instance from One Project
             tags:
                 - Serverless Instances
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Instances/operation/getGroupServerlessInstance
             x-xgen-method-verb-override:
                 customMethod: false
@@ -61109,6 +63523,8 @@ paths:
             summary: Return All Project Service Accounts
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listGroupServiceAccounts
         post:
             description: Creates one Service Account for the specified Project. The Service Account will automatically be added as an Organization Member to the Organization that the specified Project is a part of.
@@ -61153,6 +63569,8 @@ paths:
             summary: Create One Project Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createGroupServiceAccount
     /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}:
         delete:
@@ -61195,6 +63613,8 @@ paths:
             summary: Remove One Project Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteGroupServiceAccount
         get:
             description: Returns one Service Account in the specified Project.
@@ -61237,6 +63657,8 @@ paths:
             summary: Return One Project Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/getGroupServiceAccount
         patch:
             description: Updates one Service Account in the specified Project.
@@ -61288,6 +63710,8 @@ paths:
             summary: Update One Project Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/updateGroupServiceAccount
     /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}/accessList:
         get:
@@ -61334,6 +63758,8 @@ paths:
             summary: Return All Access List Entries for One Project Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listGroupServiceAccountAccessList
             x-xgen-operation-id-override: listAccessList
         post:
@@ -61395,6 +63821,8 @@ paths:
             summary: Add Access List Entries for One Project Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createGroupServiceAccountAccessList
             x-xgen-operation-id-override: createAccessList
     /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}/accessList/{ipAddress}:
@@ -61447,6 +63875,8 @@ paths:
             summary: Remove One Access List Entry from One Project Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteGroupServiceAccountAccessListEntry
             x-xgen-method-verb-override:
                 customMethod: false
@@ -61503,6 +63933,8 @@ paths:
             summary: Create One Project Service Account Secret
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createGroupServiceAccountSecret
             x-xgen-operation-id-override: createGroupSecret
     /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}/secrets/{secretId}:
@@ -61551,6 +63983,8 @@ paths:
             summary: Delete One Project Service Account Secret
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteGroupServiceAccountSecret
             x-xgen-operation-id-override: deleteGroupSecret
     /api/atlas/v2/groups/{groupId}/serviceAccounts/{clientId}:invite:
@@ -61603,6 +64037,8 @@ paths:
             summary: Assign One Service Account to One Project
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/inviteGroupServiceAccount
     /api/atlas/v2/groups/{groupId}/settings:
         get:
@@ -61638,6 +64074,8 @@ paths:
             summary: Return Project Settings
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupSettings
         patch:
             description: Updates the settings of the specified project. You can update any of the options available. MongoDB cloud only updates the options provided in the request. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
@@ -61679,6 +64117,8 @@ paths:
             summary: Update Project Settings
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupSettings
     /api/atlas/v2/groups/{groupId}/standbyLinks:
         get:
@@ -61717,6 +64157,8 @@ paths:
             summary: Return All Standby Links for One Project
             tags:
                 - Standby Links
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/listGroupStandbyLinks
         post:
             description: Creates a disaster recovery standby link between an active cluster and a standby cluster. Both clusters must not already be part of a standby link system, must be single-region clusters, and must be in different regions.
@@ -61767,6 +64209,8 @@ paths:
             summary: Create Standby Link
             tags:
                 - Standby Links
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/createGroupStandbyLink
     /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}:
         delete:
@@ -61813,6 +64257,8 @@ paths:
             summary: Delete Standby Link
             tags:
                 - Standby Links
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/deleteGroupStandbyLink
         get:
             description: Returns detailed information about a specific standby link including status, group ID, and cluster unique IDs.
@@ -61860,6 +64306,8 @@ paths:
             summary: Return One Standby Link
             tags:
                 - Standby Links
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/getGroupStandbyLink
     /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}/failovers:
         get:
@@ -61905,6 +64353,8 @@ paths:
             summary: Return All Standby Link Failovers
             tags:
                 - Standby Links
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/listGroupStandbyLinkFailovers
             x-xgen-operation-id-override: listStandbyLinkFailovers
         post:
@@ -61963,6 +64413,8 @@ paths:
             summary: Create Standby Link Failover
             tags:
                 - Standby Links
+            x-rolesRequirements:
+                - Project Cluster Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/createGroupStandbyLinkFailover
             x-xgen-operation-id-override: createStandbyLinkFailover
     /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}/failovers/{failoverId}:
@@ -62019,8 +64471,71 @@ paths:
             summary: Return One Standby Link Failover
             tags:
                 - Standby Links
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/getGroupStandbyLinkFailover
             x-xgen-operation-id-override: getStandbyLinkFailover
+    /api/atlas/v2/groups/{groupId}/standbyLinks/{standbyLinkId}:inspectFailoverReadiness:
+        get:
+            description: Returns the failover readiness metrics for the specified standby link in the specified project. The response includes the readiness snapshot identifiers, estimated data loss and failover time values. Use this endpoint to assess potential data loss before triggering an unplanned failover.
+            operationId: inspectGroupStandbyLinkFailoverReadiness
+            parameters:
+                - description: Unique 24-hexadecimal digit string that identifies the project.
+                  in: path
+                  name: groupId
+                  required: true
+                  schema:
+                    pattern: ^[a-fA-F0-9]{24}$
+                    type: string
+                - description: Unique 24-hexadecimal digit string that identifies the standby link.
+                  in: path
+                  name: standbyLinkId
+                  required: true
+                  schema:
+                    pattern: ^[a-fA-F0-9]{24}$
+                    type: string
+                - description: Flag that indicates whether to wrap the response in an envelope.
+                  in: query
+                  name: envelope
+                  schema:
+                    type: boolean
+                - $ref: '#/components/parameters/pretty'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiStandbyLinkFailoverReadinessResponse'
+                            x-xgen-preview:
+                                name: standby-links
+                            x-xgen-version: preview
+                    description: OK
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+                "503":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiError'
+                            x-xgen-preview:
+                                name: standby-links
+                            x-xgen-version: preview
+                    description: Service Unavailable.
+            summary: Inspect Failover Readiness for One Standby Link
+            tags:
+                - Standby Links
+            x-rolesRequirements:
+                - Project Read Only
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Standby-Links/operation/inspectGroupStandbyLinkFailoverReadiness
+            x-xgen-operation-id-override: inspectFailoverReadiness
     /api/atlas/v2/groups/{groupId}/streams:
         get:
             description: Returns all stream workspaces for the specified project.
@@ -62057,6 +64572,8 @@ paths:
             summary: Return All Stream Workspaces in One Project
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamWorkspaces
@@ -62106,6 +64623,10 @@ paths:
             summary: Create One Stream Workspace
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamWorkspace
@@ -62151,6 +64672,10 @@ paths:
             summary: Delete One Stream Workspace
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamWorkspace
@@ -62203,6 +64728,12 @@ paths:
             summary: Return One Stream Workspace
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamWorkspace
@@ -62258,6 +64789,10 @@ paths:
             summary: Update One Stream Workspace
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamWorkspace
@@ -62331,6 +64866,12 @@ paths:
             summary: Download Audit Logs for One Atlas Stream Processing Workspace
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/downloadGroupStreamAuditLogs
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -62378,6 +64919,12 @@ paths:
             summary: Return All Connections of the Stream Workspaces
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamConnections
@@ -62432,6 +64979,9 @@ paths:
             summary: Create One Stream Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamConnection
@@ -62482,6 +65032,9 @@ paths:
             summary: Delete One Stream Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamConnection
             x-xgen-operation-id-override: deleteStreamConnection
         get:
@@ -62528,6 +65081,8 @@ paths:
             summary: Return One Stream Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamConnection
@@ -62588,6 +65143,9 @@ paths:
             summary: Update One Stream Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamConnection
@@ -62656,6 +65214,9 @@ paths:
             summary: Create One Failover Stream Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamConnectionFailoverConnection
@@ -62711,6 +65272,9 @@ paths:
             summary: Create One Stream Processor
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamProcessor
             x-xgen-operation-id-override: createStreamProcessor
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:
@@ -62757,6 +65321,9 @@ paths:
             summary: Delete One Stream Processor
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamProcessor
             x-xgen-operation-id-override: deleteStreamProcessor
         get:
@@ -62806,6 +65373,9 @@ paths:
             summary: Return One Stream Processor
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamProcessor
             x-xgen-operation-id-override: getStreamProcessor
         patch:
@@ -62862,6 +65432,9 @@ paths:
             summary: Update One Stream Processor
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamProcessor
             x-xgen-operation-id-override: updateStreamProcessor
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start:
@@ -62908,6 +65481,9 @@ paths:
             summary: Start One Stream Processor
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/startGroupStreamProcessor
             x-xgen-operation-id-override: startStreamProcessor
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:startWith:
@@ -62936,12 +65512,24 @@ paths:
                         schema:
                             $ref: '#/components/schemas/StreamsStartStreamProcessorWith'
                         x-xgen-version: "2025-03-12"
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/StartStreamProcessorWithPreviewView'
+                        x-xgen-preview:
+                            name: regional-failover
+                            public: "false"
+                        x-xgen-version: preview
                 description: Options for starting a stream processor.
             responses:
                 "200":
                     content:
                         application/vnd.atlas.2025-03-12+json:
                             x-xgen-version: "2025-03-12"
+                        application/vnd.atlas.preview+json:
+                            x-xgen-preview:
+                                name: regional-failover
+                                public: "false"
+                            x-xgen-version: preview
                     description: OK
                     headers:
                         RateLimit-Limit:
@@ -62963,6 +65551,9 @@ paths:
             summary: Start One Stream Processor With Options
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/startGroupStreamProcessorWith
             x-xgen-operation-id-override: startStreamProcessorWith
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop:
@@ -63009,6 +65600,9 @@ paths:
             summary: Stop One Stream Processor
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/stopGroupStreamProcessor
             x-xgen-operation-id-override: stopStreamProcessor
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processors:
@@ -63056,6 +65650,9 @@ paths:
             summary: Return All Stream Processors in One Stream Workspace
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamProcessors
             x-xgen-operation-id-override: getStreamProcessors
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}:downloadOperationalLogs:
@@ -63125,6 +65722,12 @@ paths:
             summary: Download Operational Logs for One Atlas Stream Processing Workspace
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/downloadGroupStreamOperationalLogs
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -63175,6 +65778,8 @@ paths:
             summary: Return Account ID and VPC ID for One Project and Region
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamAccountDetails
             x-xgen-method-verb-override:
                 customMethod: false
@@ -63216,6 +65821,8 @@ paths:
             summary: Return All Active Incoming VPC Peering Connections
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamActiveVpcPeeringConnections
             x-xgen-operation-id-override: listActivePeeringConnections
     /api/atlas/v2/groups/{groupId}/streams/privateLinkConnections:
@@ -63254,6 +65861,8 @@ paths:
             summary: Return All Private Link Connections
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-changelog:
                 "2024-10-02": The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamPrivateLinkConnections
@@ -63302,6 +65911,9 @@ paths:
             summary: Create One Private Link Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2024-10-02": The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamPrivateLinkConnection
@@ -63344,6 +65956,9 @@ paths:
             summary: Delete One Private Link Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-changelog:
                 "2024-10-02": The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamPrivateLinkConnection
@@ -63386,6 +66001,8 @@ paths:
             summary: Return One Private Link Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-changelog:
                 "2024-10-02": The MongoDB Atlas Streams Processing Private Link API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamPrivateLinkConnection
@@ -63432,6 +66049,8 @@ paths:
             summary: Return All VPC Peering Connections
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamVpcPeeringConnections
             x-xgen-operation-id-override: listVpcPeeringConnections
     /api/atlas/v2/groups/{groupId}/streams/vpcPeeringConnections/{id}:
@@ -63471,6 +66090,9 @@ paths:
             summary: Delete One VPC Peering Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamVpcPeeringConnection
             x-xgen-operation-id-override: deleteVpcPeeringConnection
     /api/atlas/v2/groups/{groupId}/streams/vpcPeeringConnections/{id}:accept:
@@ -63517,6 +66139,9 @@ paths:
             summary: Accept One Incoming VPC Peering Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/acceptGroupStreamVpcPeeringConnection
             x-xgen-operation-id-override: acceptVpcPeeringConnection
     /api/atlas/v2/groups/{groupId}/streams/vpcPeeringConnections/{id}:reject:
@@ -63556,6 +66181,9 @@ paths:
             summary: Reject One Incoming VPC Peering Connection
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/rejectGroupStreamVpcPeeringConnection
             x-xgen-operation-id-override: rejectVpcPeeringConnection
     /api/atlas/v2/groups/{groupId}/streams:withSampleConnections:
@@ -63601,6 +66229,10 @@ paths:
             summary: Create One Stream Workspace with Sample Connections
             tags:
                 - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Data Access Admin
+                - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/withGroupStreamSampleConnections
             x-xgen-operation-id-override: withStreamSampleConnections
     /api/atlas/v2/groups/{groupId}/teams:
@@ -63642,6 +66274,8 @@ paths:
             summary: Return All Teams in One Project
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/listGroupTeams
         post:
             description: Adds multiple teams to the specified project. All members of a team share the same project access. MongoDB Cloud limits the number of users to a maximum of 100 teams per project and a maximum of 250 teams per organization. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Access Manager role.
@@ -63690,6 +66324,8 @@ paths:
             summary: Add Multiple Teams to One Project
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/addGroupTeams
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -63737,6 +66373,8 @@ paths:
             summary: Remove One Team from One Project
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/removeGroupTeam
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -63783,6 +66421,8 @@ paths:
             summary: Return One Team in One Project
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/getGroupTeam
         patch:
             description: Updates the project roles assigned to the specified team. You can grant team roles for specific projects and grant project access roles to users in the team. All members of the team share the same project access. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Access Manager role.
@@ -63836,6 +66476,8 @@ paths:
             summary: Update Team Roles in One Project
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/updateGroupTeam
     /api/atlas/v2/groups/{groupId}/userSecurity:
         get:
@@ -63871,6 +66513,8 @@ paths:
             summary: Return LDAP or X.509 Configuration
             tags:
                 - LDAP Configuration
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/getGroupUserSecurity
             x-xgen-operation-id-override: getUserSecurity
         patch:
@@ -63918,6 +66562,8 @@ paths:
             summary: Update LDAP or X.509 Configuration
             tags:
                 - LDAP Configuration
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/updateGroupUserSecurity
             x-xgen-operation-id-override: updateUserSecurity
     /api/atlas/v2/groups/{groupId}/userSecurity/customerX509:
@@ -63956,6 +66602,8 @@ paths:
             summary: Disable Customer-Managed X.509
             tags:
                 - X.509 Authentication
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/X.509-Authentication/operation/disableGroupUserSecurityCustomerX509
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -63995,6 +66643,8 @@ paths:
             summary: Remove LDAP User to DN Mapping
             tags:
                 - LDAP Configuration
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/deleteGroupUserSecurityLdapUserToDnMapping
             x-xgen-operation-id-override: deleteLdapUserMapping
     /api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify:
@@ -64040,6 +66690,8 @@ paths:
             summary: Verify LDAP Configuration in One Project
             tags:
                 - LDAP Configuration
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/verifyGroupUserSecurityLdap
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -64085,6 +66737,8 @@ paths:
             summary: Return Status of LDAP Configuration Verification in One Project
             tags:
                 - LDAP Configuration
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/getGroupUserSecurityLdapVerify
             x-xgen-method-verb-override:
                 customMethod: false
@@ -64164,6 +66818,8 @@ paths:
             summary: Return All MongoDB Cloud Users in One Project
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listGroupUsers
         post:
             description: "Adds one MongoDB Cloud user to one project. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Access Manager role. \n- If the user has a pending invitation to join the project's organization, MongoDB Cloud modifies it and grants project access. \n- If the user doesn't have an invitation to join the organization, MongoDB Cloud sends a new invitation that grants the user organization and project access. \n- If the user is already active in the project's organization, MongoDB Cloud grants access to the project. \n"
@@ -64209,6 +66865,8 @@ paths:
             summary: Add One MongoDB Cloud User to One Project
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addGroupUsers
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -64265,6 +66923,8 @@ paths:
             summary: Remove One MongoDB Cloud User from One Project
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeGroupUser
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -64316,6 +66976,8 @@ paths:
             summary: Return One MongoDB Cloud User in One Project
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/getGroupUser
     /api/atlas/v2/groups/{groupId}/users/{userId}/roles:
         put:
@@ -64367,6 +67029,8 @@ paths:
             summary: Update Project Roles for One MongoDB Cloud User
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateGroupUserRoles
     /api/atlas/v2/groups/{groupId}/users/{userId}:addRole:
         post:
@@ -64426,6 +67090,8 @@ paths:
             summary: Add One Project Role to One MongoDB Cloud User
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addGroupUserRole
     /api/atlas/v2/groups/{groupId}/users/{userId}:removeRole:
         post:
@@ -64485,6 +67151,8 @@ paths:
             summary: Remove One Project Role from One MongoDB Cloud User
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Project Access Manager
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeGroupUserRole
     /api/atlas/v2/groups/{groupId}:migrate:
         post:
@@ -64528,6 +67196,8 @@ paths:
             summary: Migrate One Project to Another Organization
             tags:
                 - Projects
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/migrateGroup
     /api/atlas/v2/groups/byName/{groupName}:
         get:
@@ -64710,6 +67380,8 @@ paths:
             summary: Remove One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/deleteOrg
         get:
             description: Returns one organization to which the requesting Service Account or API Key has access. To use this resource, the requesting Service Account or API Key must have the Organization Member role.
@@ -64748,6 +67420,8 @@ paths:
             summary: Return One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrg
         patch:
             description: Updates one organization. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -64793,6 +67467,8 @@ paths:
             summary: Update One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrg
     /api/atlas/v2/orgs/{orgId}/activityFeed:
         get:
@@ -64862,6 +67538,8 @@ paths:
             summary: Return Pre-Filtered Activity Feed Link for One Organization
             tags:
                 - Activity Feed
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Activity-Feed/operation/getOrgActivityFeed
     /api/atlas/v2/orgs/{orgId}/aiModelApiKeys:
         get:
@@ -64901,6 +67579,8 @@ paths:
             summary: Return AI Model API Keys for One Organization
             tags:
                 - AI Model API Keys
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/listOrgAiModelApiKeys
             x-xgen-operation-id-override: listOrgModelKeys
     /api/atlas/v2/orgs/{orgId}/aiModelApiKeys/{apiKeyId}:
@@ -64945,6 +67625,8 @@ paths:
             summary: Return Single AI Model API Key for One Organization
             tags:
                 - AI Model API Keys
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/getOrgAiModelApiKey
             x-xgen-operation-id-override: getOrgModelKey
     /api/atlas/v2/orgs/{orgId}/aiModelRateLimits:
@@ -64985,6 +67667,8 @@ paths:
             summary: Return AI Model Rate Limits for One Organization
             tags:
                 - AI Model Rate Limits
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listOrgAiModelRateLimits
             x-xgen-operation-id-override: listOrgModelLimits
     /api/atlas/v2/orgs/{orgId}/aiModelRateLimits/{modelGroupName}:
@@ -65029,6 +67713,8 @@ paths:
             summary: Return Single AI Model Rate Limit for One Organization
             tags:
                 - AI Model Rate Limits
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getOrgAiModelRateLimit
             x-xgen-operation-id-override: getOrgModelLimit
     /api/atlas/v2/orgs/{orgId}/apiKeys:
@@ -65071,6 +67757,8 @@ paths:
             summary: Return All Organization API Keys
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/listOrgApiKeys
         post:
             description: Creates one API key for the specified organization. An organization API key grants programmatic access to an organization. You can't use the API key to log into the console. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -65115,6 +67803,8 @@ paths:
             summary: Create One Organization API Key
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/createOrgApiKey
     /api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}:
         delete:
@@ -65158,6 +67848,8 @@ paths:
             summary: Remove One Organization API Key
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/deleteOrgApiKey
         get:
             description: Returns one organization API key. The organization API keys grant programmatic access to an organization. You can't use the API key to log into MongoDB Cloud through the user interface. To use this resource, the requesting Service Account or API Key must have the  Organization Member role.
@@ -65202,6 +67894,8 @@ paths:
             summary: Return One Organization API Key
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/getOrgApiKey
         patch:
             description: Updates one organization API key in the specified organization. The organization API keys  grant programmatic access to an organization. To use this resource, the requesting  API Key must have the Organization Owner role.
@@ -65255,6 +67949,8 @@ paths:
             summary: Update One Organization API Key
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/updateOrgApiKey
     /api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList:
         get:
@@ -65303,6 +67999,8 @@ paths:
             summary: Return All Access List Entries for One Organization API Key
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/listOrgApiKeyAccessListEntries
             x-xgen-method-verb-override:
                 customMethod: false
@@ -65477,6 +68175,8 @@ paths:
             summary: Return One Access List Entry for One Organization API Key
             tags:
                 - Programmatic API Keys
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/getOrgApiKeyAccessListEntry
             x-xgen-method-verb-override:
                 customMethod: false
@@ -65538,6 +68238,8 @@ paths:
             summary: Return Associated Invoices
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgAssociatedInvoices
     /api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage:
         post:
@@ -65581,6 +68283,8 @@ paths:
             summary: Create One Cost Explorer Query Process
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/createOrgBillingCostExplorerUsageProcess
             x-xgen-method-verb-override:
                 customMethod: false
@@ -65646,6 +68350,8 @@ paths:
             summary: Return Usage Details for One Cost Explorer Query
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgBillingCostExplorerUsage
             x-xgen-operation-id-override: getCostExplorerUsage
     /api/atlas/v2/orgs/{orgId}/events:
@@ -65724,6 +68430,8 @@ paths:
             summary: Return Events from One Organization
             tags:
                 - Events
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/listOrgEvents
     /api/atlas/v2/orgs/{orgId}/events/{eventId}:
         get:
@@ -65778,6 +68486,8 @@ paths:
             summary: Return One Event from One Organization
             tags:
                 - Events
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Events/operation/getOrgEvent
     /api/atlas/v2/orgs/{orgId}/federationSettings:
         get:
@@ -65815,6 +68525,8 @@ paths:
             summary: Return Federation Settings for One Organization
             tags:
                 - Federated Authentication
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication/operation/getOrgFederationSettings
             x-xgen-operation-id-override: getFederationSettings
     /api/atlas/v2/orgs/{orgId}/groups:
@@ -65869,6 +68581,8 @@ paths:
             summary: Return All Projects in One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgGroups
     /api/atlas/v2/orgs/{orgId}/invites:
         get:
@@ -65922,6 +68636,8 @@ paths:
             summary: Return All Invitations in One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/listOrgInvites
         patch:
             deprecated: true
@@ -65973,6 +68689,8 @@ paths:
             summary: Update One Invitation in One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgInvites
         post:
             deprecated: true
@@ -66024,6 +68742,8 @@ paths:
             summary: Create Invitation for One MongoDB Cloud User in One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/createOrgInvite
     /api/atlas/v2/orgs/{orgId}/invites/{invitationId}:
         delete:
@@ -66073,6 +68793,8 @@ paths:
             summary: Remove One Invitation from One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/deleteOrgInvite
         get:
             deprecated: true
@@ -66123,6 +68845,8 @@ paths:
             summary: Return One Invitation in One Organization by Invitation ID
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgInvite
         patch:
             deprecated: true
@@ -66181,6 +68905,8 @@ paths:
             summary: Update One Invitation in One Organization by Invitation ID
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgInviteById
             x-xgen-method-verb-override:
                 customMethod: false
@@ -66280,6 +69006,8 @@ paths:
             summary: Return All Invoices for One Organization
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/listOrgInvoices
             x-xgen-operation-id-override: listInvoices
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}:
@@ -66336,6 +69064,8 @@ paths:
             summary: Return One Invoice for One Organization
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgInvoice
             x-xgen-operation-id-override: getInvoice
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
@@ -66388,6 +69118,8 @@ paths:
             summary: Return One Invoice as CSV for One Organization
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgInvoiceCsv
             x-xgen-operation-id-override: getInvoiceCsv
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/lineItems:search:
@@ -66441,6 +69173,8 @@ paths:
             summary: Return All Line Items for One Invoice by Invoice ID
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/searchOrgInvoiceLineItems
             x-xgen-operation-id-override: searchInvoiceLineItems
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}:generateAndDownloadReport:
@@ -66497,6 +69231,8 @@ paths:
             summary: Generate and Download Invoice Report
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/generateOrgInvoiceAndDownloadReport
             x-xgen-operation-id-override: generateInvoiceReport
     /api/atlas/v2/orgs/{orgId}/invoices/pending:
@@ -66533,6 +69269,8 @@ paths:
             summary: Return All Pending Invoices for One Organization
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/listOrgInvoicePending
             x-xgen-operation-id-override: listInvoicePending
     /api/atlas/v2/orgs/{orgId}/liveMigrations/availableProjects:
@@ -66573,6 +69311,8 @@ paths:
             summary: Return All Projects Available for Migration
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/listOrgLiveMigrationAvailableProjects
             x-xgen-operation-id-override: listAvailableProjects
     /api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens:
@@ -66608,6 +69348,8 @@ paths:
             summary: Remove One Link-Token
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/deleteOrgLiveMigrationLinkTokens
             x-xgen-operation-id-override: deleteLinkTokens
         post:
@@ -66652,6 +69394,8 @@ paths:
             summary: Create One Link-Token
             tags:
                 - Cloud Migration Service
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/createOrgLiveMigrationLinkToken
             x-xgen-operation-id-override: createLinkToken
     /api/atlas/v2/orgs/{orgId}/nonCompliantResources:
@@ -66695,6 +69439,8 @@ paths:
             summary: Return All Non-Compliant Resources
             tags:
                 - Resource Policies
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/getOrgNonCompliantResources
             x-xgen-operation-id-override: getNonCompliantResources
     /api/atlas/v2/orgs/{orgId}/resourcePolicies:
@@ -66738,6 +69484,8 @@ paths:
             summary: Return All Atlas Resource Policies
             tags:
                 - Resource Policies
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/listOrgResourcePolicies
         post:
             description: Create one Atlas Resource Policy for an organization.
@@ -66790,6 +69538,8 @@ paths:
             summary: Create One Atlas Resource Policy
             tags:
                 - Resource Policies
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/createOrgResourcePolicy
     /api/atlas/v2/orgs/{orgId}/resourcePolicies/{resourcePolicyId}:
         delete:
@@ -66838,6 +69588,8 @@ paths:
             summary: Delete One Atlas Resource Policy
             tags:
                 - Resource Policies
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/deleteOrgResourcePolicy
         get:
             description: Return one Atlas Resource Policy for an organization.
@@ -66887,6 +69639,8 @@ paths:
             summary: Return One Atlas Resource Policy
             tags:
                 - Resource Policies
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/getOrgResourcePolicy
         patch:
             description: Update one Atlas Resource Policy for an organization.
@@ -66949,6 +69703,8 @@ paths:
             summary: Update One Atlas Resource Policy
             tags:
                 - Resource Policies
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/updateOrgResourcePolicy
     /api/atlas/v2/orgs/{orgId}/resourcePolicies:validate:
         post:
@@ -67002,6 +69758,8 @@ paths:
             summary: Validate One Atlas Resource Policy
             tags:
                 - Resource Policies
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/validateOrgResourcePolicies
             x-xgen-operation-id-override: validateResourcePolicies
     /api/atlas/v2/orgs/{orgId}/sandboxConfig:
@@ -67037,6 +69795,8 @@ paths:
             summary: Return Sandbox Configuration IDs for an Organization
             tags:
                 - Sandbox
+            x-rolesRequirements:
+                - Organization Project Creator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/listOrgSandboxConfig
         post:
             description: Create one sandbox configuration for an organization.
@@ -67080,6 +69840,8 @@ paths:
             summary: Create One Sandbox Configuration for an Organization
             tags:
                 - Sandbox
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/createOrgSandboxConfig
     /api/atlas/v2/orgs/{orgId}/sandboxConfig/{sandboxConfigId}:
         delete:
@@ -67107,6 +69869,8 @@ paths:
             summary: Delete the Default Sandbox Configuration and Disable Sandbox
             tags:
                 - Sandbox
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/deleteOrgSandboxConfig
         get:
             description: Return the default sandbox configuration for an organization.
@@ -67139,6 +69903,8 @@ paths:
             summary: Return Default Sandbox Configuration for One Organization
             tags:
                 - Sandbox
+            x-rolesRequirements:
+                - Organization Project Creator
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/getOrgSandboxConfig
         patch:
             description: Update an existing sandbox configuration for an organization.
@@ -67181,6 +69947,8 @@ paths:
             summary: Update an Existing Sandbox Configuration
             tags:
                 - Sandbox
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Sandbox/operation/updateOrgSandboxConfig
     /api/atlas/v2/orgs/{orgId}/serviceAccounts:
         get:
@@ -67218,6 +69986,8 @@ paths:
             summary: Return All Organization Service Accounts
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listOrgServiceAccounts
         post:
             description: Creates one Service Account for the specified Organization.
@@ -67261,6 +70031,8 @@ paths:
             summary: Create One Organization Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createOrgServiceAccount
     /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}:
         delete:
@@ -67302,6 +70074,8 @@ paths:
             summary: Delete One Organization Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteOrgServiceAccount
         get:
             description: Returns the specified Service Account.
@@ -67344,6 +70118,8 @@ paths:
             summary: Return One Organization Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/getOrgServiceAccount
         patch:
             description: Updates the specified Service Account in the specified Organization.
@@ -67395,6 +70171,8 @@ paths:
             summary: Update One Organization Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/updateOrgServiceAccount
     /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/accessList:
         get:
@@ -67441,6 +70219,8 @@ paths:
             summary: Return All Access List Entries for One Organization Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/listOrgServiceAccountAccessList
             x-xgen-operation-id-override: listOrgAccessList
         post:
@@ -67502,6 +70282,8 @@ paths:
             summary: Add Access List Entries for One Organization Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createOrgServiceAccountAccessList
             x-xgen-operation-id-override: createOrgAccessList
     /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/accessList/{ipAddress}:
@@ -67554,6 +70336,8 @@ paths:
             summary: Remove One Access List Entry from One Organization Service Account
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteOrgServiceAccountAccessListEntry
             x-xgen-method-verb-override:
                 customMethod: true
@@ -67603,6 +70387,8 @@ paths:
             summary: Return All Service Account Project Assignments
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/getOrgServiceAccountGroups
             x-xgen-operation-id-override: getServiceAccountGroups
     /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/secrets:
@@ -67656,6 +70442,8 @@ paths:
             summary: Create One Organization Service Account Secret
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/createOrgServiceAccountSecret
             x-xgen-operation-id-override: createOrgSecret
     /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}/secrets/{secretId}:
@@ -67704,6 +70492,8 @@ paths:
             summary: Delete One Organization Service Account Secret
             tags:
                 - Service Accounts
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Service-Accounts/operation/deleteOrgServiceAccountSecret
             x-xgen-operation-id-override: deleteOrgSecret
     /api/atlas/v2/orgs/{orgId}/settings:
@@ -67740,6 +70530,8 @@ paths:
             summary: Return Settings for One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgSettings
         patch:
             description: Updates the organization's settings. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -67783,6 +70575,8 @@ paths:
             summary: Update Settings for One Organization
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgSettings
     /api/atlas/v2/orgs/{orgId}/teams:
         get:
@@ -67826,6 +70620,8 @@ paths:
             summary: Return All Teams in One Organization
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/listOrgTeams
         post:
             description: Creates one team in the specified organization. Teams enable you to grant project access roles to MongoDB Cloud users. MongoDB Cloud limits the number of teams to a maximum of 250 teams per organization. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -67874,6 +70670,8 @@ paths:
             summary: Create One Team in One Organization
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/createOrgTeam
     /api/atlas/v2/orgs/{orgId}/teams/{teamId}:
         delete:
@@ -67919,6 +70717,8 @@ paths:
             summary: Remove One Team from One Organization
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/deleteOrgTeam
         get:
             description: Returns one team that you identified using its unique 24-hexadecimal digit ID. This team belongs to one organization. Teams enable you to grant project access roles to MongoDB Cloud users. To use this resource, the requesting Service Account or API Key must have the Organization Member role.
@@ -67965,6 +70765,8 @@ paths:
             summary: Return One Team by ID
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/getOrgTeam
         patch:
             description: Renames one team in the specified organization. Teams enable you to grant project access roles to MongoDB Cloud users. To use this resource, the requesting Service Account or API Key must have the Organization Owner role.
@@ -68020,6 +70822,8 @@ paths:
             summary: Rename One Team
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/renameOrgTeam
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -68102,6 +70906,8 @@ paths:
             summary: Return All MongoDB Cloud Users Assigned to One Team
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listOrgTeamUsers
             x-xgen-operation-id-override: listTeamUsers
         post:
@@ -68165,6 +70971,8 @@ paths:
             summary: Assign MongoDB Cloud Users in One Organization to One Team
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/addOrgTeamUsers
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -68226,6 +71034,8 @@ paths:
             summary: Remove One MongoDB Cloud User from One Team
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/removeOrgTeamUserFromTeam
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -68287,6 +71097,8 @@ paths:
             summary: Add One MongoDB Cloud User to One Team
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addOrgTeamUser
     /api/atlas/v2/orgs/{orgId}/teams/{teamId}:removeUser:
         post:
@@ -68344,6 +71156,8 @@ paths:
             summary: Remove One MongoDB Cloud User from One Team
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeOrgTeamUser
     /api/atlas/v2/orgs/{orgId}/teams/byName/{teamName}:
         get:
@@ -68390,6 +71204,8 @@ paths:
             summary: Return One Team by Name
             tags:
                 - Teams
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Teams/operation/getOrgTeamByName
             x-xgen-operation-id-override: getTeamByName
     /api/atlas/v2/orgs/{orgId}/users:
@@ -68456,6 +71272,8 @@ paths:
             summary: Return All MongoDB Cloud Users in One Organization
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listOrgUsers
         post:
             description: |-
@@ -68504,6 +71322,8 @@ paths:
             summary: Add One MongoDB Cloud User to One Organization
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/createOrgUser
     /api/atlas/v2/orgs/{orgId}/users/{userId}:
         delete:
@@ -68557,6 +71377,8 @@ paths:
             summary: Remove One MongoDB Cloud User from One Organization
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeOrgUser
             x-xgen-method-verb-override:
                 customMethod: "True"
@@ -68608,6 +71430,8 @@ paths:
             summary: Return One MongoDB Cloud User in One Organization
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/getOrgUser
         patch:
             description: |-
@@ -68666,6 +71490,8 @@ paths:
             summary: Update One MongoDB Cloud User in One Organization
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/updateOrgUser
     /api/atlas/v2/orgs/{orgId}/users/{userId}/roles:
         put:
@@ -68717,6 +71543,8 @@ paths:
             summary: Update Organization Roles for One MongoDB Cloud User
             tags:
                 - Organizations
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgUserRoles
     /api/atlas/v2/orgs/{orgId}/users/{userId}:addRole:
         post:
@@ -68778,6 +71606,8 @@ paths:
             summary: Add One Organization Role to One MongoDB Cloud User
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/addOrgUserRole
             x-xgen-operation-id-override: addOrgRole
     /api/atlas/v2/orgs/{orgId}/users/{userId}:removeRole:
@@ -68838,6 +71668,8 @@ paths:
             summary: Remove One Organization Role from One MongoDB Cloud User
             tags:
                 - MongoDB Cloud Users
+            x-rolesRequirements:
+                - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/removeOrgUserRole
             x-xgen-operation-id-override: removeOrgRole
     /api/atlas/v2/rateLimits:
@@ -68898,7 +71730,7 @@ paths:
                         application/vnd.atlas.preview+json:
                             schema:
                                 $ref: '#/components/schemas/PaginatedRateLimitEndpointSets'
-                            x-sunset: "2026-04-19"
+                            x-sunset: "2026-04-21"
                             x-xgen-preview:
                                 name: rate-limit
                                 public: "false"
@@ -68974,7 +71806,7 @@ paths:
                         application/vnd.atlas.preview+json:
                             schema:
                                 $ref: '#/components/schemas/RateLimitEndpointSetResponse'
-                            x-sunset: "2026-04-19"
+                            x-sunset: "2026-04-21"
                             x-xgen-preview:
                                 name: rate-limit
                                 public: "false"
@@ -69035,6 +71867,8 @@ paths:
             summary: Return All Stock Keeping Units
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/listSkus
     /api/atlas/v2/skus/{skuId}:
         get:
@@ -69076,6 +71910,8 @@ paths:
             summary: Return One Stock Keeping Unit
             tags:
                 - Invoices
+            x-rolesRequirements:
+                - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getSku
     /api/atlas/v2/unauth/controlPlaneIPAddresses:
         get:
@@ -69321,6 +72157,8 @@ tags:
       name: Limit Description
     - description: Returns, edits, and removes maintenance windows. The maintenance procedure that MongoDB Cloud performs requires at least one replica set election during the maintenance window per replica set. You can defer a scheduled maintenance event for a project up to two times. Deferred maintenance events occur during your preferred maintenance window exactly one week after the previously scheduled date and time.
       name: Maintenance Windows
+    - description: Returns, creates, updates, and removes metric integration configurations for a project.
+      name: Metric Integrations
     - description: Returns, adds, and edits MongoDB Cloud users.
       name: MongoDB Cloud Users
     - description: Returns database deployment monitoring and logging data.

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -1299,6 +1299,11 @@ resources:
             immutable_computed: true
           otel_supplied_headers:
             sensitive: true
+          use_legacy_path_structure:
+            # Optional but Atlas returns the default value when null.
+            computability:
+              optional: true
+              computed: true
     datasources:
       read:
         path: /api/atlas/v2/groups/{groupId}/logIntegrations/{id}

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -68,6 +68,8 @@ schema:
                       tf_schema_name: kms_key
                     - api_name: prefixPath
                       tf_schema_name: prefix_path
+                    - api_name: useLegacyPathStructure
+                      tf_schema_name: use_legacy_path_structure
                 required:
                     - api_name: bucketName
                       tf_schema_name: bucket_name
@@ -312,6 +314,17 @@ schema:
           create_only: false
           present_in_any_response: true
           request_only_required_on_create: false
+        - bool: {}
+          description: 'Optional for type: S3_LOG_EXPORT. When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.'
+          computed_optional_required: computed_optional
+          tf_schema_name: use_legacy_path_structure
+          tf_model_name: UseLegacyPathStructure
+          api_name: useLegacyPathStructure
+          req_body_usage: all_request_bodies
+          sensitive: false
+          create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
 operations:
     delete:
         http_method: DELETE
@@ -397,6 +410,8 @@ data_sources:
                           tf_schema_name: kms_key
                         - api_name: prefixPath
                           tf_schema_name: prefix_path
+                        - api_name: useLegacyPathStructure
+                          tf_schema_name: use_legacy_path_structure
                     required:
                         - api_name: bucketName
                           tf_schema_name: bucket_name
@@ -641,6 +656,17 @@ data_sources:
               create_only: false
               present_in_any_response: false
               request_only_required_on_create: false
+            - bool: {}
+              description: 'Applies to type: S3_LOG_EXPORT. When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.'
+              computed_optional_required: computed
+              tf_schema_name: use_legacy_path_structure
+              tf_model_name: UseLegacyPathStructure
+              api_name: useLegacyPathStructure
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
     plural:
         description: Returns all log integration configurations for the project. Optionally filter by integration type. To use this resource, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
         attributes:
@@ -736,6 +762,8 @@ data_sources:
                                       tf_schema_name: kms_key
                                     - api_name: prefixPath
                                       tf_schema_name: prefix_path
+                                    - api_name: useLegacyPathStructure
+                                      tf_schema_name: use_legacy_path_structure
                                 required:
                                     - api_name: bucketName
                                       tf_schema_name: bucket_name
@@ -964,6 +992,17 @@ data_sources:
                           tf_schema_name: type
                           tf_model_name: Type
                           api_name: type
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
+                        - bool: {}
+                          description: 'Applies to type: S3_LOG_EXPORT. When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`.'
+                          computed_optional_required: computed
+                          tf_schema_name: use_legacy_path_structure
+                          tf_model_name: UseLegacyPathStructure
+                          api_name: useLegacyPathStructure
                           req_body_usage: omit_always
                           sensitive: false
                           create_only: false


### PR DESCRIPTION
## Description

Adds `use_legacy_path_structure` attribute for `S3_LOG_EXPORT` type to use the legacy daily-folder path structure

Link to any related issue(s): [CLOUDP-401558](https://jira.mongodb.org/browse/CLOUDP-401558)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
