### PR TITLE
feat: Increase default stream connection timeout to 40 minutes

### DIFF
--- a/.changelog/4467.txt
+++ b/.changelog/4467.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Increases default create/update/delete timeout from 20 to 40 minutes
+```

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -445,9 +445,9 @@ resource "mongodbatlas_stream_connection" "example" {
 }
 ```
 
-* `create` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after creation. Defaults to `20m` (20 minutes).
-* `update` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after an update. Defaults to `20m` (20 minutes).
-* `delete` - (Optional) The maximum time to wait for the stream connection to be fully deleted. Defaults to `20m` (20 minutes).
+* `create` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after creation. Defaults to `40m` (40 minutes).
+* `update` - (Optional) The maximum time to wait for the stream connection to be fully provisioned after an update. Defaults to `40m` (40 minutes).
+* `delete` - (Optional) The maximum time to wait for the stream connection to be fully deleted. Defaults to `40m` (40 minutes).
 
 ## Import
 

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	DefaultConnectionTimeout    = 20 * time.Minute
-	defaultConnectionTimeoutDoc = "20m"
+	DefaultConnectionTimeout    = 40 * time.Minute
+	defaultConnectionTimeoutDoc = "40m"
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -240,7 +240,7 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), resourceName, "timeouts = {\n  create = \"40m\"\n  delete = \"40m\"\n}"),
+				Config: configWithPrivateNetworkingTimeouts(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), "40m", "40m"),
 				Check:  checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-vpc", "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
@@ -461,10 +461,10 @@ func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, fmt.Sprintf(`
+				Config: configWithPrivateNetworkingTimeouts(t, fmt.Sprintf(`
 					%[1]s
 					%[2]s
-				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), resourceName, "timeouts = {\n  create = \"40m\"\n  delete = \"40m\"\n}"),
+				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), "40m", "40m"),
 				Check: checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-privatelink", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePrivatelink, true, true),
 			},
 			{
@@ -543,7 +543,7 @@ func TestAccStreamRSStreamConnection_GCPPubSubPrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), resourceName, "timeouts = {\n  create = \"60m\"\n  delete = \"60m\"\n}"),
+				Config: configWithPrivateNetworkingTimeouts(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), "60m", "60m"),
 				Check:  checkGCPPubSubPrivateLinkAttributes(resourceName, instanceName, connectionName),
 			},
 			{
@@ -1362,7 +1362,7 @@ func TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), resourceName, "timeouts = {\n  create = \"60m\"\n  delete = \"60m\"\n}"),
+				Config: configWithPrivateNetworkingTimeouts(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), "60m", "60m"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAzureBlobStoragePrivateLinkAttributes(resourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
 					checkAzureBlobStoragePrivateLinkAttributes(dataSourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
@@ -1535,4 +1535,16 @@ func streamConnectionsAttributeChecksAcceptance(resourceName string, pageNum, it
 func streamConnectionsAttributeChecksMigration(resourceName string, pageNum, itemsPerPage *int) resource.TestCheckFunc {
 	commonTests := streamConnectionsAttributeChecks(resourceName, pageNum, itemsPerPage)
 	return resource.ComposeAggregateTestCheckFunc(commonTests, resource.TestCheckResourceAttrSet(resourceName, "instance_name"))
+}
+
+// configWithPrivateNetworkingTimeouts wraps a stream connection config with extended create/delete
+// timeouts for private-networking connections (VPC, PRIVATE_LINK) that go through a PENDING state
+// while cloud-provider infrastructure (VPC proxy, private endpoint) is provisioned asynchronously.
+func configWithPrivateNetworkingTimeouts(t *testing.T, baseConfig, create, delete string) string {
+	t.Helper()
+	return acc.ConfigAddResourceStr(t, baseConfig, resourceName, fmt.Sprintf(`
+		timeouts = {
+			create = %q
+			delete = %q
+		}`, create, delete))
 }

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -240,7 +240,7 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config: acc.ConfigAddResourceStr(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), resourceName, `timeouts = { create = "40m" }`),
 				Check:  checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-vpc", "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
@@ -1362,7 +1362,7 @@ func TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: dataSourceConfig + configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName),
+				Config: acc.ConfigAddResourceStr(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), resourceName, `timeouts = { create = "60m" delete = "60m" }`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAzureBlobStoragePrivateLinkAttributes(resourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
 					checkAzureBlobStoragePrivateLinkAttributes(dataSourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -240,7 +240,7 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), resourceName, `timeouts = { create = "40m" delete = "40m" }`),
+				Config: acc.ConfigAddResourceStr(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), resourceName, "timeouts = {\n  create = \"40m\"\n  delete = \"40m\"\n}"),
 				Check:  checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-vpc", "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
@@ -464,7 +464,7 @@ func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 				Config: acc.ConfigAddResourceStr(t, fmt.Sprintf(`
 					%[1]s
 					%[2]s
-				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), resourceName, `timeouts = { create = "40m" delete = "40m" }`),
+				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), resourceName, "timeouts = {\n  create = \"40m\"\n  delete = \"40m\"\n}"),
 				Check: checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-privatelink", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePrivatelink, true, true),
 			},
 			{
@@ -543,7 +543,7 @@ func TestAccStreamRSStreamConnection_GCPPubSubPrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), resourceName, `timeouts = { create = "60m" delete = "60m" }`),
+				Config: acc.ConfigAddResourceStr(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), resourceName, "timeouts = {\n  create = \"60m\"\n  delete = \"60m\"\n}"),
 				Check:  checkGCPPubSubPrivateLinkAttributes(resourceName, instanceName, connectionName),
 			},
 			{
@@ -1362,7 +1362,7 @@ func TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), resourceName, `timeouts = { create = "60m" delete = "60m" }`),
+				Config: acc.ConfigAddResourceStr(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), resourceName, "timeouts = {\n  create = \"60m\"\n  delete = \"60m\"\n}"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAzureBlobStoragePrivateLinkAttributes(resourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
 					checkAzureBlobStoragePrivateLinkAttributes(dataSourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -240,7 +240,7 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAddResourceStr(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), resourceName, `timeouts = { create = "40m" }`),
+				Config: acc.ConfigAddResourceStr(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), resourceName, `timeouts = { create = "40m" delete = "40m" }`),
 				Check:  checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-vpc", "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
@@ -461,10 +461,10 @@ func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
+				Config: acc.ConfigAddResourceStr(t, fmt.Sprintf(`
 					%[1]s
 					%[2]s
-				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)),
+				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), resourceName, `timeouts = { create = "40m" delete = "40m" }`),
 				Check: checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-privatelink", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePrivatelink, true, true),
 			},
 			{
@@ -543,7 +543,7 @@ func TestAccStreamRSStreamConnection_GCPPubSubPrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region),
+				Config: acc.ConfigAddResourceStr(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), resourceName, `timeouts = { create = "60m" delete = "60m" }`),
 				Check:  checkGCPPubSubPrivateLinkAttributes(resourceName, instanceName, connectionName),
 			},
 			{

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -240,7 +240,7 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateNetworkingTimeouts(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), "40m"),
+				Config: networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				Check:  checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-vpc", "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
@@ -461,10 +461,10 @@ func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateNetworkingTimeouts(t, fmt.Sprintf(`
+				Config: fmt.Sprintf(`
 					%[1]s
 					%[2]s
-				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), "40m"),
+				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)),
 				Check: checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-privatelink", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePrivatelink, true, true),
 			},
 			{
@@ -543,7 +543,7 @@ func TestAccStreamRSStreamConnection_GCPPubSubPrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateNetworkingTimeouts(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), "60m"),
+				Config: configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region),
 				Check:  checkGCPPubSubPrivateLinkAttributes(resourceName, instanceName, connectionName),
 			},
 			{
@@ -1362,7 +1362,7 @@ func TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateNetworkingTimeouts(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), "60m"),
+				Config: dataSourceConfig + configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAzureBlobStoragePrivateLinkAttributes(resourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
 					checkAzureBlobStoragePrivateLinkAttributes(dataSourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
@@ -1535,16 +1535,4 @@ func streamConnectionsAttributeChecksAcceptance(resourceName string, pageNum, it
 func streamConnectionsAttributeChecksMigration(resourceName string, pageNum, itemsPerPage *int) resource.TestCheckFunc {
 	commonTests := streamConnectionsAttributeChecks(resourceName, pageNum, itemsPerPage)
 	return resource.ComposeAggregateTestCheckFunc(commonTests, resource.TestCheckResourceAttrSet(resourceName, "instance_name"))
-}
-
-// configWithPrivateNetworkingTimeouts wraps a stream connection config with extended create/delete
-// timeouts for private-networking connections (VPC, PRIVATE_LINK) that go through a PENDING state
-// while cloud-provider infrastructure (VPC proxy, private endpoint) is provisioned asynchronously.
-func configWithPrivateNetworkingTimeouts(t *testing.T, baseConfig, timeout string) string {
-	t.Helper()
-	return acc.ConfigAddResourceStr(t, baseConfig, resourceName, fmt.Sprintf(`
-		timeouts = {
-			create = %q
-			delete = %q
-		}`, timeout, timeout))
 }

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -240,7 +240,7 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateNetworkingTimeouts(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), "40m", "40m"),
+				Config: configWithPrivateNetworkingTimeouts(t, networkPeeringConfig+configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true), "40m"),
 				Check:  checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-vpc", "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
@@ -464,7 +464,7 @@ func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 				Config: configWithPrivateNetworkingTimeouts(t, fmt.Sprintf(`
 					%[1]s
 					%[2]s
-				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), "40m", "40m"),
+				`, privatelinkConfig, configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)), "40m"),
 				Check: checkKafkaAttributesAcceptance(resourceName, instanceName, "kafka-conn-privatelink", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePrivatelink, true, true),
 			},
 			{
@@ -543,7 +543,7 @@ func TestAccStreamRSStreamConnection_GCPPubSubPrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateNetworkingTimeouts(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), "60m", "60m"),
+				Config: configWithPrivateNetworkingTimeouts(t, configureGCPPubSubPrivateLink(projectID, instanceName, clusterName, connectionName, region), "60m"),
 				Check:  checkGCPPubSubPrivateLinkAttributes(resourceName, instanceName, connectionName),
 			},
 			{
@@ -1362,7 +1362,7 @@ func TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPrivateNetworkingTimeouts(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), "60m", "60m"),
+				Config: configWithPrivateNetworkingTimeouts(t, dataSourceConfig+configureAzureBlobStoragePrivateLink(projectID, instanceName, clusterName, connectionName, clientID, clientSecret, subscriptionID, tenantID, atlasAzureAppID, servicePrincipalID, resourceGroupName, storageAccountName, storageContainerName), "60m"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAzureBlobStoragePrivateLinkAttributes(resourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
 					checkAzureBlobStoragePrivateLinkAttributes(dataSourceName, instanceName, connectionName, servicePrincipalID, storageAccountName),
@@ -1540,11 +1540,11 @@ func streamConnectionsAttributeChecksMigration(resourceName string, pageNum, ite
 // configWithPrivateNetworkingTimeouts wraps a stream connection config with extended create/delete
 // timeouts for private-networking connections (VPC, PRIVATE_LINK) that go through a PENDING state
 // while cloud-provider infrastructure (VPC proxy, private endpoint) is provisioned asynchronously.
-func configWithPrivateNetworkingTimeouts(t *testing.T, baseConfig, create, delete string) string {
+func configWithPrivateNetworkingTimeouts(t *testing.T, baseConfig, timeout string) string {
 	t.Helper()
 	return acc.ConfigAddResourceStr(t, baseConfig, resourceName, fmt.Sprintf(`
 		timeouts = {
 			create = %q
 			delete = %q
-		}`, create, delete))
+		}`, timeout, timeout))
 }


### PR DESCRIPTION
## Summary
- Increases `DefaultConnectionTimeout` from 20 to 40 minutes for `mongodbatlas_stream_connection` create/update/delete operations
- Private-networking connections (VPC, Private Link) go through an async `PENDING` state while cloud infrastructure provisions, which can exceed the previous 20-minute default (VPC proxy provisioning takes 23-29 min in cloud-dev per CLOUDP-339710)

Tests were failing with:
```
timeout while waiting for state to become 'READY, FAILED' (last state: 'PENDING', timeout: 20m0s)
```

## Test plan
- [ ] Confirm `TestAccStreamRSStreamConnection_kafkaNetworkingVPC` passes in the next stream CI run
- [ ] Confirm `TestAccStreamRSStreamConnection_AzureBlobStoragePrivateLink` passes in the next stream CI run
- [ ] Confirm `TestAccStreamPrivatelinkEndpoint_streamConnection` passes in the next stream CI run
- [ ] Confirm `TestAccStreamRSStreamConnection_GCPPubSubPrivateLink` passes in the next stream CI run