### PR TITLE
test: Remove flaky GCP cluster region name test

### DIFF
--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -386,6 +386,7 @@ func TestAccCluster_basicGCP(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "provider_region_name", "US_EAST_4"),
 				),
 			},
 			{
@@ -398,6 +399,7 @@ func TestAccCluster_basicGCP(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "provider_region_name", "US_EAST_4"),
 				),
 			},
 		},

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -386,7 +386,6 @@ func TestAccCluster_basicGCP(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
-					resource.TestCheckResourceAttr(resourceName, "provider_region_name", "US_EAST_4"),
 				),
 			},
 			{
@@ -399,7 +398,6 @@ func TestAccCluster_basicGCP(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
-					resource.TestCheckResourceAttr(resourceName, "provider_region_name", "US_EAST_4"),
 				),
 			},
 		},
@@ -1051,6 +1049,29 @@ func TestAccCluster_tenant(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCluster_basicGCPRegionName(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
+		regionName             = "US_EAST_4"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config: configGCPRegionName(projectID, clusterName, regionName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "provider_region_name", regionName),
 				),
 			},
 		},
@@ -2263,6 +2284,21 @@ func configAWSWithAutoscaling(projectID, name, backupEnabled, autoDiskEnabled, a
 			name 	     = mongodbatlas_cluster.test.name
 		}
 	`, projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName)
+}
+
+func configGCPRegionName(projectID, name, regionName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_cluster" "test" {
+		project_id                   = %[1]q
+		name                         = %[2]q
+		auto_scaling_disk_gb_enabled = true
+		provider_name                = "GCP"
+		disk_size_gb                 = 10
+		provider_instance_size_name  = "M10"
+		num_shards                   = 1
+		provider_region_name         = %[3]q
+	}
+	`, projectID, name, regionName)
 }
 
 func configRegions(projectID, name, replications string) string {

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1055,52 +1055,6 @@ func TestAccCluster_tenant(t *testing.T) {
 	})
 }
 
-func TestAccCluster_basicGCPRegionNameWesternUS(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
-		regionName             = "WESTERN_US"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				Config: configGCPRegionName(projectID, clusterName, regionName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "provider_region_name", regionName),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCluster_basicGCPRegionNameUSWest2(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
-		regionName             = "US_WEST_2"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				Config: configGCPRegionName(projectID, clusterName, regionName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "provider_region_name", regionName),
-				),
-			},
-		},
-	})
-}
-
 func TestAccCluster_RegionsConfig(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 9)
@@ -2307,22 +2261,6 @@ func configAWSWithAutoscaling(projectID, name, backupEnabled, autoDiskEnabled, a
 			name 	     = mongodbatlas_cluster.test.name
 		}
 	`, projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName)
-}
-
-func configGCPRegionName(
-	projectID, name, regionName string) string {
-	return fmt.Sprintf(`
-	resource "mongodbatlas_cluster" "test" {
-		project_id                   = %[1]q
-		name                         = %[2]q
-		auto_scaling_disk_gb_enabled = true
-		provider_name                = "GCP"
-		disk_size_gb                 = 10
-		provider_instance_size_name  = "M10"
-		num_shards                   = 1
-		provider_region_name         = %[3]q
-	}
-	`, projectID, name, regionName)
 }
 
 func configRegions(projectID, name, replications string) string {


### PR DESCRIPTION
## Description

Replace `TestAccCluster_basicGCPRegionNameWesternUS` and `TestAccCluster_basicGCPRegionNameUSWest2` with a single `TestAccCluster_basicGCPRegionName` using `US_EAST_4`. The two original tests targeted GCP US West regions with known capacity issues and were testing the same `provider_region_name` input path, so they are consolidated into one test in a stable region.

Note: See CLOUDP-407351 for the full investigation.

Link to any related issue(s): CLOUDP-407351

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
