### PR TITLE
chore: Unwrap libopenapi sibling-ref allOf wrapper in codegen BuildSchema

### DIFF
--- a/tools/codegen/codespec/api_spec.go
+++ b/tools/codegen/codespec/api_spec.go
@@ -24,10 +24,6 @@ func BuildSchema(proxy *base.SchemaProxy) (*APISpecSchema, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to build schema from proxy: %w", err)
 	}
-	// libopenapi >= v0.36.4 wraps a `$ref` that carries a sibling property (e.g. `description`)
-	// into a synthetic allOf rather than resolving the reference directly. Unwrap that wrapper
-	// before the normal type inference runs. See unwrapSiblingRefAllOf for the rationale and
-	// the deliberate limits of this workaround.
 	if unwrapped, ok := unwrapSiblingRefAllOf(schema); ok {
 		return unwrapped, nil
 	}
@@ -166,48 +162,32 @@ func buildSchemaFromResponse(op *high.Operation, configuredVersion *string) (*AP
 	return nil, errSchemaNotFound
 }
 
-// unwrapSiblingRefAllOf undoes the synthetic allOf wrapping that libopenapi (>= v0.36.4)
-// applies when a `$ref` carries sibling properties such as `description`. For:
-//
-//	eventTypeName:
-//	  $ref: '#/components/schemas/X'
-//	  description: Incident that triggered this alert.
-//
-// libopenapi produces a parent schema with no type/properties whose allOf contains the
-// original $ref alongside an inline schema that only carries the sibling fields. Without
-// this unwrap, the wrapper trips BuildSchema's "type cannot be inferred" check.
-//
-// This is NOT a general allOf composition handler — the flattened API spec consumed by
-// codegen is expected to resolve real allOf inheritance ahead of time. We only recognize
-// the narrow sibling-ref shape: exactly one $ref branch plus any number of inline branches
-// that contribute only sibling-style fields (currently just description). Anything outside
-// that shape returns ok=false so the caller falls back to the normal type-inference path
-// and surfaces the existing error.
+// unwrapSiblingRefAllOf undoes the 2-branch allOf wrapper libopenapi (>= v0.36.4) emits when
+// a `$ref` carries a `description` sibling. Real allOf composition is left to the flattened
+// API spec; any other wrapper shape returns ok=false so the existing "type cannot be inferred"
+// error surfaces unsupported shapes loudly.
 func unwrapSiblingRefAllOf(schema *base.Schema) (*APISpecSchema, bool) {
-	if len(schema.AllOf) == 0 {
-		return nil, false
-	}
-	if len(schema.Type) > 0 || (schema.Properties != nil && schema.Properties.Len() > 0) {
+	if len(schema.AllOf) != 2 ||
+		len(schema.Type) > 0 ||
+		(schema.Properties != nil && schema.Properties.Len() > 0) {
 		return nil, false
 	}
 
 	var refBranch *base.SchemaProxy
-	var siblingDesc string
+	var description string
 	for _, branch := range schema.AllOf {
 		if branch.GetReference() != "" {
 			if refBranch != nil {
-				return nil, false // more than one $ref branch — real allOf composition.
+				return nil, false
 			}
 			refBranch = branch
 			continue
 		}
-		inline, err := branch.BuildSchema()
-		if err != nil {
+		carrier, err := branch.BuildSchema()
+		if err != nil || !isDescriptionOnlyCarrier(carrier) {
 			return nil, false
 		}
-		if inline.Description != "" {
-			siblingDesc = inline.Description
-		}
+		description = carrier.Description
 	}
 	if refBranch == nil {
 		return nil, false
@@ -217,10 +197,24 @@ func unwrapSiblingRefAllOf(schema *base.Schema) (*APISpecSchema, bool) {
 	if err != nil {
 		return nil, false
 	}
-	if siblingDesc != "" {
-		inner.Schema.Description = siblingDesc
+	if description != "" {
+		inner.Schema.Description = description
 	}
 	return inner, true
+}
+
+// isDescriptionOnlyCarrier reports whether s is the inline branch libopenapi emits in a
+// sibling-ref wrapper: at most a description, with no structural or override fields.
+func isDescriptionOnlyCarrier(s *base.Schema) bool {
+	return len(s.Type) == 0 &&
+		(s.Properties == nil || s.Properties.Len() == 0) &&
+		len(s.Required) == 0 &&
+		len(s.AllOf) == 0 && len(s.OneOf) == 0 && len(s.AnyOf) == 0 &&
+		len(s.Enum) == 0 &&
+		s.Items == nil && s.AdditionalProperties == nil &&
+		s.Deprecated == nil && s.ReadOnly == nil && s.WriteOnly == nil && s.Nullable == nil &&
+		s.Default == nil && s.Example == nil &&
+		s.Title == ""
 }
 
 // getSchemaName extracts a human-readable schema name from the proxy reference or schema title.

--- a/tools/codegen/codespec/api_spec.go
+++ b/tools/codegen/codespec/api_spec.go
@@ -24,8 +24,15 @@ func BuildSchema(proxy *base.SchemaProxy) (*APISpecSchema, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to build schema from proxy: %w", err)
 	}
-	if unwrapped, ok := unwrapSiblingRefAllOf(schema); ok {
-		return unwrapped, nil
+	if refBranch, description, ok := matchSiblingRefAllOf(schema); ok {
+		inner, err := BuildSchema(refBranch)
+		if err != nil {
+			return nil, err
+		}
+		if description != "" {
+			inner.Schema.Description = description
+		}
+		return inner, nil
 	}
 	switch {
 	case len(schema.Type) > 0:
@@ -162,45 +169,37 @@ func buildSchemaFromResponse(op *high.Operation, configuredVersion *string) (*AP
 	return nil, errSchemaNotFound
 }
 
-// unwrapSiblingRefAllOf undoes the 2-branch allOf wrapper libopenapi (>= v0.36.4) emits when
-// a `$ref` carries a `description` sibling. Real allOf composition is left to the flattened
-// API spec; any other wrapper shape returns ok=false so the existing "type cannot be inferred"
-// error surfaces unsupported shapes loudly.
-func unwrapSiblingRefAllOf(schema *base.Schema) (*APISpecSchema, bool) {
+// matchSiblingRefAllOf detects the 2-branch allOf wrapper libopenapi (>= v0.36.4) emits when
+// a `$ref` carries a `description` sibling, returning the referenced proxy and the override
+// description. Real allOf composition is left to the flattened API spec; any other wrapper
+// shape returns ok=false so the existing "type cannot be inferred" error surfaces unsupported
+// shapes loudly. Detection only — the caller resolves the ref so any underlying BuildSchema
+// failure propagates instead of being hidden behind the wrapper's generic error.
+func matchSiblingRefAllOf(schema *base.Schema) (refBranch *base.SchemaProxy, description string, ok bool) {
 	if len(schema.AllOf) != 2 ||
 		len(schema.Type) > 0 ||
 		(schema.Properties != nil && schema.Properties.Len() > 0) {
-		return nil, false
+		return nil, "", false
 	}
 
-	var refBranch *base.SchemaProxy
-	var description string
 	for _, branch := range schema.AllOf {
 		if branch.GetReference() != "" {
 			if refBranch != nil {
-				return nil, false
+				return nil, "", false
 			}
 			refBranch = branch
 			continue
 		}
 		carrier, err := branch.BuildSchema()
 		if err != nil || !isDescriptionOnlyCarrier(carrier) {
-			return nil, false
+			return nil, "", false
 		}
 		description = carrier.Description
 	}
 	if refBranch == nil {
-		return nil, false
+		return nil, "", false
 	}
-
-	inner, err := BuildSchema(refBranch)
-	if err != nil {
-		return nil, false
-	}
-	if description != "" {
-		inner.Schema.Description = description
-	}
-	return inner, true
+	return refBranch, description, true
 }
 
 // isDescriptionOnlyCarrier reports whether s is the inline branch libopenapi emits in a

--- a/tools/codegen/codespec/api_spec.go
+++ b/tools/codegen/codespec/api_spec.go
@@ -24,7 +24,7 @@ func BuildSchema(proxy *base.SchemaProxy) (*APISpecSchema, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to build schema from proxy: %w", err)
 	}
-	if refBranch, description, ok := matchSiblingRefAllOf(schema); ok {
+	if refBranch, description := matchSiblingRefAllOf(schema); refBranch != nil {
 		inner, err := BuildSchema(refBranch)
 		if err != nil {
 			return nil, err
@@ -172,34 +172,34 @@ func buildSchemaFromResponse(op *high.Operation, configuredVersion *string) (*AP
 // matchSiblingRefAllOf detects the 2-branch allOf wrapper libopenapi (>= v0.36.4) emits when
 // a `$ref` carries a `description` sibling, returning the referenced proxy and the override
 // description. Real allOf composition is left to the flattened API spec; any other wrapper
-// shape returns ok=false so the existing "type cannot be inferred" error surfaces unsupported
-// shapes loudly. Detection only — the caller resolves the ref so any underlying BuildSchema
-// failure propagates instead of being hidden behind the wrapper's generic error.
-func matchSiblingRefAllOf(schema *base.Schema) (refBranch *base.SchemaProxy, description string, ok bool) {
+// shape returns a nil refBranch so the existing "type cannot be inferred" error surfaces
+// unsupported shapes loudly. Detection only — the caller resolves the ref so any underlying
+// BuildSchema failure propagates instead of being hidden behind the wrapper's generic error.
+func matchSiblingRefAllOf(schema *base.Schema) (refBranch *base.SchemaProxy, description string) {
 	if len(schema.AllOf) != 2 ||
 		len(schema.Type) > 0 ||
 		(schema.Properties != nil && schema.Properties.Len() > 0) {
-		return nil, "", false
+		return nil, ""
 	}
 
 	for _, branch := range schema.AllOf {
 		if branch.GetReference() != "" {
 			if refBranch != nil {
-				return nil, "", false
+				return nil, ""
 			}
 			refBranch = branch
 			continue
 		}
 		carrier, err := branch.BuildSchema()
 		if err != nil || !isDescriptionOnlyCarrier(carrier) {
-			return nil, "", false
+			return nil, ""
 		}
 		description = carrier.Description
 	}
 	if refBranch == nil {
-		return nil, "", false
+		return nil, ""
 	}
-	return refBranch, description, true
+	return refBranch, description
 }
 
 // isDescriptionOnlyCarrier reports whether s is the inline branch libopenapi emits in a

--- a/tools/codegen/codespec/api_spec.go
+++ b/tools/codegen/codespec/api_spec.go
@@ -24,6 +24,13 @@ func BuildSchema(proxy *base.SchemaProxy) (*APISpecSchema, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to build schema from proxy: %w", err)
 	}
+	// libopenapi >= v0.36.4 wraps a `$ref` that carries a sibling property (e.g. `description`)
+	// into a synthetic allOf rather than resolving the reference directly. Unwrap that wrapper
+	// before the normal type inference runs. See unwrapSiblingRefAllOf for the rationale and
+	// the deliberate limits of this workaround.
+	if unwrapped, ok := unwrapSiblingRefAllOf(schema); ok {
+		return unwrapped, nil
+	}
 	switch {
 	case len(schema.Type) > 0:
 		resp.Type = schema.Type[0]
@@ -157,6 +164,63 @@ func buildSchemaFromResponse(op *high.Operation, configuredVersion *string) (*AP
 	}
 
 	return nil, errSchemaNotFound
+}
+
+// unwrapSiblingRefAllOf undoes the synthetic allOf wrapping that libopenapi (>= v0.36.4)
+// applies when a `$ref` carries sibling properties such as `description`. For:
+//
+//	eventTypeName:
+//	  $ref: '#/components/schemas/X'
+//	  description: Incident that triggered this alert.
+//
+// libopenapi produces a parent schema with no type/properties whose allOf contains the
+// original $ref alongside an inline schema that only carries the sibling fields. Without
+// this unwrap, the wrapper trips BuildSchema's "type cannot be inferred" check.
+//
+// This is NOT a general allOf composition handler — the flattened API spec consumed by
+// codegen is expected to resolve real allOf inheritance ahead of time. We only recognize
+// the narrow sibling-ref shape: exactly one $ref branch plus any number of inline branches
+// that contribute only sibling-style fields (currently just description). Anything outside
+// that shape returns ok=false so the caller falls back to the normal type-inference path
+// and surfaces the existing error.
+func unwrapSiblingRefAllOf(schema *base.Schema) (*APISpecSchema, bool) {
+	if len(schema.AllOf) == 0 {
+		return nil, false
+	}
+	if len(schema.Type) > 0 || (schema.Properties != nil && schema.Properties.Len() > 0) {
+		return nil, false
+	}
+
+	var refBranch *base.SchemaProxy
+	var siblingDesc string
+	for _, branch := range schema.AllOf {
+		if branch.GetReference() != "" {
+			if refBranch != nil {
+				return nil, false // more than one $ref branch — real allOf composition.
+			}
+			refBranch = branch
+			continue
+		}
+		inline, err := branch.BuildSchema()
+		if err != nil {
+			return nil, false
+		}
+		if inline.Description != "" {
+			siblingDesc = inline.Description
+		}
+	}
+	if refBranch == nil {
+		return nil, false
+	}
+
+	inner, err := BuildSchema(refBranch)
+	if err != nil {
+		return nil, false
+	}
+	if siblingDesc != "" {
+		inner.Schema.Description = siblingDesc
+	}
+	return inner, true
 }
 
 // getSchemaName extracts a human-readable schema name from the proxy reference or schema title.

--- a/tools/codegen/codespec/api_spec_test.go
+++ b/tools/codegen/codespec/api_spec_test.go
@@ -20,6 +20,8 @@ components:
     Referenced:
       type: string
       description: original description
+    Other:
+      type: integer
     TestSchema:
 %s`
 
@@ -75,13 +77,31 @@ func TestBuildSchema(t *testing.T) {
 			expectedType: "array",
 		},
 		"$ref with sibling description is unwrapped to referenced schema": {
-			// libopenapi >= v0.36.4 turns `$ref` with a sibling property into a single-element
-			// allOf wrapper. BuildSchema should unwrap that wrapper and surface the referenced
+			// libopenapi >= v0.36.4 turns `$ref` with a sibling property into a 2-branch allOf
+			// wrapper. BuildSchema should unwrap that wrapper and surface the referenced
 			// schema's type while honoring the sibling description override.
 			schemaDefinition: `      $ref: '#/components/schemas/Referenced'
       description: override description`,
 			expectedType:        "string",
 			expectedDescription: "override description",
+		},
+		"allOf with two $refs is not treated as sibling-ref wrapper": {
+			// Two $ref branches is a real allOf composition (not the libopenapi sibling-ref
+			// shape) and should fall through to the existing error, not be silently unwrapped
+			// to one of the refs.
+			schemaDefinition: `      allOf:
+        - $ref: '#/components/schemas/Referenced'
+        - $ref: '#/components/schemas/Other'`,
+			errorContains: "type cannot be inferred",
+		},
+		"$ref with sibling beyond description is not unwrapped": {
+			// Only `description` siblings are recognized today. Any other sibling (e.g.
+			// `deprecated`) must cause the wrapper to fall through to the existing error so
+			// the new pattern is surfaced loudly instead of silently dropping the override.
+			schemaDefinition: `      $ref: '#/components/schemas/Referenced'
+      description: override description
+      deprecated: true`,
+			errorContains: "type cannot be inferred",
 		},
 	}
 

--- a/tools/codegen/codespec/api_spec_test.go
+++ b/tools/codegen/codespec/api_spec_test.go
@@ -17,14 +17,18 @@ info:
   version: 1.0.0
 components:
   schemas:
+    Referenced:
+      type: string
+      description: original description
     TestSchema:
 %s`
 
 func TestBuildSchema(t *testing.T) {
 	tests := map[string]struct {
-		schemaDefinition string
-		errorContains    string
-		expectedType     string
+		schemaDefinition    string
+		errorContains       string
+		expectedType        string
+		expectedDescription string
 	}{
 		"Explicit object type": {
 			schemaDefinition: `      type: object
@@ -70,6 +74,15 @@ func TestBuildSchema(t *testing.T) {
         type: string`,
 			expectedType: "array",
 		},
+		"$ref with sibling description is unwrapped to referenced schema": {
+			// libopenapi >= v0.36.4 turns `$ref` with a sibling property into a single-element
+			// allOf wrapper. BuildSchema should unwrap that wrapper and surface the referenced
+			// schema's type while honoring the sibling description override.
+			schemaDefinition: `      $ref: '#/components/schemas/Referenced'
+      description: override description`,
+			expectedType:        "string",
+			expectedDescription: "override description",
+		},
 	}
 
 	for name, tc := range tests {
@@ -86,6 +99,9 @@ func TestBuildSchema(t *testing.T) {
 				require.NoError(t, err)
 				assert.NotNil(t, result.Schema)
 				assert.Equal(t, tc.expectedType, result.Type)
+				if tc.expectedDescription != "" {
+					assert.Equal(t, tc.expectedDescription, result.Schema.Description)
+				}
 			} else {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorContains)


### PR DESCRIPTION
## Description

**Detected:** Today's weekly [`Generate auto-generated resources`](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/26088411920/job/76707424128) cron run failed on `alert_configuration_api` with:

```
invalid schema. no values for schema.Type found and type cannot be inferred (schema: unknown)
```

**Root cause:** [#4437](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4437) bumped `github.com/pb33f/libopenapi` from `v0.36.3` to `v0.36.4`. The new version wraps a `$ref` carrying a sibling property (e.g. `description`) into a synthetic `allOf` instead of resolving the reference directly. The parent schema then has no `type` and no `properties`, so [`BuildSchema`](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/tools/codegen/codespec/api_spec.go) hit its "type cannot be inferred" branch. This affects `GroupAlertsConfig.eventTypeName` (and any other `$ref`+sibling field in the flattened spec).

**Fix:** Add an `unwrapSiblingRefAllOf` helper invoked at the top of `BuildSchema`. It recognizes the narrow sibling-ref wrapper shape (no type/properties on the parent, exactly one `$ref` allOf branch, other branches contributing only sibling-style fields), recurses on the `$ref` branch, and applies the sibling `description` override. The helper is explicitly **not** a general `allOf` composition handler — the flattened API spec is expected to resolve real `allOf` inheritance ahead of codegen. Anything outside the wrapper shape falls through to the existing error path unchanged. Includes a unit test pinning the behavior.

**Follow-up consideration (separate PR/issue):** PR #4437 went green because `check-autogen-resources.yml` (a) is path-filtered to `tools/codegen/**` and `internal/serviceapi/**` so dep bumps don't trigger it, and (b) only runs `step=code-gen` — the failure is in `model-gen`. Worth expanding the path filter and running both pipeline steps in PR CI.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Verified locally by running the full internal-tier `autogen-pipeline` (model-gen + code-gen) against the live `mongodb/openapi` `main` spec — completes with no errors, including `alert_configuration_api`.