### PR TITLE
doc: DOCSP-58933: Add auth requirements for federated DB S3 example

### DIFF
--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -43,7 +43,7 @@ resource "mongodbatlas_federated_database_instance" "test" {
 
 ## Example Usages with Amazon S3 bucket as storage database
 
-> **NOTE:** You must configure the Cloud Provider Access properly to authorize the federated database instance to access your S3 bucket. This requires creating a `mongodbatlas_cloud_provider_access_setup` and a `mongodbatlas_cloud_provider_access_authorization` resource, as well as the corresponding AWS IAM roles and policies. For a complete, runnable example, see the [AWS Federated Database Instance example](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_federated_database_instance/aws).
+> **NOTE:** You must configure the Cloud Provider Access properly to authorize the federated database instance to access your S3 bucket. This requires creating a `mongodbatlas_cloud_provider_access_setup` and a `mongodbatlas_cloud_provider_access_authorization` resource, as well as the corresponding AWS IAM roles and policies. For a complete, runnable example, see the [AWS Federated Database Instance example](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.12.0/examples/mongodbatlas_federated_database_instance/aws).
 
 ```terraform
 resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
@@ -55,7 +55,7 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
   project_id = "PROJECT ID"
   role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
   aws {
-    iam_assumed_role_arn = "arn:aws:iam::770682223847:role/TEST-ROLE-FOR-FEDERATED-DATABASE"
+    iam_assumed_role_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/<IAM_ROLE_NAME>"
   }
 }
 

--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -43,7 +43,7 @@ resource "mongodbatlas_federated_database_instance" "test" {
 
 ## Example Usages with Amazon S3 bucket as storage database
 
-> **NOTE:** You must configure the Cloud Provider Access properly to authorize the federated database instance to access your S3 bucket. This requires creating a `mongodbatlas_cloud_provider_access_setup` and a `mongodbatlas_cloud_provider_access_authorization` resource, as well as the corresponding AWS IAM roles and policies. For a complete, runnable example, see the [AWS Federated Database Instance example](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.12.0/examples/mongodbatlas_federated_database_instance/aws).
+**NOTE:** You must configure the Cloud Provider Access properly to authorize the federated database instance to access your S3 bucket. This requires creating a `mongodbatlas_cloud_provider_access_setup` and a `mongodbatlas_cloud_provider_access_authorization` resource, as well as the corresponding AWS IAM roles and policies. For a complete example, see the [AWS Federated Database Instance example](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.12.0/examples/mongodbatlas_federated_database_instance/aws).
 
 ```terraform
 resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
@@ -51,7 +51,7 @@ resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
   provider_name = "AWS"
 }
 
-resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+  project_id = mongodbatlas_cloud_provider_access_setup.setup_only.project_id
   project_id = "PROJECT ID"
   role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
   aws {
@@ -59,7 +59,7 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
   }
 }
 
-resource "mongodbatlas_federated_database_instance" "test" {
+  project_id         = mongodbatlas_cloud_provider_access_setup.setup_only.project_id
   project_id         = "PROJECT ID"
   name = "TENANT NAME OF THE FEDERATED DATABASE INSTANCE"
   cloud_provider_config {

--- a/docs/resources/federated_database_instance.md
+++ b/docs/resources/federated_database_instance.md
@@ -43,14 +43,28 @@ resource "mongodbatlas_federated_database_instance" "test" {
 
 ## Example Usages with Amazon S3 bucket as storage database
 
+> **NOTE:** You must configure the Cloud Provider Access properly to authorize the federated database instance to access your S3 bucket. This requires creating a `mongodbatlas_cloud_provider_access_setup` and a `mongodbatlas_cloud_provider_access_authorization` resource, as well as the corresponding AWS IAM roles and policies. For a complete, runnable example, see the [AWS Federated Database Instance example](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_federated_database_instance/aws).
 
 ```terraform
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+  project_id    = "PROJECT ID"
+  provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+  project_id = "PROJECT ID"
+  role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+  aws {
+    iam_assumed_role_arn = "arn:aws:iam::770682223847:role/TEST-ROLE-FOR-FEDERATED-DATABASE"
+  }
+}
+
 resource "mongodbatlas_federated_database_instance" "test" {
   project_id         = "PROJECT ID"
   name = "TENANT NAME OF THE FEDERATED DATABASE INSTANCE"
   cloud_provider_config {
     aws {
-      role_id = "AWS ROLE ID"
+      role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
       test_s3_bucket = "S3 BUCKET NAME"
     }
 	}


### PR DESCRIPTION
**Jira Ticket:** [DOCSP-58933](https://jira.mongodb.org/browse/DOCSP-58933)

## Description

The `mongodbatlas_federated_database_instance` S3 example in the Terraform provider documentation was missing the authentication and authorization setup required to connect to the S3 bucket.

This PR adds the missing `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` resources to the example and provides a note linking to the fully executable AWS example in the `examples/` directory.
