### PR TITLE
chore: Serialize stream tests that share a workspace to avoid Atlas storage-doc race

### DIFF
--- a/internal/service/streamconnection/resource_stream_connection_migration_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_migration_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestMigStreamRSStreamConnection_kafkaPlaintext(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.16.0") // when reached GA
-	mig.CreateAndRunTest(t, testCaseKafkaPlaintextMigration(t))
+	mig.CreateAndRunTestNonParallel(t, testCaseKafkaPlaintextMigration(t))
 }
 
 func TestMigStreamRSStreamConnection_cluster(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.16.0") // when reached GA
-	mig.CreateAndRunTest(t, testCaseClusterMigration(t))
+	mig.CreateAndRunTestNonParallel(t, testCaseClusterMigration(t))
 }

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -103,7 +103,7 @@ var (
 
 func TestAccStreamRSStreamConnection_kafkaPlaintext(t *testing.T) {
 	testCase := testCaseKafkaPlaintext(t)
-	resource.ParallelTest(t, *testCase)
+	resource.Test(t, *testCase)
 }
 
 func testCaseKafkaPlaintext(t *testing.T) *resource.TestCase {
@@ -219,7 +219,7 @@ func TestAccStreamRSStreamConnection_kafkaOAuthBearer(t *testing.T) {
 			},
 		},
 	}
-	resource.ParallelTest(t, *testCase)
+	resource.Test(t, *testCase)
 }
 
 func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
@@ -265,7 +265,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 		providerName            = "AWS"
 		networkPeeringConfig    = configNetworkPeeringAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion)
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -294,7 +294,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 
 func TestAccStreamRSStreamConnection_cluster(t *testing.T) {
 	testCase := testCaseCluster(t)
-	resource.ParallelTest(t, *testCase)
+	resource.Test(t, *testCase)
 }
 
 func testCaseCluster(t *testing.T) *resource.TestCase {
@@ -361,7 +361,7 @@ func TestAccStreamRSStreamConnection_sample(t *testing.T) {
 		instanceName = acc.RandomStreamInstanceName() // The execution stream instance use sample stream, so we need to create this in a different instance
 		sampleName   = "sample_stream_solar"
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -397,7 +397,7 @@ func TestAccStreamStreamConnection_https(t *testing.T) {
 		}`
 		emptyHeaders string
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -455,7 +455,7 @@ func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 		}`, networkingTypePrivatelink)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -484,7 +484,7 @@ func TestAccStreamRSStreamConnection_AWSLambda(t *testing.T) {
 		awsIAMRoleName          = acc.RandomIAMRole()
 		connectionName          = acc.RandomName()
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -509,7 +509,7 @@ func TestAccStreamRSStreamConnection_GCPPubSub(t *testing.T) {
 		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
 		connectionName          = acc.RandomName()
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -562,7 +562,7 @@ func TestAccStreamRSStreamConnection_instanceName(t *testing.T) {
 		connectionName          = acc.RandomName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -595,7 +595,7 @@ func TestAccStreamRSStreamConnection_conflictingFields(t *testing.T) {
 		connectionName          = "conflict-test"
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -616,7 +616,7 @@ func TestAccStreamRSStreamConnection_SchemaRegistry(t *testing.T) {
 		username                = "user"
 		password                = "password"
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -683,7 +683,7 @@ func TestAccStreamRSStreamConnection_SchemaRegistrySASLInherit(t *testing.T) {
 		connectionName          = acc.RandomName()
 		schemaRegistryURLs      = []string{"https://schemaregistry.example.com"}
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
@@ -1311,7 +1311,7 @@ func TestAccStreamRSStreamConnection_AzureBlobStorage(t *testing.T) {
 		storageAccountName      = "tfacctest" + acctest.RandString(10)
 		storageContainerName    = acc.RandomBucketName()
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acc.PreCheckAzureEnvWithServicePrincipal(t)
 			azureServicePrincipalMu.Lock()

--- a/internal/service/streamprocessor/resource_migration_test.go
+++ b/internal/service/streamprocessor/resource_migration_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestMigStreamProcessor_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.19.0") // when resource 1st released
-	mig.CreateAndRunTest(t, basicTestCaseMigration(t))
+	mig.CreateAndRunTestNonParallel(t, basicTestCaseMigration(t))
 }

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -50,7 +50,7 @@ func importStep() resource.TestStep {
 }
 
 func TestAccStreamProcessor_basic(t *testing.T) {
-	resource.ParallelTest(t, *basicTestCase(t))
+	resource.Test(t, *basicTestCase(t))
 }
 
 func TestAccStreamProcessor_withTier(t *testing.T) {
@@ -60,7 +60,7 @@ func TestAccStreamProcessor_withTier(t *testing.T) {
 		processorName            = "new-processor-tier" + randomSuffix
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroyStreamProcessor,
@@ -153,7 +153,7 @@ func TestAccStreamProcessor_JSONWhiteSpaceFormat(t *testing.T) {
 		processorName              = "new-processor-json-unchanged"
 		sampleSrcConfigExtraSpaces = connectionConfig{connectionType: connTypeSample, pipelineStepIsSource: true, extraWhitespace: true}
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		CheckDestroy:             checkDestroyStreamProcessor,
@@ -176,7 +176,7 @@ func TestAccStreamProcessor_withOptions(t *testing.T) {
 		processorName            = "new-processor" + randomSuffix
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroyStreamProcessor,
@@ -319,7 +319,7 @@ func TestAccStreamProcessor_clusterType(t *testing.T) {
 		srcConfig                = connectionConfig{connectionType: connTypeCluster, clusterName: clusterName, pipelineStepIsSource: true}
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroyStreamProcessor,
@@ -340,7 +340,7 @@ func TestAccStreamProcessor_createErrors(t *testing.T) {
 		randomSuffix             = acctest.RandString(5)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroyStreamProcessor,
@@ -366,7 +366,7 @@ func TestAccStreamProcessor_createTimeoutWithDeleteOnCreate(t *testing.T) {
 		deleteOnCreateTimeout    = true
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroyStreamProcessor,
@@ -521,7 +521,7 @@ func testAccStreamProcessorStateTransitionForUpdates(t *testing.T, setupState, i
 	}
 	steps = append(steps, finalStep)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroyStreamProcessor,


### PR DESCRIPTION
## Description

Replaces \`resource.ParallelTest\` with \`resource.Test\` for 22 acceptance tests and \`mig.CreateAndRunTest\` with \`mig.CreateAndRunTestNonParallel\` for 3 migration tests, in the stream packages that share a workspace via \`acc.ProjectIDExecutionWithStreamInstance\`. Mitigates a concurrent-writer race on the shared storage-config doc inside Atlas's stream service (tracked in CLOUDP-384308) that surfaces in our suite as \`bootstrap_servers\` flapping, intermittent \`HTTP 4xx "connection does not exist"\`, and missing-connection 404s.

Out of scope (own workspace, kept parallel): \`TestAccStreamRSStreamConnection_GCPPubSubPrivateLink\`, \`TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink\`. The \`streaminstance\` package and the other three stream packages are untouched.

Wall-time impact: stream job ~64 min vs ~70 min today. Full breakdown by package and the calculation are in CLOUDP-408013.

Link to any related issue(s): CLOUDP-408013

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments