### PR TITLE
chore: Add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -265,38 +265,34 @@ jobs:
     env:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
-      # TODO: TEMPORARY This change will be reverted in the last commit before merging.
-      # Forces only the `config` test group to run so the workflow-permissions PR
-      # (CLOUDP-409147) can be verified with a fast acceptance-test run that still
-      # exercises the GCP OIDC path. Revert to restore real change detection.
-      advanced_cluster: 'false'
-      assume_role: 'false'
-      authentication: 'false'
-      autogen_fast: 'false'
-      autogen_slow: 'false'
-      backup: 'false'
-      control_plane_ip_addresses: 'false'
-      cloud_user: 'false'
-      cluster: 'false'
-      cluster_outage_simulation: 'false'
-      config: 'true'
-      encryption: 'false'
-      event_trigger: 'false'
-      federated: 'false'
-      flex_cluster: 'false'
-      generic: 'false'
-      global_cluster_config: 'false'
-      ldap: 'false'
-      mongodb_employee_access_grant: 'false'
-      network: 'false'
-      project: 'false'
-      push_based_log_export: 'false'
-      resource_policy: 'false'
-      search_deployment: 'false'
-      search_index: 'false'
-      service_account: 'false'
-      service_account_jwt: 'false'
-      stream: 'false'
+      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
+      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
+      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
+      autogen_fast: ${{ steps.filter.outputs.autogen_fast == 'true' || env.mustTrigger == 'true' }}
+      autogen_slow: ${{ steps.filter.outputs.autogen_slow == 'true' || env.mustTrigger == 'true' }}
+      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
+      control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
+      cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
+      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
+      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
+      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
+      encryption: ${{ steps.filter.outputs.encryption == 'true' || env.mustTrigger == 'true' }}
+      event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
+      federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
+      flex_cluster: ${{ steps.filter.outputs.flex_cluster == 'true' || env.mustTrigger == 'true' }}
+      generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
+      global_cluster_config: ${{ steps.filter.outputs.global_cluster_config == 'true' || env.mustTrigger == 'true' }}
+      ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}
+      mongodb_employee_access_grant: ${{ steps.filter.outputs.mongodb_employee_access_grant == 'true' || env.mustTrigger == 'true' }}
+      network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
+      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
+      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
+      resource_policy: ${{ steps.filter.outputs.resource_policy == 'true' || env.mustTrigger == 'true' }}
+      search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
+      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
+      service_account: ${{ steps.filter.outputs.service_account == 'true' || env.mustTrigger == 'true' }}
+      service_account_jwt: ${{ steps.filter.outputs.service_account_jwt == 'true' || env.mustTrigger == 'true' }}
+      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -265,34 +265,38 @@ jobs:
     env:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
-      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
-      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
-      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
-      autogen_fast: ${{ steps.filter.outputs.autogen_fast == 'true' || env.mustTrigger == 'true' }}
-      autogen_slow: ${{ steps.filter.outputs.autogen_slow == 'true' || env.mustTrigger == 'true' }}
-      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
-      control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
-      cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
-      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
-      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
-      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
-      encryption: ${{ steps.filter.outputs.encryption == 'true' || env.mustTrigger == 'true' }}
-      event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
-      federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
-      flex_cluster: ${{ steps.filter.outputs.flex_cluster == 'true' || env.mustTrigger == 'true' }}
-      generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
-      global_cluster_config: ${{ steps.filter.outputs.global_cluster_config == 'true' || env.mustTrigger == 'true' }}
-      ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}
-      mongodb_employee_access_grant: ${{ steps.filter.outputs.mongodb_employee_access_grant == 'true' || env.mustTrigger == 'true' }}
-      network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
-      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
-      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
-      resource_policy: ${{ steps.filter.outputs.resource_policy == 'true' || env.mustTrigger == 'true' }}
-      search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
-      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
-      service_account: ${{ steps.filter.outputs.service_account == 'true' || env.mustTrigger == 'true' }}
-      service_account_jwt: ${{ steps.filter.outputs.service_account_jwt == 'true' || env.mustTrigger == 'true' }}
-      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      # TODO: TEMPORARY This change will be reverted in the last commit before merging.
+      # Forces only the `config` test group to run so the workflow-permissions PR
+      # (CLOUDP-409147) can be verified with a fast acceptance-test run that still
+      # exercises the GCP OIDC path. Revert to restore real change detection.
+      advanced_cluster: 'false'
+      assume_role: 'false'
+      authentication: 'false'
+      autogen_fast: 'false'
+      autogen_slow: 'false'
+      backup: 'false'
+      control_plane_ip_addresses: 'false'
+      cloud_user: 'false'
+      cluster: 'false'
+      cluster_outage_simulation: 'false'
+      config: 'true'
+      encryption: 'false'
+      event_trigger: 'false'
+      federated: 'false'
+      flex_cluster: 'false'
+      generic: 'false'
+      global_cluster_config: 'false'
+      ldap: 'false'
+      mongodb_employee_access_grant: 'false'
+      network: 'false'
+      project: 'false'
+      push_based_log_export: 'false'
+      resource_policy: 'false'
+      search_deployment: 'false'
+      search_index: 'false'
+      service_account: 'false'
+      service_account_jwt: 'false'
+      stream: 'false'
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -265,34 +265,39 @@ jobs:
     env:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
-      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
-      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
-      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
-      autogen_fast: ${{ steps.filter.outputs.autogen_fast == 'true' || env.mustTrigger == 'true' }}
-      autogen_slow: ${{ steps.filter.outputs.autogen_slow == 'true' || env.mustTrigger == 'true' }}
-      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
-      control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
-      cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
-      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
-      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
-      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
-      encryption: ${{ steps.filter.outputs.encryption == 'true' || env.mustTrigger == 'true' }}
-      event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
-      federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
-      flex_cluster: ${{ steps.filter.outputs.flex_cluster == 'true' || env.mustTrigger == 'true' }}
-      generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
-      global_cluster_config: ${{ steps.filter.outputs.global_cluster_config == 'true' || env.mustTrigger == 'true' }}
-      ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}
-      mongodb_employee_access_grant: ${{ steps.filter.outputs.mongodb_employee_access_grant == 'true' || env.mustTrigger == 'true' }}
-      network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
-      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
-      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
-      resource_policy: ${{ steps.filter.outputs.resource_policy == 'true' || env.mustTrigger == 'true' }}
-      search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
-      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
-      service_account: ${{ steps.filter.outputs.service_account == 'true' || env.mustTrigger == 'true' }}
-      service_account_jwt: ${{ steps.filter.outputs.service_account_jwt == 'true' || env.mustTrigger == 'true' }}
-      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      # TODO: TEMPORARY This change will be reverted in the last commit before merging.
+      # Forces only the `autogen_fast` test group to run so the workflow-permissions PR
+      # (CLOUDP-409147) can be verified against the one job that performs GCP OIDC auth
+      # (google-github-actions/auth with id-token: write), exercising the reusable-workflow
+      # permission chain this PR hardens. Revert to restore real change detection.
+      advanced_cluster: 'false'
+      assume_role: 'false'
+      authentication: 'false'
+      autogen_fast: 'true'
+      autogen_slow: 'false'
+      backup: 'false'
+      control_plane_ip_addresses: 'false'
+      cloud_user: 'false'
+      cluster: 'false'
+      cluster_outage_simulation: 'false'
+      config: 'false'
+      encryption: 'false'
+      event_trigger: 'false'
+      federated: 'false'
+      flex_cluster: 'false'
+      generic: 'false'
+      global_cluster_config: 'false'
+      ldap: 'false'
+      mongodb_employee_access_grant: 'false'
+      network: 'false'
+      project: 'false'
+      push_based_log_export: 'false'
+      resource_policy: 'false'
+      search_deployment: 'false'
+      search_index: 'false'
+      service_account: 'false'
+      service_account_jwt: 'false'
+      stream: 'false'
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -265,39 +265,34 @@ jobs:
     env:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
-      # TODO: TEMPORARY This change will be reverted in the last commit before merging.
-      # Forces only the `autogen_fast` test group to run so the workflow-permissions PR
-      # (CLOUDP-409147) can be verified against the one job that performs GCP OIDC auth
-      # (google-github-actions/auth with id-token: write), exercising the reusable-workflow
-      # permission chain this PR hardens. Revert to restore real change detection.
-      advanced_cluster: 'false'
-      assume_role: 'false'
-      authentication: 'false'
-      autogen_fast: 'true'
-      autogen_slow: 'false'
-      backup: 'false'
-      control_plane_ip_addresses: 'false'
-      cloud_user: 'false'
-      cluster: 'false'
-      cluster_outage_simulation: 'false'
-      config: 'false'
-      encryption: 'false'
-      event_trigger: 'false'
-      federated: 'false'
-      flex_cluster: 'false'
-      generic: 'false'
-      global_cluster_config: 'false'
-      ldap: 'false'
-      mongodb_employee_access_grant: 'false'
-      network: 'false'
-      project: 'false'
-      push_based_log_export: 'false'
-      resource_policy: 'false'
-      search_deployment: 'false'
-      search_index: 'false'
-      service_account: 'false'
-      service_account_jwt: 'false'
-      stream: 'false'
+      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
+      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
+      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
+      autogen_fast: ${{ steps.filter.outputs.autogen_fast == 'true' || env.mustTrigger == 'true' }}
+      autogen_slow: ${{ steps.filter.outputs.autogen_slow == 'true' || env.mustTrigger == 'true' }}
+      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
+      control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
+      cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
+      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
+      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
+      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
+      encryption: ${{ steps.filter.outputs.encryption == 'true' || env.mustTrigger == 'true' }}
+      event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
+      federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
+      flex_cluster: ${{ steps.filter.outputs.flex_cluster == 'true' || env.mustTrigger == 'true' }}
+      generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
+      global_cluster_config: ${{ steps.filter.outputs.global_cluster_config == 'true' || env.mustTrigger == 'true' }}
+      ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}
+      mongodb_employee_access_grant: ${{ steps.filter.outputs.mongodb_employee_access_grant == 'true' || env.mustTrigger == 'true' }}
+      network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
+      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
+      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
+      resource_policy: ${{ steps.filter.outputs.resource_policy == 'true' || env.mustTrigger == 'true' }}
+      search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
+      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
+      service_account: ${{ steps.filter.outputs.service_account == 'true' || env.mustTrigger == 'true' }}
+      service_account_jwt: ${{ steps.filter.outputs.service_account_jwt == 'true' || env.mustTrigger == 'true' }}
+      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -69,6 +69,10 @@ on:
         type: boolean
         required: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   tests:
     name: tests-${{ inputs.terraform_version || 'latest' }}-${{ inputs.provider_version || 'latest' }}-${{ inputs.atlas_cloud_env || 'dev' }}

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -80,6 +80,9 @@ jobs:
           exit 1
   call-acceptance-tests-workflow:
     needs: [build, github-linters, unit-test, generate-doc-check]
+    permissions:
+      id-token: write
+      contents: read
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,6 +19,8 @@ jobs:
   generate-and-update-changelog:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,6 +5,10 @@
   on:
     issues:
       types: [opened, reopened, closed]
+
+  permissions:
+    issues: write
+
   jobs:
     jira_task:
       name: Create Jira issue

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-compatibility-matrix.yml
+++ b/.github/workflows/terraform-compatibility-matrix.yml
@@ -38,6 +38,9 @@ jobs:
   run-test-supported-versions:
     needs: ["get-supported-versions"]
     if: ${{ !cancelled() }}
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -63,6 +63,7 @@ concurrency:
    
 jobs:
   variables:
+    permissions: {}
     env:
       schedule_terraform_matrix: '["1.15.x"]'
       schedule_provider_matrix: '[""]' # "" for latest version    
@@ -81,12 +82,16 @@ jobs:
           echo "DAY=$(date +'%a')"
           echo "DAY=$(date +'%a')" >> "$GITHUB_OUTPUT"
   clean-before:
+    permissions: {}
     secrets: inherit
     uses: ./.github/workflows/cleanup-test-env.yml
 
   tests:
     needs: [clean-before, variables]
     if: ${{ !cancelled() }}
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       max-parallel: 1
       fail-fast: false
@@ -107,6 +112,7 @@ jobs:
   clean-after:
     needs: tests
     if: ${{ !cancelled() }}
+    permissions: {}
     secrets: inherit
     uses: ./.github/workflows/cleanup-test-env.yml
 


### PR DESCRIPTION
## Description

Adds explicit least-privilege `permissions:` blocks to the GitHub Actions workflows that CodeQL flagged with `actions/missing-workflow-permissions`, matching the repo's existing per-job convention. Most jobs get `{}` or `contents: read`; the jobs that call the reusable acceptance-test workflows get `id-token: write` + `contents: read` (the runner's GCP OIDC job needs it, and a blanket `{}` would cap the called workflow and break cloud auth). `stale.yml` uses the same block as the other provider repos (`contents: read` + `issues: write` + `pull-requests: write`).

`release.yml` is intentionally out of scope and left untouched; its alerts will be hardened separately after confirming the exact scopes its release jobs require.

The test-chain changes are verified with a real acceptance/test-suite run including the GCP OIDC path before merge.

Link to any related issue(s): CLOUDP-409147

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
