### PR TITLE
test: Fix Azure Blob Storage acceptance tests to use serial execution…

### DIFF
--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -16,6 +17,10 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
+
+// azureServicePrincipalMu serializes Azure Blob Storage tests that share the same
+// service principal ID, preventing DUPLICATE_AZURE_SERVICE_PRINCIPAL errors
+var azureServicePrincipalMu sync.Mutex
 
 const (
 	dataSourceConfig = `
@@ -1307,7 +1312,11 @@ func TestAccStreamRSStreamConnection_AzureBlobStorage(t *testing.T) {
 		storageContainerName    = acc.RandomBucketName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckAzureEnvWithServicePrincipal(t) },
+		PreCheck: func() {
+			acc.PreCheckAzureEnvWithServicePrincipal(t)
+			azureServicePrincipalMu.Lock()
+			t.Cleanup(azureServicePrincipalMu.Unlock)
+		},
 		ExternalProviders:        acc.ExternalProvidersOnlyAzurerm(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -1328,21 +1337,26 @@ func TestAccStreamRSStreamConnection_AzureBlobStorage(t *testing.T) {
 
 func TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink(t *testing.T) {
 	var (
-		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
-		clusterName             = acc.RandomClusterName()
-		connectionName          = acc.RandomName()
-		clientID                = os.Getenv("AZURE_CLIENT_ID")
-		clientSecret            = os.Getenv("AZURE_APP_SECRET")
-		subscriptionID          = os.Getenv("AZURE_SUBSCRIPTION_ID")
-		tenantID                = os.Getenv("AZURE_TENANT_ID")
-		atlasAzureAppID         = os.Getenv("AZURE_ATLAS_APP_ID")
-		servicePrincipalID      = os.Getenv("AZURE_SERVICE_PRINCIPAL_ID")
-		resourceGroupName       = acc.RandomName()
-		storageAccountName      = "tfacctest" + acctest.RandString(10)
-		storageContainerName    = acc.RandomBucketName()
+		projectID            = acc.ProjectIDExecution(t)
+		instanceName         = acc.RandomStreamInstanceName()
+		clusterName          = acc.RandomClusterName()
+		connectionName       = acc.RandomName()
+		clientID             = os.Getenv("AZURE_CLIENT_ID")
+		clientSecret         = os.Getenv("AZURE_APP_SECRET")
+		subscriptionID       = os.Getenv("AZURE_SUBSCRIPTION_ID")
+		tenantID             = os.Getenv("AZURE_TENANT_ID")
+		atlasAzureAppID      = os.Getenv("AZURE_ATLAS_APP_ID")
+		servicePrincipalID   = os.Getenv("AZURE_SERVICE_PRINCIPAL_ID")
+		resourceGroupName    = acc.RandomName()
+		storageAccountName   = "tfacctest" + acctest.RandString(10)
+		storageContainerName = acc.RandomBucketName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckAzureEnvWithServicePrincipal(t) },
+		PreCheck: func() {
+			acc.PreCheckAzureEnvWithServicePrincipal(t)
+			azureServicePrincipalMu.Lock()
+			t.Cleanup(azureServicePrincipalMu.Unlock)
+		},
 		ExternalProviders:        acc.ExternalProvidersOnlyAzurerm(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -1439,6 +1453,15 @@ func configAzureBlobStoragePrivateLinkResources(projectID, workspaceName, cluste
 			}]
 		}
 
+		resource "mongodbatlas_stream_workspace" "test" {
+			project_id     = %[1]q
+			workspace_name = %[2]q
+			data_process_region = {
+				region         = "eastus2"
+				cloud_provider = "AZURE"
+			}
+		}
+
 		resource "mongodbatlas_stream_privatelink_endpoint" "test" {
 			project_id          = %[1]q
 			provider_name       = "AZURE"
@@ -1451,7 +1474,7 @@ func configAzureBlobStoragePrivateLinkResources(projectID, workspaceName, cluste
 
 		resource "mongodbatlas_stream_connection" "test" {
 			project_id      = %[1]q
-			workspace_name  = %[2]q
+			workspace_name  = mongodbatlas_stream_workspace.test.workspace_name
 			connection_name = %[3]q
 			type            = "AzureBlobStorage"
 			azure = {

--- a/internal/testutil/acc/cloud_provider_access.go
+++ b/internal/testutil/acc/cloud_provider_access.go
@@ -51,7 +51,7 @@ func ConfigAzureStorageResources(prefix, resourceGroupName, storageAccountName, 
 	return fmt.Sprintf(`
 		resource "azurerm_resource_group" "%[1]s_rg" {
 			name     = %[2]q
-			location = "East US"
+			location = "East US 2"
 		}
 
 		resource "azurerm_storage_account" "%[1]s_storage" {


### PR DESCRIPTION
… and East US 2 region

## Description

There were two failing tests for Azure blob storage private link, one was because the private link region did not match the cluster region, and the other was because two tests were running in parallel and using the same Azure service principal

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
