### PR TITLE
test: Remove flaky GCP cluster region name tests

### DIFF
--- a/.changelog/4453.txt
+++ b/.changelog/4453.txt
@@ -1,6 +1,6 @@
 ```release-note:enhancement
-datasource/mongodbatlas_advanced_cluster: Adds `disk_throughput` computed attribute to specs sub-resources
+data-source/mongodbatlas_advanced_cluster: Adds `disk_throughput` attribute
 ```
 ```release-note:enhancement
-datasource/mongodbatlas_advanced_clusters: Adds `disk_throughput` computed attribute to specs sub-resources
+data-source/mongodbatlas_advanced_clusters: Adds `disk_throughput` attribute
 ```

--- a/.changelog/4453.txt
+++ b/.changelog/4453.txt
@@ -1,6 +1,6 @@
 ```release-note:enhancement
-datasource/advanced_cluster: Added `disk_throughput` computed attribute to specs sub-resources
+datasource/mongodbatlas_advanced_cluster: Adds `disk_throughput` computed attribute to specs sub-resources
 ```
 ```release-note:enhancement
-datasource/advanced_clusters: Added `disk_throughput` computed attribute to specs sub-resources
+datasource/mongodbatlas_advanced_clusters: Adds `disk_throughput` computed attribute to specs sub-resources
 ```

--- a/.changelog/4453.txt
+++ b/.changelog/4453.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+datasource/advanced_cluster: Added `disk_throughput` computed attribute to specs sub-resources
+```
+```release-note:enhancement
+datasource/advanced_clusters: Added `disk_throughput` computed attribute to specs sub-resources
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -451,7 +451,8 @@ jobs:
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           HTTP_MOCKER_CAPTURE: 'true'
-          ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests == true && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
+          # TODO: TEMPORARY This change will be reverted in the last commit before merging.
+          ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests == true && 'TestAccAdvancedCluster_diskThroughput' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -451,8 +451,7 @@ jobs:
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           HTTP_MOCKER_CAPTURE: 'true'
-          # TODO: TEMPORARY This change will be reverted in the last commit before merging.
-          ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests == true && 'TestAccAdvancedCluster_diskThroughput' || env.ACCTEST_REGEX_RUN }}
+          ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests == true && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -79,8 +79,7 @@ jobs:
           cat doc.repo.patch
           exit 1
   call-acceptance-tests-workflow:
-    # TODO: TEMPORARY This change will be reverted in the last commit before merging.
-    # needs: [build, github-linters, unit-test, generate-doc-check]
+    needs: [build, github-linters, unit-test, generate-doc-check]
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -79,7 +79,8 @@ jobs:
           cat doc.repo.patch
           exit 1
   call-acceptance-tests-workflow:
-    needs: [build, github-linters, unit-test, generate-doc-check]
+    # TODO: TEMPORARY This change will be reverted in the last commit before merging.
+    # needs: [build, github-linters, unit-test, generate-doc-check]
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:

--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -244,6 +244,7 @@ Key-value pairs that categorize the cluster. Each key and value has a maximum le
 ### specs
 
 * `disk_iops` - Target IOPS (Input/Output Operations Per Second) desired for storage attached to this hardware. This parameter defaults to the cluster tier's standard IOPS value.
+* `disk_throughput` - Target throughput desired for storage attached to this hardware. Only returned for Gen 2 instance sizes with Standard (GP3) volume type.
 * `ebs_volume_type` - Type of storage you want to attach to your AWS-provisioned cluster. 
   * `STANDARD` volume types can't exceed the default IOPS rate for the selected volume size.
   * `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size.

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -279,6 +279,7 @@ Key-value pairs that categorize the cluster. Each key and value has a maximum le
 ### specs
 
 * `disk_iops` - Target IOPS (Input/Output Operations Per Second) desired for storage attached to this hardware. This parameter defaults to the cluster tier's standard IOPS value.
+* `disk_throughput` - Target throughput desired for storage attached to this hardware. Only returned for Gen 2 instance sizes with Standard (GP3) volume type.
 * `ebs_volume_type` - Type of storage you want to attach to your AWS-provisioned cluster.
   * `STANDARD` volume types can't exceed the default IOPS rate for the selected volume size.
   * `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size.

--- a/internal/service/advancedcluster/model_ClusterDescription20240805.go
+++ b/internal/service/advancedcluster/model_ClusterDescription20240805.go
@@ -262,9 +262,12 @@ func newRegionConfigsDSObjType(ctx context.Context, input *[]admin.CloudRegionCo
 		item := &(*input)[i]
 		baseModel := newRegionConfigModel(ctx, item, diags)
 		dsModel := *conversion.CopyModel[TFRegionConfigsDSModel](&baseModel)
-		dsModel.EffectiveAnalyticsSpecs = newSpecsObjType(ctx, item.EffectiveAnalyticsSpecs, diags)
-		dsModel.EffectiveElectableSpecs = newSpecsObjType(ctx, item.EffectiveElectableSpecs, diags)
-		dsModel.EffectiveReadOnlySpecs = newSpecsObjType(ctx, item.EffectiveReadOnlySpecs, diags)
+		dsModel.AnalyticsSpecs = newSpecsDSObjType(ctx, item.AnalyticsSpecs, diags)
+		dsModel.ElectableSpecs = newSpecsDSFromHwObjType(ctx, item.ElectableSpecs, diags)
+		dsModel.ReadOnlySpecs = newSpecsDSObjType(ctx, item.ReadOnlySpecs, diags)
+		dsModel.EffectiveAnalyticsSpecs = newSpecsDSObjType(ctx, item.EffectiveAnalyticsSpecs, diags)
+		dsModel.EffectiveElectableSpecs = newSpecsDSObjType(ctx, item.EffectiveElectableSpecs, diags)
+		dsModel.EffectiveReadOnlySpecs = newSpecsDSObjType(ctx, item.EffectiveReadOnlySpecs, diags)
 		tfModels[i] = dsModel
 	}
 	listType, diagsLocal := types.ListValueFrom(ctx, regionConfigsDSObjType, tfModels)
@@ -317,6 +320,40 @@ func newSpecsFromHwObjType(ctx context.Context, input *admin.HardwareSpec2024080
 		NodeCount:     types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.NodeCount)),
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, specsObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}
+
+func newSpecsDSObjType(ctx context.Context, input *admin.DedicatedHardwareSpec20240805, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(specsDSObjType.AttrTypes)
+	}
+	tfModel := TFSpecsDSModel{
+		DiskIops:       types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskIOPS)),
+		DiskThroughput: types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskThroughput)),
+		DiskSizeGb:     types.Float64PointerValue(input.DiskSizeGB),
+		EbsVolumeType:  types.StringValue(conversion.SafeValue(input.EbsVolumeType)),
+		InstanceSize:   types.StringValue(conversion.SafeValue(input.InstanceSize)),
+		NodeCount:      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.NodeCount)),
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, specsDSObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}
+
+func newSpecsDSFromHwObjType(ctx context.Context, input *admin.HardwareSpec20240805, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(specsDSObjType.AttrTypes)
+	}
+	tfModel := TFSpecsDSModel{
+		DiskIops:       types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskIOPS)),
+		DiskThroughput: types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskThroughput)),
+		DiskSizeGb:     types.Float64PointerValue(input.DiskSizeGB),
+		EbsVolumeType:  types.StringValue(conversion.SafeValue(input.EbsVolumeType)),
+		InstanceSize:   types.StringValue(conversion.SafeValue(input.InstanceSize)),
+		NodeCount:      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.NodeCount)),
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, specsDSObjType.AttrTypes, tfModel)
 	diags.Append(diagsLocal...)
 	return objType
 }

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -3201,8 +3201,10 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
 func checkDiskThroughput() resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{acc.CheckExistsCluster(resourceName)}
-	for _, specsAttr := range []string{"electable_specs", "analytics_specs", "read_only_specs", "effective_electable_specs", "effective_analytics_specs", "effective_read_only_specs"} {
-		checks = append(checks, resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0."+specsAttr+".disk_throughput", acc.IntGreatThan(0)))
+	for _, specsAttr := range []string{"electable_specs", "analytics_specs", "read_only_specs"} {
+		attr := "replication_specs.0.region_configs.0." + specsAttr + ".disk_throughput"
+		effectiveAttr := "replication_specs.0.region_configs.0.effective_" + specsAttr + ".disk_throughput"
+		checks = append(checks, resource.TestCheckResourceAttrWith(dataSourceName, attr, acc.IntGreatThan(0)), resource.TestCheckResourceAttrPair(dataSourceName, attr, dataSourceName, effectiveAttr))
 	}
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -3202,7 +3202,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 func checkDiskThroughput() resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{acc.CheckExistsCluster(resourceName)}
 	for _, specsAttr := range []string{"electable_specs", "analytics_specs", "read_only_specs", "effective_electable_specs", "effective_analytics_specs", "effective_read_only_specs"} {
-		checks = append(checks, resource.TestCheckResourceAttr(dataSourceName, "replication_specs.0.region_configs.0."+specsAttr+".disk_throughput", "125"))
+		checks = append(checks, resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0."+specsAttr+".disk_throughput", acc.IntGreatThan(0)))
 	}
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -3147,3 +3147,62 @@ func checkUseAwsTimeBasedSnapshotCopy(value bool) resource.TestCheckFunc {
 		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0."+attrName),
 	)
 }
+
+func TestAccAdvancedCluster_diskThroughput(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 5)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config: configDiskThroughput(projectID, clusterName),
+				Check:  checkDiskThroughput(),
+			},
+		},
+	})
+}
+
+func configDiskThroughput(projectID, clusterName string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = %[1]q
+  name         = %[2]q
+  cluster_type = "REPLICASET"
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          region_name   = "AF_SOUTH_1"
+          priority      = 7
+          provider_name = "AWS"
+          electable_specs = {
+            instance_size = "M30_GEN_2"
+            node_count    = 3
+          }
+          analytics_specs = {
+            instance_size = "M30_GEN_2"
+            node_count    = 1
+          }
+          read_only_specs = {
+            instance_size = "M30_GEN_2"
+            node_count    = 1
+          }
+        }
+      ]
+    }
+  ]
+}
+`, projectID, clusterName) + dataSourcesConfig
+}
+
+func checkDiskThroughput() resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{acc.CheckExistsCluster(resourceName)}
+	for _, specsAttr := range []string{"electable_specs", "analytics_specs", "read_only_specs", "effective_electable_specs", "effective_analytics_specs", "effective_read_only_specs"} {
+		checks = append(checks, resource.TestCheckResourceAttr(dataSourceName, "replication_specs.0.region_configs.0."+specsAttr+".disk_throughput", "125"))
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}

--- a/internal/service/advancedcluster/schema.go
+++ b/internal/service/advancedcluster/schema.go
@@ -24,6 +24,7 @@ const (
 	descUseEffectiveFields        = "Controls how hardware specification fields are returned in the response. When set to true, the non-effective specs (`electable_specs`, `read_only_specs`, `analytics_specs`) fields return the hardware specifications that the client provided. When set to false (default), the non-effective specs fields show the **current** hardware specifications. Cluster auto-scaling is the primary cause for differences between initial and current hardware specifications."
 	descSpecs                     = "Hardware specifications for nodes deployed in the region."
 	descDiskIops                  = "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `\"replicationSpecs[n].regionConfigs[m].providerName\" : \"Azure\"`.\n- set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : \"M40\"` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected **.instanceSize** and **.diskSizeGB**.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost."
+	descDiskThroughput            = "Target throughput desired for storage attached to this hardware. Only returned for Gen 2 instance sizes with Standard (GP3) volume type."
 	descDiskSizeGb                = "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier."
 	descEbsVolumeType             = "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters."
 	descInstanceSize              = "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards."
@@ -558,6 +559,10 @@ func specsSchemaDS() dsschema.SingleNestedAttribute {
 				Computed:            true,
 				MarkdownDescription: descDiskIops,
 			},
+			"disk_throughput": dsschema.Int64Attribute{
+				Computed:            true,
+				MarkdownDescription: descDiskThroughput,
+			},
 			"disk_size_gb": dsschema.Float64Attribute{
 				Computed:            true,
 				MarkdownDescription: descDiskSizeGb,
@@ -866,16 +871,16 @@ type TFRegionConfigsDSModel struct {
 
 var regionConfigsDSObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"analytics_auto_scaling":    autoScalingObjType,
-	"analytics_specs":           specsObjType,
+	"analytics_specs":           specsDSObjType,
 	"auto_scaling":              autoScalingObjType,
 	"backing_provider_name":     types.StringType,
-	"effective_analytics_specs": specsObjType,
-	"effective_electable_specs": specsObjType,
-	"effective_read_only_specs": specsObjType,
-	"electable_specs":           specsObjType,
+	"effective_analytics_specs": specsDSObjType,
+	"effective_electable_specs": specsDSObjType,
+	"effective_read_only_specs": specsDSObjType,
+	"electable_specs":           specsDSObjType,
 	"priority":                  types.Int64Type,
 	"provider_name":             types.StringType,
-	"read_only_specs":           specsObjType,
+	"read_only_specs":           specsDSObjType,
 	"region_name":               types.StringType,
 }}
 
@@ -906,6 +911,24 @@ type TFSpecsModel struct {
 var specsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"disk_iops":       types.Int64Type,
 	"disk_size_gb":    types.Float64Type,
+	"ebs_volume_type": types.StringType,
+	"instance_size":   types.StringType,
+	"node_count":      types.Int64Type,
+}}
+
+type TFSpecsDSModel struct {
+	DiskSizeGb     types.Float64 `tfsdk:"disk_size_gb"`
+	EbsVolumeType  types.String  `tfsdk:"ebs_volume_type"`
+	InstanceSize   types.String  `tfsdk:"instance_size"`
+	DiskIops       types.Int64   `tfsdk:"disk_iops"`
+	DiskThroughput types.Int64   `tfsdk:"disk_throughput"`
+	NodeCount      types.Int64   `tfsdk:"node_count"`
+}
+
+var specsDSObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"disk_iops":       types.Int64Type,
+	"disk_size_gb":    types.Float64Type,
+	"disk_throughput": types.Int64Type,
 	"ebs_volume_type": types.StringType,
 	"instance_size":   types.StringType,
 	"node_count":      types.Int64Type,


### PR DESCRIPTION
## Description

Remove two acceptance tests that repeatedly cause CI failures due to GCP capacity shortages in US West regions.

`TestAccCluster_basicGCPRegionNameWesternUS` and `TestAccCluster_basicGCPRegionNameUSWest2` both create M10 clusters in GCP US West regions (`WESTERN_US` / `US_WEST_2`) that have known infrastructure capacity issues. `TestAccCluster_basicGCP` already covers GCP cluster creation in a stable region (`US_EAST_4`) and provides sufficient coverage. The deleted tests were validating legacy region name aliases on a deprecated resource, which is not worth maintaining.

Link to any related issue(s): CLOUDP-407351

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments