### PR TITLE
chore: Run GCP private link endpoint tests serially

### DIFF
--- a/internal/service/privatelinkendpoint/resource_test.go
+++ b/internal/service/privatelinkendpoint/resource_test.go
@@ -86,7 +86,7 @@ func TestAccPrivateLinkEndpoint_basicGCP(t *testing.T) {
 		withPluralDS = true
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
@@ -126,11 +126,11 @@ func TestAccPrivateLinkEndpoint_deleteOnCreateTimeout(t *testing.T) {
 }
 
 func TestAccPrivateLinkEndpoint_gcpPortMappingEnabled(t *testing.T) {
-	resource.ParallelTest(t, *basicGCPTestCaseWithPortMapping(t, true))
+	resource.Test(t, *basicGCPTestCaseWithPortMapping(t, true))
 }
 
 func TestAccPrivateLinkEndpoint_gcpPortMappingDisabled(t *testing.T) {
-	resource.ParallelTest(t, *basicGCPTestCaseWithPortMapping(t, false))
+	resource.Test(t, *basicGCPTestCaseWithPortMapping(t, false))
 }
 
 func basicGCPTestCaseWithPortMapping(tb testing.TB, portMappingEnabled bool) *resource.TestCase {

--- a/internal/service/privatelinkendpoint/resource_test.go
+++ b/internal/service/privatelinkendpoint/resource_test.go
@@ -85,7 +85,7 @@ func TestAccPrivateLinkEndpoint_basicGCP(t *testing.T) {
 		providerName = constant.GCP
 		withPluralDS = true
 	)
-
+	// Run serially to avoid GCP project conflicts.
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -126,10 +126,12 @@ func TestAccPrivateLinkEndpoint_deleteOnCreateTimeout(t *testing.T) {
 }
 
 func TestAccPrivateLinkEndpoint_gcpPortMappingEnabled(t *testing.T) {
+	// Run serially to avoid GCP project conflicts.
 	resource.Test(t, *basicGCPTestCaseWithPortMapping(t, true))
 }
 
 func TestAccPrivateLinkEndpoint_gcpPortMappingDisabled(t *testing.T) {
+	// Run serially to avoid GCP project conflicts.
 	resource.Test(t, *basicGCPTestCaseWithPortMapping(t, false))
 }
 


### PR DESCRIPTION
## Description

Three GCP private link endpoint acceptance tests (`TestAccPrivateLinkEndpoint_basicGCP`, `TestAccPrivateLinkEndpoint_gcpPortMappingEnabled`, `TestAccPrivateLinkEndpoint_gcpPortMappingDisabled`) share the same project via `acc.ProjectIDExecution` and fail intermittently (~50% pass rate) when run in parallel. The root cause is an Atlas per-group org-assignment race: when multiple `POST /privateEndpoint/endpointService` requests land concurrently in the same project, the first request assigns the project to a GCP org; subsequent in-flight requests don't see that state yet and receive `ATLAS_GENERAL_ERROR / No Capacity`. Running the tests serially eliminates the concurrent requests and the race.

Link to any related issue(s): CLOUDP-404269

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments