### PR TITLE
chore: Avoid IP collisions between parallel project_ip_access_list tests

### DIFF
--- a/internal/service/accesslistapikey/data_source_test.go
+++ b/internal/service/accesslistapikey/data_source_test.go
@@ -14,7 +14,7 @@ func TestAccConfigDSAccesslistAPIKey_basic(t *testing.T) {
 	dataSourceName := "data.mongodbatlas_access_list_api_key.test"
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	description := acc.RandomName()
-	ipAddress := acc.RandomIP(179, 154, 226)
+	ipAddress := acc.RandomIP()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -66,7 +66,7 @@ func TestAccConfigDSAccesslistAPIKeys_basic(t *testing.T) {
 		dataSourceName = "data.mongodbatlas_access_list_api_keys.test"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		description    = acc.RandomName()
-		ipAddress      = acc.RandomIP(179, 154, 226)
+		ipAddress      = acc.RandomIP()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/accesslistapikey/resource_migration_test.go
+++ b/internal/service/accesslistapikey/resource_migration_test.go
@@ -14,7 +14,7 @@ func TestMigProjectAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		ipAddress    = acc.RandomIP(179, 154, 226)
+		ipAddress    = acc.RandomIP()
 		description  = acc.RandomName()
 	)
 
@@ -42,7 +42,7 @@ func TestMigProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		cidrBlock    = acc.RandomIP(179, 154, 226) + "/32"
+		cidrBlock    = acc.RandomIP() + "/32"
 		description  = acc.RandomName()
 		config       = configWithCIDRBlock(orgID, description, cidrBlock)
 	)

--- a/internal/service/accesslistapikey/resource_test.go
+++ b/internal/service/accesslistapikey/resource_test.go
@@ -16,9 +16,9 @@ func TestAccProjectRSAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 	var (
 		resourceName     = "mongodbatlas_access_list_api_key.test"
 		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		ipAddress        = acc.RandomIP(179, 154, 226)
+		ipAddress        = acc.RandomIP()
 		description      = acc.RandomName()
-		updatedIPAddress = acc.RandomIP(179, 154, 228)
+		updatedIPAddress = acc.RandomIP()
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -56,9 +56,9 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock(t *testing.T) {
 	var (
 		resourceName     = "mongodbatlas_access_list_api_key.test"
 		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		cidrBlock        = acc.RandomIP(179, 154, 226) + "/32"
+		cidrBlock        = acc.RandomIP() + "/32"
 		description      = acc.RandomName()
-		updatedCIDRBlock = acc.RandomIP(179, 154, 228) + "/32"
+		updatedCIDRBlock = acc.RandomIP() + "/32"
 	)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_migration_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_migration_test.go
@@ -13,7 +13,7 @@ import (
 func TestMigProjectIPAccessList_settingIPAddress(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
-		ipAddress = acc.RandomIP(180, 154, 226)
+		ipAddress = acc.RandomIP()
 		comment   = fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
 		withDS    = false
 		config    = configWithIPAddress(projectID, ipAddress, comment, withDS)
@@ -36,7 +36,7 @@ func TestMigProjectIPAccessList_settingIPAddress(t *testing.T) {
 func TestMigProjectIPAccessList_settingCIDRBlock(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
-		cidrBlock = acc.RandomIP(180, 154, 228) + "/32"
+		cidrBlock = acc.RandomIP() + "/32"
 		comment   = fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
 		withDS    = false
 		config    = configWithCIDRBlock(projectID, cidrBlock, comment, withDS)

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_migration_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_migration_test.go
@@ -36,7 +36,7 @@ func TestMigProjectIPAccessList_settingIPAddress(t *testing.T) {
 func TestMigProjectIPAccessList_settingCIDRBlock(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
-		cidrBlock = acc.RandomIP(180, 154, 226) + "/32"
+		cidrBlock = acc.RandomIP(180, 154, 228) + "/32"
 		comment   = fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
 		withDS    = false
 		config    = configWithCIDRBlock(projectID, cidrBlock, comment, withDS)

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -164,7 +164,7 @@ func TestAccProjectIPAccessList_importIncorrectId(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
 		ipAddress = acc.RandomIP(179, 154, 234)
-		comment   = fmt.Sprintf("TestAcc for ipaddres (%s)", ipAddress)
+		comment   = fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
 		withDS    = false
 	)
 

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -56,9 +56,9 @@ func TestAccProjectIPAccessList_settingIPAddress(t *testing.T) {
 func TestAccProjectIPAccessList_settingCIDRBlock(t *testing.T) {
 	var (
 		projectID        = acc.ProjectIDExecution(t)
-		cidrBlock        = acc.RandomIP(179, 154, 226) + "/32"
+		cidrBlock        = acc.RandomIP(179, 154, 230) + "/32"
 		comment          = fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
-		updatedCIDRBlock = acc.RandomIP(179, 154, 228) + "/32"
+		updatedCIDRBlock = acc.RandomIP(179, 154, 232) + "/32"
 		updatedComment   = fmt.Sprintf("TestAcc for cidrBlock updated (%s)", updatedCIDRBlock)
 		withDS           = true
 	)
@@ -163,7 +163,7 @@ func TestAccProjectIPAccessList_settingMultiple(t *testing.T) {
 func TestAccProjectIPAccessList_importIncorrectId(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
-		ipAddress = acc.RandomIP(179, 154, 226)
+		ipAddress = acc.RandomIP(179, 154, 234)
 		comment   = fmt.Sprintf("TestAcc for ipaddres (%s)", ipAddress)
 		withDS    = false
 	)

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -23,9 +23,9 @@ const (
 func TestAccProjectIPAccessList_settingIPAddress(t *testing.T) {
 	var (
 		projectID        = acc.ProjectIDExecution(t)
-		ipAddress        = acc.RandomIP(179, 154, 226)
+		ipAddress        = acc.RandomIP()
 		comment          = fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
-		updatedIPAddress = acc.RandomIP(179, 154, 228)
+		updatedIPAddress = acc.RandomIP()
 		updatedComment   = fmt.Sprintf("TestAcc for ipAddress updated (%s)", updatedIPAddress)
 		withDS           = true
 	)
@@ -56,9 +56,9 @@ func TestAccProjectIPAccessList_settingIPAddress(t *testing.T) {
 func TestAccProjectIPAccessList_settingCIDRBlock(t *testing.T) {
 	var (
 		projectID        = acc.ProjectIDExecution(t)
-		cidrBlock        = acc.RandomIP(179, 154, 230) + "/32"
+		cidrBlock        = acc.RandomIP() + "/32"
 		comment          = fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
-		updatedCIDRBlock = acc.RandomIP(179, 154, 232) + "/32"
+		updatedCIDRBlock = acc.RandomIP() + "/32"
 		updatedComment   = fmt.Sprintf("TestAcc for cidrBlock updated (%s)", updatedCIDRBlock)
 		withDS           = true
 	)
@@ -130,11 +130,11 @@ func TestAccProjectIPAccessList_settingMultiple(t *testing.T) {
 
 		if i%2 == 0 {
 			entryName = "cidr_block"
-			entry["cidr_block"] = acc.RandomIP(byte(i), 2, 3) + "/32"
+			entry["cidr_block"] = acc.RandomIP() + "/32"
 			ipAddr = entry["cidr_block"]
 		} else {
 			entryName = "ip_address"
-			entry["ip_address"] = acc.RandomIP(byte(i), 2, 3)
+			entry["ip_address"] = acc.RandomIP()
 			ipAddr = entry["ip_address"]
 		}
 		entry["comment"] = fmt.Sprintf("TestAcc for %s (%s)", entryName, ipAddr)
@@ -163,7 +163,7 @@ func TestAccProjectIPAccessList_settingMultiple(t *testing.T) {
 func TestAccProjectIPAccessList_importIncorrectId(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
-		ipAddress = acc.RandomIP(179, 154, 234)
+		ipAddress = acc.RandomIP()
 		comment   = fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
 		withDS    = false
 	)

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -41,36 +41,12 @@ func RandomIAMUser() string {
 	return acctest.RandomWithPrefix(prefixIAMUser)
 }
 
-// ipCounter is a process-global counter used by RandomIP to allocate unique IPs.
-// Initialized to a random offset so two test runs do not replay identical sequences.
+// ipCounter provides unique IPs per process; each run gets its own project so no cross-process seed is needed.
 var ipCounter atomic.Uint32
 
-const (
-	// ipCounterMask keeps the counter inside a 24-bit address space (3 octets).
-	ipCounterMask uint32 = 0xFFFFFF
-	// ipOctetMask isolates a single octet (8 bits) from the counter.
-	ipOctetMask uint32 = 0xFF
-	// ipOctetShiftHigh / ipOctetShiftMid extract the high and middle octets
-	// from the 24-bit counter; the low octet is taken without a shift.
-	ipOctetShiftHigh uint32 = 16
-	ipOctetShiftMid  uint32 = 8
-)
-
-func init() {
-	ipCounter.Store(uint32(acctest.RandIntRange(0, int(ipCounterMask)))) //nolint:gosec // value capped at 24 bits, fits in uint32
-}
-
-// RandomIP returns a unique IP within the 179.0.0.0/8 range. Uniqueness is
-// guaranteed within a single test process for up to ~16M calls, which avoids
-// the collisions a previous shared-octets implementation produced when parallel
-// tests rolled the same last octet.
 func RandomIP() string {
-	n := ipCounter.Add(1) & ipCounterMask
-	return fmt.Sprintf("179.%d.%d.%d",
-		byte((n>>ipOctetShiftHigh)&ipOctetMask),
-		byte((n>>ipOctetShiftMid)&ipOctetMask),
-		byte(n&ipOctetMask),
-	)
+	n := ipCounter.Add(1)
+	return fmt.Sprintf("179.%d.%d.%d", byte(n>>16), byte(n>>8), byte(n)) //nolint:gosec // intentional octet extraction
 }
 
 func RandomEmail() string {

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -2,6 +2,7 @@ package acc
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
@@ -40,8 +41,36 @@ func RandomIAMUser() string {
 	return acctest.RandomWithPrefix(prefixIAMUser)
 }
 
-func RandomIP(a, b, c byte) string {
-	return fmt.Sprintf("%d.%d.%d.%d", a, b, c, acctest.RandIntRange(0, 255))
+// ipCounter is a process-global counter used by RandomIP to allocate unique IPs.
+// Initialized to a random offset so two test runs do not replay identical sequences.
+var ipCounter atomic.Uint32
+
+const (
+	// ipCounterMask keeps the counter inside a 24-bit address space (3 octets).
+	ipCounterMask uint32 = 0xFFFFFF
+	// ipOctetMask isolates a single octet (8 bits) from the counter.
+	ipOctetMask uint32 = 0xFF
+	// ipOctetShiftHigh / ipOctetShiftMid extract the high and middle octets
+	// from the 24-bit counter; the low octet is taken without a shift.
+	ipOctetShiftHigh uint32 = 16
+	ipOctetShiftMid  uint32 = 8
+)
+
+func init() {
+	ipCounter.Store(uint32(acctest.RandIntRange(0, int(ipCounterMask)))) //nolint:gosec // value capped at 24 bits, fits in uint32
+}
+
+// RandomIP returns a unique IP within the 179.0.0.0/8 range. Uniqueness is
+// guaranteed within a single test process for up to ~16M calls, which avoids
+// the collisions a previous shared-octets implementation produced when parallel
+// tests rolled the same last octet.
+func RandomIP() string {
+	n := ipCounter.Add(1) & ipCounterMask
+	return fmt.Sprintf("179.%d.%d.%d",
+		byte((n>>ipOctetShiftHigh)&ipOctetMask),
+		byte((n>>ipOctetShiftMid)&ipOctetMask),
+		byte(n&ipOctetMask),
+	)
 }
 
 func RandomEmail() string {


### PR DESCRIPTION
## Description

Fixes a flake in `internal/service/projectipaccesslist` where two parallel acceptance tests could collide on the same Atlas project IP access list entry, and removes the underlying footgun in the test utility so the same class of bug cannot reappear. Observed on PR #4455's CI run.

### Root cause

`TestAccProjectIPAccessList_settingIPAddress`, `TestAccProjectIPAccessList_settingCIDRBlock`, and `TestAccProjectIPAccessList_importIncorrectId` all run in parallel against the same shared project (`acc.ProjectIDExecution(t)`) and were sharing the same `(a, b, c)` octets when calling `acc.RandomIP`. The old `acc.RandomIP(a, b, c byte)` only varied the *last* octet via `acctest.RandIntRange(0, 255)`, so two tests rolling the same last octet ended up managing the same Atlas IP access list entry. Atlas treats `179.154.x.y` and `179.154.x.y/32` as the same entry, so the IP-style and CIDR-style tests overwrote each other. Symptoms were `After applying this test step, the refresh plan was not empty` with either the resource appearing replaced (other test's comment) or deleted (other test's `CheckDestroy`). 

The same shared-octets pattern existed in the `TestMig*` migration tests for the same package.

### Fix

Make collisions impossible by construction at the utility level: simplify `acc.RandomIP` to take no arguments and allocate IPs from a process-global atomic counter inside the `179.0.0.0/8` range. ~16M unique IPs per process before any wrap — effectively collision-free forever.

All ~17 call sites in `internal/service/projectipaccesslist` and `internal/service/accesslistapikey` updated to the no-args form. 

Link to any related issue(s): test infrastructure cleanup spotted while landing [CLOUDP-407011](https://jira.mongodb.org/browse/CLOUDP-407011) (#4455).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.