### PR TITLE
fix: Fix `flex_cluster` deletion wait and test cleanup

### DIFF
--- a/.changelog/4431.txt
+++ b/.changelog/4431.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_flex_cluster: Fixes deletion waits to improve reliability when deleting flex clusters
+```

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20250312018/admin"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/flexcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -58,13 +58,11 @@ func TestAccFlexClusterRS_createTimeoutWithDeleteOnCreateFlex(t *testing.T) {
 
 func waitFlexClusterDeletion(t *testing.T, projectID, clusterName string) {
 	t.Helper()
-	ctx := context.Background()
-	client := acc.ConnV2().FlexClustersApi
 	params := &admin.GetFlexClusterApiParams{
 		GroupId: projectID,
 		Name:    clusterName,
 	}
-	require.NoError(t, flexcluster.WaitStateTransitionDelete(ctx, params, client, constant.DefaultTimeout))
+	require.NoError(t, flexcluster.WaitStateTransitionDelete(context.Background(), params, acc.ConnV2().FlexClustersApi, 10*time.Minute))
 }
 
 func TestAccFlexClusterRS_updateDeleteTimeout(t *testing.T) {

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -1,12 +1,17 @@
 package flexcluster_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20250312018/admin"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/flexcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -36,6 +41,9 @@ func TestAccFlexClusterRS_createTimeoutWithDeleteOnCreateFlex(t *testing.T) {
 		createTimeout         = "1s"
 		deleteOnCreateTimeout = true
 	)
+	t.Cleanup(func() {
+		waitFlexClusterDeletion(t, projectID, clusterName)
+	})
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -46,6 +54,17 @@ func TestAccFlexClusterRS_createTimeoutWithDeleteOnCreateFlex(t *testing.T) {
 			},
 		},
 	})
+}
+
+func waitFlexClusterDeletion(t *testing.T, projectID, clusterName string) {
+	t.Helper()
+	ctx := context.Background()
+	client := acc.ConnV2().FlexClustersApi
+	params := &admin.GetFlexClusterApiParams{
+		GroupId: projectID,
+		Name:    clusterName,
+	}
+	require.NoError(t, flexcluster.WaitStateTransitionDelete(ctx, params, client, constant.DefaultTimeout))
 }
 
 func TestAccFlexClusterRS_updateDeleteTimeout(t *testing.T) {

--- a/internal/service/flexcluster/state_transition.go
+++ b/internal/service/flexcluster/state_transition.go
@@ -37,7 +37,7 @@ func WaitStateTransition(ctx context.Context, requestParams *admin.GetFlexCluste
 
 func WaitStateTransitionDelete(ctx context.Context, requestParams *admin.GetFlexClusterApiParams, client admin.FlexClustersApi, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{retrystrategy.RetryStrategyDeletingState},
+		Pending:    []string{retrystrategy.RetryStrategyCreatingState, retrystrategy.RetryStrategyIdleState, retrystrategy.RetryStrategyDeletingState},
 		Target:     []string{retrystrategy.RetryStrategyDeletedState},
 		Refresh:    refreshFunc(ctx, requestParams, client, false),
 		Timeout:    timeout,


### PR DESCRIPTION
## Description

Fix `flex_cluster` deletion wait and test cleanup. 
- Allows `CREATING` and `IDLE` as pending states while waiting for flex cluster deletion, because Atlas can briefly return these states after a delete request is accepted.
- Wait in `TestAccFlexClusterRS_createTimeoutWithDeleteOnCreateFlex` until the cluster is deleted so project can be deleted later.

E.g. fail in [execution](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/25706288470/job/75477220636) that is being fixed:  "DELETE: HTTP 409 Conflict (Error code: "CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS") Detail: Cannot close group while it has active clusters; please terminate all clusters."

Link to any related issue(s): CLOUDP-404496

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
