### PR TITLE
doc: Uses objectCreator for GCS log integration example and test

### DIFF
--- a/examples/mongodbatlas_log_integration/gcp/README.md
+++ b/examples/mongodbatlas_log_integration/gcp/README.md
@@ -18,7 +18,7 @@ This example creates the following resources:
 
 ### GCP
 - GCS bucket for storing logs.
-- IAM binding granting the Atlas-managed service account object admin access to the bucket.
+- IAM binding granting the Atlas-managed service account `roles/storage.objectCreator` on the bucket.
 
 ## Usage
 

--- a/examples/mongodbatlas_log_integration/gcp/gcp.tf
+++ b/examples/mongodbatlas_log_integration/gcp/gcp.tf
@@ -5,9 +5,9 @@ resource "google_storage_bucket" "log_bucket" {
   force_destroy = true
 }
 
-# Grant the Atlas-managed service account object admin access to the bucket
+# Grant the Atlas-managed service account object creator access to the bucket
 resource "google_storage_bucket_iam_member" "atlas_access" {
   bucket = google_storage_bucket.log_bucket.name
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectCreator"
   member = "serviceAccount:${mongodbatlas_cloud_provider_access_authorization.auth.gcp[0].service_account_for_atlas}"
 }

--- a/internal/serviceapi/logintegration/resource_test.go
+++ b/internal/serviceapi/logintegration/resource_test.go
@@ -718,7 +718,7 @@ func gcsStorageBucketConfig(projectID string, config *gcsConfig) string {
 
 		resource "google_storage_bucket_iam_member" "bucket_permission" {
 			bucket = google_storage_bucket.log_bucket.name
-			role   = "roles/storage.objectAdmin"
+			role   = "roles/storage.objectCreator"
 			member = "serviceAccount:${mongodbatlas_cloud_provider_access_authorization.gcp_auth.gcp[0].service_account_for_atlas}"
 		}
 	`, projectID, config.bucketName)


### PR DESCRIPTION
## Description

Discovered during GCP module implementation that only `roles/storage.objectCreator` is enough for the log_integration with `GCS_LOG_EXPORT`

Link to any related issue(s): CLOUDP-407780

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
