### PR TITLE
chore: Fix adaptive_capacity tests

### DIFF
--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -3210,7 +3210,6 @@ func checkAdaptiveCapacity(value *string, addTags bool) resource.TestCheckFunc {
 		checks = append(checks,
 			resource.TestCheckResourceAttr(resourceName, attrName, *value),
 			resource.TestCheckResourceAttr(dataSourceName, attrName, *value),
-			resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0."+attrName),
 		)
 	}
 	if addTags {

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -3124,24 +3126,29 @@ func TestAccAdvancedCluster_adaptiveCapacity(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configAdaptiveCapacity(projectID, clusterName, new("ENABLED"), true, "AZURE", "US_EAST_2"), // create
-				Check:  checkAdaptiveCapacity(new("ENABLED"), true),
+				Config:            configAdaptiveCapacity(projectID, clusterName, new("ENABLED"), true, "AZURE", "US_EAST_2"), // create
+				Check:             checkAdaptiveCapacity(new("ENABLED"), true),
+				ConfigStateChecks: pluralAdaptiveCapacityChecks(clusterName, new("ENABLED")),
 			},
 			{
-				Config: configAdaptiveCapacity(projectID, clusterName, new("DISABLED"), true, "AZURE", "US_EAST_2"), // AC only change
-				Check:  checkAdaptiveCapacity(new("DISABLED"), true),
+				Config:            configAdaptiveCapacity(projectID, clusterName, new("DISABLED"), true, "AZURE", "US_EAST_2"), // AC only change
+				Check:             checkAdaptiveCapacity(new("DISABLED"), true),
+				ConfigStateChecks: pluralAdaptiveCapacityChecks(clusterName, new("DISABLED")),
 			},
 			{
-				Config: configAdaptiveCapacity(projectID, clusterName, nil, true, "AZURE", "US_EAST_2"), // AC remove only
-				Check:  checkAdaptiveCapacity(nil, true),
+				Config:            configAdaptiveCapacity(projectID, clusterName, nil, true, "AZURE", "US_EAST_2"), // AC remove only
+				Check:             checkAdaptiveCapacity(nil, true),
+				ConfigStateChecks: pluralAdaptiveCapacityChecks(clusterName, nil),
 			},
 			{
-				Config: configAdaptiveCapacity(projectID, clusterName, new("ENABLED"), false, "AZURE", "US_EAST_2"), // AC set-from-null + tag change
-				Check:  checkAdaptiveCapacity(new("ENABLED"), false),
+				Config:            configAdaptiveCapacity(projectID, clusterName, new("ENABLED"), false, "AZURE", "US_EAST_2"), // AC set-from-null + tag change
+				Check:             checkAdaptiveCapacity(new("ENABLED"), false),
+				ConfigStateChecks: pluralAdaptiveCapacityChecks(clusterName, new("ENABLED")),
 			},
 			{
-				Config: configAdaptiveCapacity(projectID, clusterName, nil, true, "AZURE", "US_EAST_2"), // AC remove + tag change
-				Check:  checkAdaptiveCapacity(nil, true),
+				Config:            configAdaptiveCapacity(projectID, clusterName, nil, true, "AZURE", "US_EAST_2"), // AC remove + tag change
+				Check:             checkAdaptiveCapacity(nil, true),
+				ConfigStateChecks: pluralAdaptiveCapacityChecks(clusterName, nil),
 			},
 			acc.TestStepImportCluster(resourceName),
 		},
@@ -3161,8 +3168,9 @@ func TestAccAdvancedCluster_adaptiveCapacityAWS(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configAdaptiveCapacity(projectID, clusterName, new("ENABLED"), false, "AWS", "US_EAST_1"),
-				Check:  checkAdaptiveCapacity(new("ENABLED"), false),
+				Config:            configAdaptiveCapacity(projectID, clusterName, new("ENABLED"), false, "AWS", "US_EAST_1"),
+				Check:             checkAdaptiveCapacity(new("ENABLED"), false),
+				ConfigStateChecks: pluralAdaptiveCapacityChecks(clusterName, new("ENABLED")),
 			},
 		},
 	})
@@ -3196,6 +3204,18 @@ func configAdaptiveCapacity(projectID, name string, value *string, addTags bool,
 			}]
 		}
 	`, projectID, name, extraAttrs, providerName, regionName) + dataSourcesConfig
+}
+
+func pluralAdaptiveCapacityChecks(clusterName string, value *string) []statecheck.StateCheck {
+	var acCheck knownvalue.Check = knownvalue.Null()
+	if value != nil {
+		acCheck = knownvalue.StringExact(*value)
+	}
+	return []statecheck.StateCheck{
+		acc.PluralResultCheck(dataSourcePluralName, "name", knownvalue.StringExact(clusterName), map[string]knownvalue.Check{
+			"adaptive_capacity": acCheck,
+		}),
+	}
 }
 
 func checkAdaptiveCapacity(value *string, addTags bool) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

Makes `checkAdaptiveCapacity` robust against parallel tests sharing a project. The plural data source returns all clusters in the project, so the previous `results.0.adaptive_capacity` assertion could read a different cluster (from another test) and produce a flaky failure.

Switches the plural DS assertion to `acc.PluralResultCheck`, which locates the cluster by `name` within `results` and then asserts `adaptive_capacity` (exact value when set, null when removed). Resource and singular DS checks are unchanged.

Link to any related issue(s): CLOUDP-408742

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments