### PR TITLE
chore: Persist test-suite AI summary to run page and artifact

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -265,35 +265,34 @@ jobs:
     env:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
-      # TODO: TEMPORARY This change will be reverted in the last commit before merging. Hardcoded to run only the config test group.
-      advanced_cluster: 'false'
-      assume_role: 'false'
-      authentication: 'false'
-      autogen_fast: 'false'
-      autogen_slow: 'false'
-      backup: 'false'
-      control_plane_ip_addresses: 'false'
-      cloud_user: 'false'
-      cluster: 'false'
-      cluster_outage_simulation: 'false'
-      config: 'true'
-      encryption: 'false'
-      event_trigger: 'false'
-      federated: 'false'
-      flex_cluster: 'false'
-      generic: 'false'
-      global_cluster_config: 'false'
-      ldap: 'false'
-      mongodb_employee_access_grant: 'false'
-      network: 'false'
-      project: 'false'
-      push_based_log_export: 'false'
-      resource_policy: 'false'
-      search_deployment: 'false'
-      search_index: 'false'
-      service_account: 'false'
-      service_account_jwt: 'false'
-      stream: 'false'
+      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
+      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
+      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
+      autogen_fast: ${{ steps.filter.outputs.autogen_fast == 'true' || env.mustTrigger == 'true' }}
+      autogen_slow: ${{ steps.filter.outputs.autogen_slow == 'true' || env.mustTrigger == 'true' }}
+      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
+      control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
+      cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
+      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
+      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
+      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
+      encryption: ${{ steps.filter.outputs.encryption == 'true' || env.mustTrigger == 'true' }}
+      event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
+      federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
+      flex_cluster: ${{ steps.filter.outputs.flex_cluster == 'true' || env.mustTrigger == 'true' }}
+      generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
+      global_cluster_config: ${{ steps.filter.outputs.global_cluster_config == 'true' || env.mustTrigger == 'true' }}
+      ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}
+      mongodb_employee_access_grant: ${{ steps.filter.outputs.mongodb_employee_access_grant == 'true' || env.mustTrigger == 'true' }}
+      network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
+      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
+      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
+      resource_policy: ${{ steps.filter.outputs.resource_policy == 'true' || env.mustTrigger == 'true' }}
+      search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
+      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
+      service_account: ${{ steps.filter.outputs.service_account == 'true' || env.mustTrigger == 'true' }}
+      service_account_jwt: ${{ steps.filter.outputs.service_account_jwt == 'true' || env.mustTrigger == 'true' }}
+      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -265,34 +265,35 @@ jobs:
     env:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
-      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
-      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
-      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
-      autogen_fast: ${{ steps.filter.outputs.autogen_fast == 'true' || env.mustTrigger == 'true' }}
-      autogen_slow: ${{ steps.filter.outputs.autogen_slow == 'true' || env.mustTrigger == 'true' }}
-      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
-      control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
-      cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
-      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
-      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
-      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
-      encryption: ${{ steps.filter.outputs.encryption == 'true' || env.mustTrigger == 'true' }}
-      event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
-      federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
-      flex_cluster: ${{ steps.filter.outputs.flex_cluster == 'true' || env.mustTrigger == 'true' }}
-      generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
-      global_cluster_config: ${{ steps.filter.outputs.global_cluster_config == 'true' || env.mustTrigger == 'true' }}
-      ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}
-      mongodb_employee_access_grant: ${{ steps.filter.outputs.mongodb_employee_access_grant == 'true' || env.mustTrigger == 'true' }}
-      network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
-      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
-      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
-      resource_policy: ${{ steps.filter.outputs.resource_policy == 'true' || env.mustTrigger == 'true' }}
-      search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
-      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
-      service_account: ${{ steps.filter.outputs.service_account == 'true' || env.mustTrigger == 'true' }}
-      service_account_jwt: ${{ steps.filter.outputs.service_account_jwt == 'true' || env.mustTrigger == 'true' }}
-      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      # TODO: TEMPORARY This change will be reverted in the last commit before merging. Hardcoded to run only the config test group.
+      advanced_cluster: 'false'
+      assume_role: 'false'
+      authentication: 'false'
+      autogen_fast: 'false'
+      autogen_slow: 'false'
+      backup: 'false'
+      control_plane_ip_addresses: 'false'
+      cloud_user: 'false'
+      cluster: 'false'
+      cluster_outage_simulation: 'false'
+      config: 'true'
+      encryption: 'false'
+      event_trigger: 'false'
+      federated: 'false'
+      flex_cluster: 'false'
+      generic: 'false'
+      global_cluster_config: 'false'
+      ldap: 'false'
+      mongodb_employee_access_grant: 'false'
+      network: 'false'
+      project: 'false'
+      push_based_log_export: 'false'
+      resource_policy: 'false'
+      search_deployment: 'false'
+      search_index: 'false'
+      service_account: 'false'
+      service_account_jwt: 'false'
+      stream: 'false'
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -142,13 +142,11 @@ jobs:
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Persist summary to run page and file
-        if: ${{ steps.summary.outputs.structured_output != '' }}
         env:
           SUMMARY: ${{ fromJSON(steps.summary.outputs.structured_output).summary }}
         run: |
           printf '%s\n' "$SUMMARY" | tee summary.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upload summary artifact
-        if: ${{ steps.summary.outputs.structured_output != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: summary

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -141,6 +141,18 @@ jobs:
           ANTHROPIC_CUSTOM_HEADERS: "api-key: ${{ secrets.AI_GATEWAY_API_KEY }}"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Persist summary to run page and file
+        if: ${{ steps.summary.outputs.structured_output != '' }}
+        env:
+          SUMMARY: ${{ fromJSON(steps.summary.outputs.structured_output).summary }}
+        run: |
+          printf '%s\n' "$SUMMARY" | tee summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload summary artifact
+        if: ${{ steps.summary.outputs.structured_output != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: summary
+          path: summary.md
       - name: Post summary to Slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -82,7 +82,6 @@ jobs:
           echo "DAY=$(date +'%a')"
           echo "DAY=$(date +'%a')" >> "$GITHUB_OUTPUT"
   clean-before:
-    if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips cleanup. Reverted in the last commit before merging.
     permissions: {}
     secrets: inherit
     uses: ./.github/workflows/cleanup-test-env.yml
@@ -112,7 +111,7 @@ jobs:
 
   clean-after:
     needs: tests
-    if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips cleanup. Reverted in the last commit before merging. Original: ${{ !cancelled() }}
+    if: ${{ !cancelled() }}
     permissions: {}
     secrets: inherit
     uses: ./.github/workflows/cleanup-test-env.yml
@@ -155,7 +154,6 @@ jobs:
           name: summary
           path: summary.md
       - name: Post summary to Slack
-        if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips Slack post. Reverted in the last commit before merging.
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -175,7 +173,7 @@ jobs:
               ]
             }
       - name: Fallback ping if any prior step failed
-        if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips Slack ping. Reverted in the last commit before merging. Original: ${{ failure() }}
+        if: ${{ failure() }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -82,6 +82,7 @@ jobs:
           echo "DAY=$(date +'%a')"
           echo "DAY=$(date +'%a')" >> "$GITHUB_OUTPUT"
   clean-before:
+    if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips cleanup. Reverted in the last commit before merging.
     permissions: {}
     secrets: inherit
     uses: ./.github/workflows/cleanup-test-env.yml
@@ -111,7 +112,7 @@ jobs:
 
   clean-after:
     needs: tests
-    if: ${{ !cancelled() }}
+    if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips cleanup. Reverted in the last commit before merging. Original: ${{ !cancelled() }}
     permissions: {}
     secrets: inherit
     uses: ./.github/workflows/cleanup-test-env.yml
@@ -154,6 +155,7 @@ jobs:
           name: summary
           path: summary.md
       - name: Post summary to Slack
+        if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips Slack post. Reverted in the last commit before merging.
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -173,7 +175,7 @@ jobs:
               ]
             }
       - name: Fallback ping if any prior step failed
-        if: ${{ failure() }}
+        if: ${{ github.run_number == 0 }} # TODO: TEMPORARY Always false (run numbers start at 1); skips Slack ping. Reverted in the last commit before merging. Original: ${{ failure() }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

The `trigger-test-summary` job in `test-suite.yml` generates an AI summary of each daily Test Suite run and posts it to Slack. That summary was write-once to Slack and not persisted anywhere machine-readable, and Slack bot/webhook posts are not indexable downstream, so the summary could not be reused by tooling or automation.

This change persists the generated summary in the GitHub Actions run, in addition to the existing Slack post: it writes the summary to `$GITHUB_STEP_SUMMARY` (rendered on the run's Summary page) and uploads it as a `summary` artifact (`summary.md`), retrievable with `gh run download <run_id> -n summary`. Retention follows the repo default. The existing Slack post and failure-fallback ping are unchanged.

Link to any related issue(s): CLOUDP-409584

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

<img width="1056" height="913" alt="example" src="https://github.com/user-attachments/assets/f6eb5e67-0383-402c-938d-c29d1296e02f" />


