### PR TITLE
feat: Add failover_regions to stream_workspace and failover_enabled to stream_processor

### DIFF
--- a/.changelog/4441.txt
+++ b/.changelog/4441.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_workspace: Adds `failover_regions` attribute with write-once semantics and mutual exclusivity with `data_process_region` on updates
+```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_processor: Adds `failover_enabled` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_instance: Adds computed `failover_regions` attribute
+```

--- a/docs/resources/stream_workspace.md
+++ b/docs/resources/stream_workspace.md
@@ -21,6 +21,25 @@ resource "mongodbatlas_stream_workspace" "test" {
 }
 ```
 
+### With Failover Regions
+
+```terraform
+resource "mongodbatlas_stream_workspace" "test" {
+    project_id = var.project_id
+    workspace_name = "WorkspaceName"
+    data_process_region = {
+        region         = "VIRGINIA_USA"
+        cloud_provider = "AWS"
+    }
+    failover_regions = [
+        {
+            cloud_provider = "AWS"
+            region         = "OREGON_USA"
+        }
+    ]
+}
+```
+
 ### Further Examples
 - [Atlas Stream Workspace](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.12.0/examples/mongodbatlas_stream_workspace)
 
@@ -49,7 +68,8 @@ resource "mongodbatlas_stream_workspace" "example" {
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project, also known as `groupId` in the official documentation.
 * `workspace_name` - (Required) Label that identifies the stream workspace.
 * `data_process_region` - (Required) Cloud service provider and region where MongoDB Cloud performs stream processing. See [data process region](#data-process-region).
-* `stream_config` - (Optional) Configuration options for an Atlas Stream Processing Instance. See [stream config](#stream-config)
+* `stream_config` - (Optional) Configuration options for an Atlas Stream Processing Instance. See [stream config](#stream-config).
+* `failover_regions` - (Optional) List of cloud provider regions to which the workspace can fail over if the primary region becomes unavailable. See [failover regions](#failover-regions).
 
 
 ### Data Process Region
@@ -62,12 +82,18 @@ resource "mongodbatlas_stream_workspace" "example" {
 * `max_tier_size` - (Optional) Max tier size for the Stream Workspace. Configures Memory / VCPU allowances.
 * `tier` - (Optional) Selected tier for the Stream Workspace. Configures Memory / VCPU allowances. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/creategroupstreamworkspace) describes the valid values.
 
+### Failover Regions
+
+* `cloud_provider` - (Required) Cloud service provider for the failover region. Must match the primary region's cloud provider.
+* `region` - (Required) Name of the failover cloud provider region.
+
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `hostnames` - List that contains the hostnames assigned to the stream workspace.
+* `failover_regions` - List of failover regions configured for the workspace. Populated from the API response after create.
 
 ## Import
 

--- a/internal/service/streaminstance/model_stream_instance.go
+++ b/internal/service/streaminstance/model_stream_instance.go
@@ -69,6 +69,20 @@ func NewTFStreamInstance(ctx context.Context, apiResp *admin.StreamsTenant) (*TF
 		streamConfig = returnedStreamConfig
 		diags.Append(diagsStreamConfig...)
 	}
+	failoverRegions := types.ListNull(FailoverRegionObjectType)
+	if apiResp.HasFailoverRegions() {
+		sdkRegions := apiResp.GetFailoverRegions()
+		tfRegions := make([]TFInstanceProcessRegionSpecModel, len(sdkRegions))
+		for i, r := range sdkRegions {
+			tfRegions[i] = TFInstanceProcessRegionSpecModel{
+				CloudProvider: types.StringValue(r.CloudProvider),
+				Region:        types.StringValue(r.Region),
+			}
+		}
+		returnedFailoverRegions, diagsFailover := types.ListValueFrom(ctx, FailoverRegionObjectType, tfRegions)
+		diags.Append(diagsFailover...)
+		failoverRegions = returnedFailoverRegions
+	}
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -78,6 +92,7 @@ func NewTFStreamInstance(ctx context.Context, apiResp *admin.StreamsTenant) (*TF
 		InstanceName:      types.StringPointerValue(apiResp.Name),
 		ProjectID:         types.StringPointerValue(apiResp.GroupId),
 		DataProcessRegion: dataProcessRegion,
+		FailoverRegions:   failoverRegions,
 		StreamConfig:      streamConfig,
 		Hostnames:         hostnames,
 	}, nil

--- a/internal/service/streaminstance/resource_schema.go
+++ b/internal/service/streaminstance/resource_schema.go
@@ -32,13 +32,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"data_process_region": schema.SingleNestedAttribute{
-				Required: true,
-				Attributes: map[string]schema.Attribute{
-					"cloud_provider": schema.StringAttribute{
-						Required: true,
-					},
-					"region": schema.StringAttribute{
-						Required: true,
+				Required:   true,
+				Attributes: regionAttributes(),
+			},
+			"failover_regions": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"cloud_provider": schema.StringAttribute{Computed: true},
+						"region":         schema.StringAttribute{Computed: true},
 					},
 				},
 			},
@@ -64,11 +66,23 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
+func regionAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"cloud_provider": schema.StringAttribute{
+			Required: true,
+		},
+		"region": schema.StringAttribute{
+			Required: true,
+		},
+	}
+}
+
 type TFStreamInstanceModel struct {
 	ID                types.String `tfsdk:"id"`
 	InstanceName      types.String `tfsdk:"instance_name"`
 	ProjectID         types.String `tfsdk:"project_id"`
 	DataProcessRegion types.Object `tfsdk:"data_process_region"`
+	FailoverRegions   types.List   `tfsdk:"failover_regions"`
 	StreamConfig      types.Object `tfsdk:"stream_config"`
 	Hostnames         types.List   `tfsdk:"hostnames"`
 }
@@ -84,6 +98,11 @@ type TFInstanceStreamConfigSpecModel struct {
 }
 
 var ProcessRegionObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"cloud_provider": types.StringType,
+	"region":         types.StringType,
+}}
+
+var FailoverRegionObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"cloud_provider": types.StringType,
 	"region":         types.StringType,
 }}

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -30,6 +30,10 @@ func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) 
 		Pipeline: &pipeline,
 	}
 
+	if !plan.FailoverEnabled.IsNull() && !plan.FailoverEnabled.IsUnknown() {
+		streamProcessor.FailoverEnabled = plan.FailoverEnabled.ValueBoolPointer()
+	}
+
 	if !plan.Options.IsNull() && !plan.Options.IsUnknown() {
 		optionsModel := &TFOptionsModel{}
 		if diags := plan.Options.As(ctx, optionsModel, basetypes.ObjectAsOptions{}); diags.HasError() {
@@ -67,6 +71,10 @@ func NewStreamProcessorUpdateReq(ctx context.Context, plan *TFStreamProcessorRSM
 			Name:     plan.ProcessorName.ValueStringPointer(),
 			Pipeline: &pipeline,
 		},
+	}
+
+	if !plan.FailoverEnabled.IsNull() && !plan.FailoverEnabled.IsUnknown() {
+		streamProcessorAPIParams.StreamsModifyStreamProcessor.FailoverEnabled = plan.FailoverEnabled.ValueBoolPointer()
 	}
 
 	if !plan.Options.IsNull() && !plan.Options.IsUnknown() {
@@ -107,14 +115,15 @@ func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName, w
 		return nil, diags
 	}
 	tfModel := &TFStreamProcessorRSModel{
-		Options:       *optionsTF,
-		Pipeline:      pipelineTF,
-		ProcessorID:   types.StringPointerValue(&apiResp.Id),
-		ProcessorName: types.StringPointerValue(&apiResp.Name),
-		ProjectID:     types.StringPointerValue(&projectID),
-		State:         types.StringPointerValue(&apiResp.State),
-		Stats:         statsTF,
-		Tier:          types.StringPointerValue(apiResp.Tier),
+		Options:         *optionsTF,
+		Pipeline:        pipelineTF,
+		ProcessorID:     types.StringPointerValue(&apiResp.Id),
+		ProcessorName:   types.StringPointerValue(&apiResp.Name),
+		ProjectID:       types.StringPointerValue(&projectID),
+		State:           types.StringPointerValue(&apiResp.State),
+		Stats:           statsTF,
+		Tier:            types.StringPointerValue(apiResp.Tier),
+		FailoverEnabled: types.BoolPointerValue(apiResp.FailoverEnabled),
 	}
 
 	if workspaceName != "" {
@@ -152,14 +161,15 @@ func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName, w
 		return nil, diags
 	}
 	tfModel := &TFStreamProcessorDSModel{
-		ID:            types.StringPointerValue(&apiResp.Id),
-		Options:       *optionsTF,
-		Pipeline:      types.StringValue(pipelineTF.ValueString()),
-		ProcessorName: types.StringPointerValue(&apiResp.Name),
-		ProjectID:     types.StringPointerValue(&projectID),
-		State:         types.StringPointerValue(&apiResp.State),
-		Stats:         statsTF,
-		Tier:          types.StringPointerValue(apiResp.Tier),
+		ID:              types.StringPointerValue(&apiResp.Id),
+		Options:         *optionsTF,
+		Pipeline:        types.StringValue(pipelineTF.ValueString()),
+		ProcessorName:   types.StringPointerValue(&apiResp.Name),
+		ProjectID:       types.StringPointerValue(&projectID),
+		State:           types.StringPointerValue(&apiResp.State),
+		Stats:           statsTF,
+		Tier:            types.StringPointerValue(apiResp.Tier),
+		FailoverEnabled: types.BoolPointerValue(apiResp.FailoverEnabled),
 	}
 
 	if workspaceName != "" {

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -139,6 +139,7 @@ func optionsToTFModel(t *testing.T, options *admin.StreamsOptions) types.Object 
 }
 
 func TestDSSDKToTFModel(t *testing.T) {
+	failoverEnabled := true
 	testCases := map[string]struct {
 		sdkModel        *admin.StreamsProcessorWithStats
 		expectedTFModel *streamprocessor.TFStreamProcessorDSModel
@@ -156,6 +157,18 @@ func TestDSSDKToTFModel(t *testing.T) {
 		"withOptions": {
 			sdkModel:        streamProcessorWithStats(t, &streamOptionsExample),
 			expectedTFModel: streamProcessorDSTFModel(t, stateStarted, statsExample, optionsToTFModel(t, &streamOptionsExample)),
+		},
+		"withFailoverEnabled": {
+			sdkModel: func() *admin.StreamsProcessorWithStats {
+				p := admin.NewStreamsProcessorWithStats(processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, stateCreated)
+				p.FailoverEnabled = &failoverEnabled
+				return p
+			}(),
+			expectedTFModel: func() *streamprocessor.TFStreamProcessorDSModel {
+				m := streamProcessorDSTFModel(t, stateCreated, "", optionsToTFModel(t, nil))
+				m.FailoverEnabled = types.BoolValue(true)
+				return m
+			}(),
 		},
 	}
 
@@ -222,6 +235,7 @@ func TestDSSDKToTFModelInstanceName(t *testing.T) {
 }
 
 func TestSDKToTFModel(t *testing.T) {
+	failoverEnabled := true
 	testCases := map[string]struct {
 		sdkModel        *admin.StreamsProcessorWithStats
 		expectedTFModel *streamprocessor.TFStreamProcessorRSModel
@@ -265,6 +279,24 @@ func TestSDKToTFModel(t *testing.T) {
 				ProjectID:     types.StringValue(projectID),
 				State:         types.StringValue("STARTED"),
 				Stats:         types.StringNull(),
+			},
+		},
+		"withFailoverEnabled": {
+			sdkModel: func() *admin.StreamsProcessorWithStats {
+				p := admin.NewStreamsProcessorWithStats(processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, "CREATED")
+				p.FailoverEnabled = &failoverEnabled
+				return p
+			}(),
+			expectedTFModel: &streamprocessor.TFStreamProcessorRSModel{
+				InstanceName:    types.StringValue(workspaceName),
+				Options:         types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes),
+				ProcessorID:     types.StringValue(processorID),
+				Pipeline:        jsontypes.NewNormalizedValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				ProcessorName:   types.StringValue(processorName),
+				ProjectID:       types.StringValue(projectID),
+				State:           types.StringValue("CREATED"),
+				Stats:           types.StringNull(),
+				FailoverEnabled: types.BoolValue(true),
 			},
 		},
 	}
@@ -383,8 +415,10 @@ func TestNewStreamProcessorUpdateReq(t *testing.T) {
 	validPipeline := jsontypes.NewNormalizedValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]")
 
 	testCases := map[string]struct {
-		model          *streamprocessor.TFStreamProcessorRSModel
-		expectedResult string
+		model               *streamprocessor.TFStreamProcessorRSModel
+		expectedTenantName  string
+		expectedFailoverSet bool
+		expectedFailover    bool
 	}{
 		"workspace_name provided": {
 			model: &streamprocessor.TFStreamProcessorRSModel{
@@ -394,7 +428,7 @@ func TestNewStreamProcessorUpdateReq(t *testing.T) {
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 			},
-			expectedResult: workspaceName,
+			expectedTenantName: workspaceName,
 		},
 		"instance_name provided": {
 			model: &streamprocessor.TFStreamProcessorRSModel{
@@ -404,7 +438,7 @@ func TestNewStreamProcessorUpdateReq(t *testing.T) {
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 			},
-			expectedResult: instanceName,
+			expectedTenantName: instanceName,
 		},
 		"workspace_name and instance_name provided": {
 			model: &streamprocessor.TFStreamProcessorRSModel{
@@ -414,7 +448,7 @@ func TestNewStreamProcessorUpdateReq(t *testing.T) {
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 			},
-			expectedResult: workspaceName,
+			expectedTenantName: workspaceName,
 		},
 		"neither provided": {
 			model: &streamprocessor.TFStreamProcessorRSModel{
@@ -424,19 +458,62 @@ func TestNewStreamProcessorUpdateReq(t *testing.T) {
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 			},
-			expectedResult: "",
+			expectedTenantName: "",
+		},
+		"failover_enabled true": {
+			model: &streamprocessor.TFStreamProcessorRSModel{
+				WorkspaceName:   types.StringValue(workspaceName),
+				InstanceName:    types.StringNull(),
+				Pipeline:        validPipeline,
+				ProcessorName:   types.StringValue(processorName),
+				ProjectID:       types.StringValue(projectID),
+				FailoverEnabled: types.BoolValue(true),
+			},
+			expectedTenantName:  workspaceName,
+			expectedFailoverSet: true,
+			expectedFailover:    true,
+		},
+		"failover_enabled false": {
+			model: &streamprocessor.TFStreamProcessorRSModel{
+				WorkspaceName:   types.StringValue(workspaceName),
+				InstanceName:    types.StringNull(),
+				Pipeline:        validPipeline,
+				ProcessorName:   types.StringValue(processorName),
+				ProjectID:       types.StringValue(projectID),
+				FailoverEnabled: types.BoolValue(false),
+			},
+			expectedTenantName:  workspaceName,
+			expectedFailoverSet: true,
+			expectedFailover:    false,
+		},
+		"failover_enabled null (not set)": {
+			model: &streamprocessor.TFStreamProcessorRSModel{
+				WorkspaceName:   types.StringValue(workspaceName),
+				InstanceName:    types.StringNull(),
+				Pipeline:        validPipeline,
+				ProcessorName:   types.StringValue(processorName),
+				ProjectID:       types.StringValue(projectID),
+				FailoverEnabled: types.BoolNull(),
+			},
+			expectedTenantName:  workspaceName,
+			expectedFailoverSet: false,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			updateReq, diags := streamprocessor.NewStreamProcessorUpdateReq(t.Context(), tc.model)
-			if tc.expectedResult == "" {
-				assert.False(t, diags.HasError())
+			assert.False(t, diags.HasError())
+			if tc.expectedTenantName == "" {
 				assert.Empty(t, updateReq.TenantName)
 			} else {
-				assert.False(t, diags.HasError())
-				assert.Equal(t, tc.expectedResult, updateReq.TenantName)
+				assert.Equal(t, tc.expectedTenantName, updateReq.TenantName)
+			}
+			if tc.expectedFailoverSet {
+				require.NotNil(t, updateReq.StreamsModifyStreamProcessor.FailoverEnabled)
+				assert.Equal(t, tc.expectedFailover, *updateReq.StreamsModifyStreamProcessor.FailoverEnabled)
+			} else {
+				assert.Nil(t, updateReq.StreamsModifyStreamProcessor.FailoverEnabled)
 			}
 		})
 	}

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -112,6 +112,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
 			},
+			"failover_enabled": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Indicates whether failover is enabled for the stream processor. When enabled, the processor will automatically failover to a secondary region if the primary region becomes unavailable.",
+			},
 		},
 	}
 }
@@ -129,6 +134,7 @@ type TFStreamProcessorRSModel struct {
 	Tier                  types.String         `tfsdk:"tier"`
 	Timeouts              timeouts.Value       `tfsdk:"timeouts"`
 	DeleteOnCreateTimeout types.Bool           `tfsdk:"delete_on_create_timeout"`
+	FailoverEnabled       types.Bool           `tfsdk:"failover_enabled"`
 }
 
 type TFOptionsModel struct {
@@ -153,16 +159,17 @@ var DlqObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 }
 
 type TFStreamProcessorDSModel struct {
-	ID            types.String `tfsdk:"id"`
-	InstanceName  types.String `tfsdk:"instance_name"`
-	WorkspaceName types.String `tfsdk:"workspace_name"`
-	Options       types.Object `tfsdk:"options"`
-	Pipeline      types.String `tfsdk:"pipeline"`
-	ProcessorName types.String `tfsdk:"processor_name"`
-	ProjectID     types.String `tfsdk:"project_id"`
-	State         types.String `tfsdk:"state"`
-	Stats         types.String `tfsdk:"stats"`
-	Tier          types.String `tfsdk:"tier"`
+	ID              types.String `tfsdk:"id"`
+	InstanceName    types.String `tfsdk:"instance_name"`
+	WorkspaceName   types.String `tfsdk:"workspace_name"`
+	Options         types.Object `tfsdk:"options"`
+	Pipeline        types.String `tfsdk:"pipeline"`
+	ProcessorName   types.String `tfsdk:"processor_name"`
+	ProjectID       types.String `tfsdk:"project_id"`
+	State           types.String `tfsdk:"state"`
+	Stats           types.String `tfsdk:"stats"`
+	Tier            types.String `tfsdk:"tier"`
+	FailoverEnabled types.Bool   `tfsdk:"failover_enabled"`
 }
 
 type TFStreamProcessorsDSModel struct {

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -53,6 +53,37 @@ func TestAccStreamProcessor_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCase(t))
 }
 
+func TestAccStreamProcessor_withFailoverEnabled(t *testing.T) {
+	var (
+		projectID, workspaceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		randomSuffix             = acctest.RandString(5)
+		processorName            = "new-processor-failover" + randomSuffix
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithFailoverEnabled(t, projectID, workspaceName, processorName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "failover_enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "failover_enabled", "true"),
+				),
+			},
+			{
+				Config: configWithFailoverEnabled(t, projectID, workspaceName, processorName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "failover_enabled", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "failover_enabled", "false"),
+				),
+			},
+			importStep(),
+		}})
+}
+
 func TestAccStreamProcessor_withTier(t *testing.T) {
 	var (
 		projectID, workspaceName = acc.ProjectIDExecutionWithStreamInstance(t)
@@ -703,6 +734,42 @@ func config(t *testing.T, projectID, workspaceName, processorName, state, nameSu
 		}
 		
 	`, projectID, workspaceName, processorName, pipeline, stateConfig, optionsStr, dependsOnStr, timeoutConfig, deleteOnCreateTimeoutConfig) + otherConfig
+}
+
+func configWithFailoverEnabled(t *testing.T, projectID, workspaceName, processorName string, failoverEnabled bool) string {
+	t.Helper()
+
+	return fmt.Sprintf(`
+	data "mongodbatlas_stream_connection" "sample_stream_solar" {
+		project_id      = %[1]q
+		workspace_name  = %[2]q
+		connection_name = "sample_stream_solar"
+	}
+
+	resource "mongodbatlas_stream_processor" "processor" {
+		project_id       = %[1]q
+		workspace_name   = %[2]q
+		processor_name   = %[3]q
+		pipeline = jsonencode([
+			{ "$source" = { "connectionName" = data.mongodbatlas_stream_connection.sample_stream_solar.connection_name } },
+			{ "$emit" = { "connectionName" = "__testLog" } }
+		])
+		state            = "STARTED"
+		failover_enabled = %[4]t
+	}
+
+	data "mongodbatlas_stream_processor" "test" {
+		project_id     = mongodbatlas_stream_processor.processor.project_id
+		workspace_name = mongodbatlas_stream_processor.processor.workspace_name
+		processor_name = mongodbatlas_stream_processor.processor.processor_name
+	}
+
+	data "mongodbatlas_stream_processors" "test" {
+		project_id     = %[1]q
+		workspace_name = %[2]q
+		depends_on     = [mongodbatlas_stream_processor.processor]
+	}
+	`, projectID, workspaceName, processorName, failoverEnabled)
 }
 
 func configWithTier(t *testing.T, projectID, workspaceName, processorName, tier string) string {

--- a/internal/service/streamworkspace/export_test.go
+++ b/internal/service/streamworkspace/export_test.go
@@ -1,0 +1,5 @@
+package streamworkspace
+
+var NewStreamWorkspaceUpdateReq = newStreamWorkspaceUpdateReq
+
+type ExportedFailoverRegionsWriteOnce = failoverRegionsWriteOnce

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -25,6 +25,20 @@ func newStreamWorkspaceCreateReq(ctx context.Context, plan *TFModel) (*admin.Str
 			Region:        dataProcessRegion.Region.ValueString(),
 		},
 	}
+	if !plan.FailoverRegions.IsNull() && !plan.FailoverRegions.IsUnknown() {
+		var failoverRegions []TFWorkspaceProcessRegionSpecModel
+		if diags := plan.FailoverRegions.ElementsAs(ctx, &failoverRegions, false); diags.HasError() {
+			return nil, diags
+		}
+		failoverDataRegions := make([]admin.StreamsDataProcessRegion, 0, len(failoverRegions))
+		for _, r := range failoverRegions {
+			failoverDataRegions = append(failoverDataRegions, admin.StreamsDataProcessRegion{
+				CloudProvider: r.CloudProvider.ValueString(),
+				Region:        r.Region.ValueString(),
+			})
+		}
+		streamTenant.FailoverRegions = &failoverDataRegions
+	}
 	if !plan.StreamConfig.IsNull() && !plan.StreamConfig.IsUnknown() {
 		streamConfig := new(TFWorkspaceStreamConfigModel)
 		if diags := plan.StreamConfig.As(ctx, streamConfig, basetypes.ObjectAsOptions{}); diags.HasError() {
@@ -34,7 +48,6 @@ func newStreamWorkspaceCreateReq(ctx context.Context, plan *TFModel) (*admin.Str
 		if streamConfig.MaxTierSize.ValueString() != "" {
 			maxTierSize = streamConfig.MaxTierSize.ValueStringPointer()
 		}
-
 		var tier *string
 		if streamConfig.Tier.ValueString() != "" {
 			tier = streamConfig.Tier.ValueStringPointer()
@@ -53,10 +66,25 @@ func newStreamWorkspaceUpdateReq(ctx context.Context, plan *TFModel) (*admin.Str
 	if diags := plan.DataProcessRegion.As(ctx, dataProcessRegion, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return nil, diags
 	}
-	return &admin.StreamsTenantUpdateRequest{
+	updateReq := &admin.StreamsTenantUpdateRequest{
 		CloudProvider: dataProcessRegion.CloudProvider.ValueStringPointer(),
 		Region:        dataProcessRegion.Region.ValueStringPointer(),
-	}, nil
+	}
+	if !plan.FailoverRegions.IsNull() && !plan.FailoverRegions.IsUnknown() {
+		var failoverRegions []TFWorkspaceProcessRegionSpecModel
+		if diags := plan.FailoverRegions.ElementsAs(ctx, &failoverRegions, false); diags.HasError() {
+			return nil, diags
+		}
+		failoverDataRegions := make([]admin.StreamsDataProcessRegion, 0, len(failoverRegions))
+		for _, r := range failoverRegions {
+			failoverDataRegions = append(failoverDataRegions, admin.StreamsDataProcessRegion{
+				CloudProvider: r.CloudProvider.ValueString(),
+				Region:        r.Region.ValueString(),
+			})
+		}
+		updateReq.FailoverRegions = &failoverDataRegions
+	}
+	return updateReq, nil
 }
 
 // FromInstanceModel populates this workspace model from a TFStreamInstanceModel and maps instance_name to workspace_name.
@@ -66,6 +94,7 @@ func (m *TFModel) FromInstanceModel(instanceModel *streaminstance.TFStreamInstan
 	m.WorkspaceName = instanceModel.InstanceName
 	m.ProjectID = instanceModel.ProjectID
 	m.DataProcessRegion = instanceModel.DataProcessRegion
+	m.FailoverRegions = instanceModel.FailoverRegions
 	if instanceModel.StreamConfig.IsNull() {
 		m.StreamConfig = types.ObjectNull(map[string]attr.Type{
 			"max_tier_size": types.StringType,

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -61,15 +61,9 @@ func newStreamWorkspaceCreateReq(ctx context.Context, plan *TFModel) (*admin.Str
 }
 
 // newStreamWorkspaceUpdateReq creates an API request for updating a stream workspace.
+// dataProcessRegion and failoverRegions are mutually exclusive in the PATCH body.
 func newStreamWorkspaceUpdateReq(ctx context.Context, plan *TFModel) (*admin.StreamsTenantUpdateRequest, diag.Diagnostics) {
-	dataProcessRegion := &TFWorkspaceProcessRegionSpecModel{}
-	if diags := plan.DataProcessRegion.As(ctx, dataProcessRegion, basetypes.ObjectAsOptions{}); diags.HasError() {
-		return nil, diags
-	}
-	updateReq := &admin.StreamsTenantUpdateRequest{
-		CloudProvider: dataProcessRegion.CloudProvider.ValueStringPointer(),
-		Region:        dataProcessRegion.Region.ValueStringPointer(),
-	}
+	updateReq := &admin.StreamsTenantUpdateRequest{}
 	if !plan.FailoverRegions.IsNull() && !plan.FailoverRegions.IsUnknown() {
 		var failoverRegions []TFWorkspaceProcessRegionSpecModel
 		if diags := plan.FailoverRegions.ElementsAs(ctx, &failoverRegions, false); diags.HasError() {
@@ -83,6 +77,13 @@ func newStreamWorkspaceUpdateReq(ctx context.Context, plan *TFModel) (*admin.Str
 			})
 		}
 		updateReq.FailoverRegions = &failoverDataRegions
+	} else {
+		dataProcessRegion := &TFWorkspaceProcessRegionSpecModel{}
+		if diags := plan.DataProcessRegion.As(ctx, dataProcessRegion, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return nil, diags
+		}
+		updateReq.CloudProvider = dataProcessRegion.CloudProvider.ValueStringPointer()
+		updateReq.Region = dataProcessRegion.Region.ValueStringPointer()
 	}
 	return updateReq, nil
 }

--- a/internal/service/streamworkspace/model_test.go
+++ b/internal/service/streamworkspace/model_test.go
@@ -1,0 +1,78 @@
+package streamworkspace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamworkspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStreamWorkspaceUpdateReq(t *testing.T) {
+	regionAttrTypes := map[string]attr.Type{
+		"cloud_provider": types.StringType,
+		"region":         types.StringType,
+	}
+	regionObjType := types.ObjectType{AttrTypes: regionAttrTypes}
+
+	dataProcessRegionObj, _ := types.ObjectValue(regionAttrTypes, map[string]attr.Value{
+		"cloud_provider": types.StringValue("AWS"),
+		"region":         types.StringValue("VIRGINIA_USA"),
+	})
+	failoverRegionObj, _ := types.ObjectValue(regionAttrTypes, map[string]attr.Value{
+		"cloud_provider": types.StringValue("AWS"),
+		"region":         types.StringValue("DUBLIN_IRL"),
+	})
+	failoverList, _ := types.ListValue(regionObjType, []attr.Value{failoverRegionObj})
+
+	testCases := map[string]struct {
+		plan                      streamworkspace.TFModel
+		expectCloudProvider       string
+		expectRegion              string
+		expectFailoverRegionCount int
+	}{
+		"no_failover_sends_data_process_region": {
+			plan: streamworkspace.TFModel{
+				DataProcessRegion: dataProcessRegionObj,
+				FailoverRegions:   types.ListNull(regionObjType),
+			},
+			expectCloudProvider:       "AWS",
+			expectRegion:              "VIRGINIA_USA",
+			expectFailoverRegionCount: 0,
+		},
+		"with_failover_sends_only_failover_regions": {
+			plan: streamworkspace.TFModel{
+				DataProcessRegion: dataProcessRegionObj,
+				FailoverRegions:   failoverList,
+			},
+			expectCloudProvider:       "",
+			expectRegion:              "",
+			expectFailoverRegionCount: 1,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			req, diags := streamworkspace.NewStreamWorkspaceUpdateReq(context.Background(), &tc.plan)
+			require.False(t, diags.HasError())
+			require.NotNil(t, req)
+
+			if tc.expectFailoverRegionCount > 0 {
+				require.NotNil(t, req.FailoverRegions)
+				assert.Len(t, *req.FailoverRegions, tc.expectFailoverRegionCount)
+				assert.Equal(t, "DUBLIN_IRL", (*req.FailoverRegions)[0].Region)
+				assert.Nil(t, req.CloudProvider)
+				assert.Nil(t, req.Region)
+			} else {
+				assert.Nil(t, req.FailoverRegions)
+				require.NotNil(t, req.CloudProvider)
+				require.NotNil(t, req.Region)
+				assert.Equal(t, tc.expectCloudProvider, *req.CloudProvider)
+				assert.Equal(t, tc.expectRegion, *req.Region)
+			}
+		})
+	}
+}

--- a/internal/service/streamworkspace/move_state.go
+++ b/internal/service/streamworkspace/move_state.go
@@ -36,6 +36,14 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 				"region":         tftypes.String,
 			},
 		},
+		"failover_regions": tftypes.List{
+			ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"cloud_provider": tftypes.String,
+					"region":         tftypes.String,
+				},
+			},
+		},
 		"stream_config": tftypes.Object{
 			AttributeTypes: map[string]tftypes.Type{
 				"tier": tftypes.String,
@@ -127,6 +135,38 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 		})
 	}
 
+	// Extract and preserve failover_regions if present.
+	if failoverRegionsVal, exists := stateObj["failover_regions"]; exists && !failoverRegionsVal.IsNull() {
+		var regionsList []tftypes.Value
+		if err := failoverRegionsVal.As(&regionsList); err == nil {
+			tfRegions := make([]attr.Value, 0, len(regionsList))
+			for _, regionVal := range regionsList {
+				var regionObj map[string]tftypes.Value
+				if err := regionVal.As(&regionObj); err == nil {
+					cloudProvider := schemafunc.GetAttrFromStateObj[string](regionObj, "cloud_provider")
+					region := schemafunc.GetAttrFromStateObj[string](regionObj, "region")
+					objValue, diags := types.ObjectValue(map[string]attr.Type{
+						"cloud_provider": types.StringType,
+						"region":         types.StringType,
+					}, map[string]attr.Value{
+						"cloud_provider": types.StringPointerValue(cloudProvider),
+						"region":         types.StringPointerValue(region),
+					})
+					if !diags.HasError() {
+						tfRegions = append(tfRegions, objValue)
+					}
+				}
+			}
+			listValue, diags := types.ListValue(streaminstance.FailoverRegionObjectType, tfRegions)
+			if !diags.HasError() {
+				model.FailoverRegions = listValue
+			}
+		}
+	}
+	if model.FailoverRegions.IsNull() {
+		model.FailoverRegions = types.ListNull(streaminstance.FailoverRegionObjectType)
+	}
+
 	// Extract and preserve hostnames if present.
 	if hostnamesVal, exists := stateObj["hostnames"]; exists && !hostnamesVal.IsNull() {
 		var hostnamesList []tftypes.Value
@@ -147,8 +187,6 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 	if model.Hostnames.IsNull() {
 		model.Hostnames = types.ListNull(types.StringType)
 	}
-
-	model.FailoverRegions = types.ListNull(streaminstance.FailoverRegionObjectType)
 
 	resp.Diagnostics.Append(resp.TargetState.Set(ctx, model)...)
 }

--- a/internal/service/streamworkspace/move_state.go
+++ b/internal/service/streamworkspace/move_state.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streaminstance"
 )
 
 // MoveState is used with moved block to upgrade from stream_instance to stream_workspace.
@@ -146,6 +147,8 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 	if model.Hostnames.IsNull() {
 		model.Hostnames = types.ListNull(types.StringType)
 	}
+
+	model.FailoverRegions = types.ListNull(streaminstance.FailoverRegionObjectType)
 
 	resp.Diagnostics.Append(resp.TargetState.Set(ctx, model)...)
 }

--- a/internal/service/streamworkspace/plan_modifier.go
+++ b/internal/service/streamworkspace/plan_modifier.go
@@ -1,0 +1,33 @@
+package streamworkspace
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// failoverRegionsWriteOnce requires replacement when failover_regions is already configured
+// and being changed. The backend treats failover_regions as write-once: it can be set via PATCH
+// exactly once, but cannot be modified or removed after that.
+type failoverRegionsWriteOnce struct{}
+
+func (m failoverRegionsWriteOnce) Description(_ context.Context) string {
+	return "Requires replacement when failover_regions is already configured and being changed."
+}
+
+func (m failoverRegionsWriteOnce) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m failoverRegionsWriteOnce) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+	if len(req.StateValue.Elements()) == 0 {
+		return
+	}
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+	resp.RequiresReplace = true
+}

--- a/internal/service/streamworkspace/plan_modifier_test.go
+++ b/internal/service/streamworkspace/plan_modifier_test.go
@@ -1,0 +1,71 @@
+package streamworkspace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamworkspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFailoverRegionsWriteOnce(t *testing.T) {
+	regionObjType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"cloud_provider": types.StringType,
+		"region":         types.StringType,
+	}}
+
+	regionObj, _ := types.ObjectValue(regionObjType.AttrTypes, map[string]attr.Value{
+		"cloud_provider": types.StringValue("AWS"),
+		"region":         types.StringValue("VIRGINIA_USA"),
+	})
+	listWithRegion, _ := types.ListValue(regionObjType, []attr.Value{regionObj})
+	emptyList, _ := types.ListValue(regionObjType, []attr.Value{})
+
+	testCases := map[string]struct {
+		stateValue            types.List
+		planValue             types.List
+		expectRequiresReplace bool
+	}{
+		"null_state_allows_first_time_set": {
+			stateValue:            types.ListNull(regionObjType),
+			planValue:             listWithRegion,
+			expectRequiresReplace: false,
+		},
+		"empty_state_allows_first_time_set": {
+			stateValue:            emptyList,
+			planValue:             listWithRegion,
+			expectRequiresReplace: false,
+		},
+		"no_change_no_replace": {
+			stateValue:            listWithRegion,
+			planValue:             listWithRegion,
+			expectRequiresReplace: false,
+		},
+		"configured_regions_removed_requires_replace": {
+			stateValue:            listWithRegion,
+			planValue:             types.ListNull(regionObjType),
+			expectRequiresReplace: true,
+		},
+		"configured_regions_changed_requires_replace": {
+			stateValue:            listWithRegion,
+			planValue:             emptyList,
+			expectRequiresReplace: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			modifier := streamworkspace.ExportedFailoverRegionsWriteOnce{}
+			req := planmodifier.ListRequest{
+				StateValue: tc.stateValue,
+				PlanValue:  tc.planValue,
+			}
+			resp := &planmodifier.ListResponse{PlanValue: tc.planValue}
+			modifier.PlanModifyList(context.Background(), req, resp)
+			assert.Equal(t, tc.expectRequiresReplace, resp.RequiresReplace)
+		})
+	}
+}

--- a/internal/service/streamworkspace/resource.go
+++ b/internal/service/streamworkspace/resource.go
@@ -102,7 +102,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !plan.DataProcessRegion.Equal(state.DataProcessRegion) && !plan.FailoverRegions.Equal(state.FailoverRegions) {
+	if !plan.DataProcessRegion.Equal(state.DataProcessRegion) && !plan.FailoverRegions.IsNull() && !plan.FailoverRegions.IsUnknown() && len(plan.FailoverRegions.Elements()) > 0 {
 		resp.Diagnostics.AddError("Invalid stream workspace update",
 			"data_process_region and failover_regions cannot be changed in the same apply. Apply each change separately.")
 		return

--- a/internal/service/streamworkspace/resource.go
+++ b/internal/service/streamworkspace/resource.go
@@ -96,9 +96,15 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 }
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan TFModel
+	var plan, state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !plan.DataProcessRegion.Equal(state.DataProcessRegion) && !plan.FailoverRegions.Equal(state.FailoverRegions) {
+		resp.Diagnostics.AddError("Invalid stream workspace update",
+			"data_process_region and failover_regions cannot be changed in the same apply. Apply each change separately.")
 		return
 	}
 	connV2 := r.Client.AtlasV2

--- a/internal/service/streamworkspace/resource_schema.go
+++ b/internal/service/streamworkspace/resource_schema.go
@@ -33,6 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"failover_regions": schema.ListNestedAttribute{
 				Optional: true,
+				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: regionAttributes(),
 				},

--- a/internal/service/streamworkspace/resource_schema.go
+++ b/internal/service/streamworkspace/resource_schema.go
@@ -28,14 +28,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"data_process_region": schema.SingleNestedAttribute{
-				Required: true,
-				Attributes: map[string]schema.Attribute{
-					"cloud_provider": schema.StringAttribute{
-						Required: true,
-					},
-					"region": schema.StringAttribute{
-						Required: true,
-					},
+				Required:   true,
+				Attributes: regionAttributes(),
+			},
+			"failover_regions": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: regionAttributes(),
 				},
 			},
 			"hostnames": schema.ListAttribute{
@@ -60,11 +59,23 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
+func regionAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"cloud_provider": schema.StringAttribute{
+			Required: true,
+		},
+		"region": schema.StringAttribute{
+			Required: true,
+		},
+	}
+}
+
 type TFModel struct {
 	ID                types.String `tfsdk:"id"`
 	WorkspaceName     types.String `tfsdk:"workspace_name"` // Only difference from TFStreamInstanceModel
 	ProjectID         types.String `tfsdk:"project_id"`
 	DataProcessRegion types.Object `tfsdk:"data_process_region"`
+	FailoverRegions   types.List   `tfsdk:"failover_regions"`
 	StreamConfig      types.Object `tfsdk:"stream_config"`
 	Hostnames         types.List   `tfsdk:"hostnames"`
 }

--- a/internal/service/streamworkspace/resource_schema.go
+++ b/internal/service/streamworkspace/resource_schema.go
@@ -34,6 +34,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"failover_regions": schema.ListNestedAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.List{
+					failoverRegionsWriteOnce{},
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: regionAttributes(),
 				},

--- a/internal/service/streamworkspace/resource_test.go
+++ b/internal/service/streamworkspace/resource_test.go
@@ -3,9 +3,11 @@ package streamworkspace_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -92,6 +94,94 @@ func TestAccStreamWorkspaceRS_withFailoverRegions(t *testing.T) {
 	})
 }
 
+func TestAccStreamWorkspaceRS_updateWithFailoverRegions(t *testing.T) {
+	var (
+		resourceName  = "mongodbatlas_stream_workspace.test"
+		projectID     = acc.ProjectIDExecution(t)
+		workspaceName = acc.RandomName()
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyStreamInstance,
+		Steps: []resource.TestStep{
+			// Step 1: create without failover_regions
+			{
+				Config: streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkStreamsWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "failover_regions.#", "0"),
+				),
+			},
+			// Step 2: add failover_regions via update (null → value, allowed)
+			{
+				Config: streamsWorkspaceWithFailoverRegionsConfig(projectID, workspaceName, region, cloudProvider, failoverRegion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkStreamsWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "failover_regions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "failover_regions.0.region", failoverRegion),
+					resource.TestCheckResourceAttr(resourceName, "failover_regions.0.cloud_provider", cloudProvider),
+				),
+			},
+			// Step 3: no-op plan — failover_regions unchanged, expect no diff
+			{
+				Config:   streamsWorkspaceWithFailoverRegionsConfig(projectID, workspaceName, region, cloudProvider, failoverRegion),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccStreamWorkspaceRS_failoverWriteOnceRequiresReplace(t *testing.T) {
+	var (
+		resourceName  = "mongodbatlas_stream_workspace.test"
+		projectID     = acc.ProjectIDExecution(t)
+		workspaceName = acc.RandomName()
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyStreamInstance,
+		Steps: []resource.TestStep{
+			// Step 1: create with DUBLIN_IRL failover
+			{
+				Config: streamsWorkspaceWithFailoverRegionsConfig(projectID, workspaceName, region, cloudProvider, "DUBLIN_IRL"),
+				Check:  checkStreamsWorkspaceExists(resourceName),
+			},
+			// Step 2: change failover region — must require replace, not in-place update
+			{
+				Config: streamsWorkspaceWithFailoverRegionsConfig(projectID, workspaceName, region, cloudProvider, "OREGON_USA"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccStreamWorkspaceRS_simultaneousDataProcessRegionAndFailoverChange(t *testing.T) {
+	var (
+		projectID     = acc.ProjectIDExecution(t)
+		workspaceName = acc.RandomName()
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyStreamInstance,
+		Steps: []resource.TestStep{
+			{
+				Config: streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider),
+			},
+			{
+				Config:      streamsWorkspaceWithChangedRegionAndFailover(projectID, workspaceName),
+				ExpectError: regexp.MustCompile(`data_process_region and failover_regions cannot be changed in the same apply`),
+			},
+		},
+	})
+}
+
 func checkStreamsWorkspaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -162,6 +252,28 @@ func streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cl
 			}
 		}
 	`, projectID, workspaceName, region, cloudProvider, tier, maxTierSize)
+}
+
+func streamsWorkspaceWithChangedRegionAndFailover(projectID, workspaceName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_stream_workspace" "test" {
+			project_id = %[1]q
+			workspace_name = %[2]q
+			data_process_region = {
+				region = "OREGON_USA"
+				cloud_provider = "AWS"
+			}
+			failover_regions = [
+				{
+					cloud_provider = "AWS"
+					region = %[3]q
+				}
+			]
+			stream_config = {
+				tier = "SP10"
+			}
+		}
+	`, projectID, workspaceName, failoverRegion)
 }
 
 func streamsWorkspaceResourceWithDataSourcesConfig(projectID, workspaceName, region, cloudProvider string) string {

--- a/internal/service/streamworkspace/resource_test.go
+++ b/internal/service/streamworkspace/resource_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	region        = "VIRGINIA_USA"
-	cloudProvider = "AWS"
+	region         = "VIRGINIA_USA"
+	cloudProvider  = "AWS"
+	failoverRegion = "DUBLIN_IRL"
 )
 
 func TestAccStreamWorkspaceRS_basic(t *testing.T) {
@@ -53,6 +54,44 @@ func TestAccStreamWorkspaceRS_basic(t *testing.T) {
 	})
 }
 
+func TestAccStreamWorkspaceRS_withFailoverRegions(t *testing.T) {
+	var (
+		resourceName  = "mongodbatlas_stream_workspace.test"
+		projectID     = acc.ProjectIDExecution(t)
+		workspaceName = acc.RandomName()
+	)
+	attrsMap := map[string]string{
+		"workspace_name":                     workspaceName,
+		"data_process_region.region":         region,
+		"data_process_region.cloud_provider": cloudProvider,
+		"failover_regions.#":                 "1",
+		"failover_regions.0.cloud_provider":  cloudProvider,
+		"failover_regions.0.region":          failoverRegion,
+		"stream_config.tier":                 "SP10",
+	}
+	attrsSet := []string{"project_id", "hostnames.#"}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyStreamInstance,
+		Steps: []resource.TestStep{
+			{
+				Config: streamsWorkspaceWithFailoverRegionsConfig(projectID, workspaceName, region, cloudProvider, failoverRegion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkStreamsWorkspaceExists(resourceName),
+					acc.CheckRSAndDS(resourceName, nil, nil, attrsSet, attrsMap),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: checkStreamsWorkspaceImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func checkStreamsWorkspaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -80,6 +119,28 @@ func checkStreamsWorkspaceImportStateIDFunc(resourceName string) resource.Import
 		}
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["workspace_name"]), nil
 	}
+}
+
+func streamsWorkspaceWithFailoverRegionsConfig(projectID, workspaceName, region, cloudProvider, failoverRegion string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_stream_workspace" "test" {
+			project_id = %[1]q
+			workspace_name = %[2]q
+			data_process_region = {
+				region = %[3]q
+				cloud_provider = %[4]q
+			}
+			failover_regions = [
+				{
+					cloud_provider = %[4]q
+					region = %[5]q
+				}
+			]
+			stream_config = {
+				tier = "SP10"
+			}
+		}
+	`, projectID, workspaceName, region, cloudProvider, failoverRegion)
 }
 
 func streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider string) string {


### PR DESCRIPTION
https://jira.mongodb.org/browse/CLOUDP-405521

Here's a summary of what was done:

## mongodbatlas_stream_workspace: add failover_regions

- New `failover_regions` attribute. Each element has `cloud_provider` and `region` (both required).
- `failover_regions` is **write-once**: it can be set via PATCH exactly once (null → value). Once configured it cannot be modified — any change triggers workspace replacement (`RequiresReplace`).
- `data_process_region` and `failover_regions` are **mutually exclusive** in the backend PATCH body. The provider enforces this: if both fields change in the same `terraform apply`, an error is returned before any API call is made.
- The PATCH body correctly sends either `failoverRegions` or `cloudProvider`+`region`, never both.
- `mongodbatlas_stream_instance` gains a computed-only `failover_regions` that reads back any failover regions returned by the API.
- Docs updated with a "With Failover Regions" example, argument reference, and nested attribute table.
