### PR TITLE
chore: Automate Azure VNet peering cleanup to prevent flaky network peering tests

### DIFF
--- a/.agents/skills/summarize-test-suite/SKILL.md
+++ b/.agents/skills/summarize-test-suite/SKILL.md
@@ -53,17 +53,6 @@ Special cases (do not apply the simple rule):
 - `config_sa_mig` runs the same packages as the `config` group, but only the migration tests, in SA-auth mode.
 - `clean-before` / `clean-after` are cleanup utilities under `internal/testutil/clean/`, **not** provider code. Failures in these never count as code regressions.
 
-## Well-known manual fixes
-
-Some failing tests have recurring root causes that aren't fully captured by category indicators alone. When a failing test name in the *current run* matches an entry below, surface the matching manual fix inline in the summary so on-call can act without re-investigating from scratch. Match strictly on test name within this run only — do not consult any other run.
-
-| Test name | Manual fix |
-|---|---|
-| `TestAccNetworkRSNetworkPeering_Azure` | Check for existing peering connections from a prior run. |
-| `TestAccEncryptionAtRest_azure_requirePrivateNetworking` | Ensure no active encryption-at-rest private-endpoint connections from a prior run. |
-
-When the *Known manual fixes* section is emitted, append a closing line `See team's internal wiki for more details.` after the per-test bullets, so on-call knows there's a deeper playbook to consult. Do not include any URL — the wiki is internal and the skill output ships through a public skill file; on-call already knows where to find the team wiki.
-
 ## Workflow
 
 ### Step 1: Run context and failed jobs
@@ -191,11 +180,6 @@ Use this when at least one failure is category 1.
 • Cleanup: <N> tests (incl. clean-before / clean-after)
 [only when present:] • Logs unavailable: `<job-name>` (failed after <N> min — logs inaccessible)
 
-[only when ≥1 failing test in this run matches the *Well-known manual fixes* table:]
-*Known manual fixes*:
-• `TestNameX` — <manual fix from the table>
-See team's internal wiki for more details.
-
 *Failing tests* (first 10): `TestName1`, `TestName2`, `TestA`, `TestB`, …, and 7 more
 
 [only when confidence is medium or low:]
@@ -219,11 +203,6 @@ Use this when every failure is category 2–5.
 • Timeout: <N> tests
 • Cleanup: <N> tests (incl. clean-before / clean-after)
 [only when present:] • Logs unavailable: `<job-name>` (failed after <N> min — logs inaccessible)
-
-[only when ≥1 failing test in this run matches the *Well-known manual fixes* table:]
-*Known manual fixes*:
-• `TestNameX` — <manual fix from the table>
-See team's internal wiki for more details.
 
 *Failing tests* (first 10): `TestA`, `TestB`, …, and 4 more
 
@@ -269,7 +248,6 @@ The shape of the second line is therefore always: `<confidence> confidence — <
 - Categories 2 to 5 (infrastructure noise): collapse to a single count line per category. Apply root-cause aggregation when ≥3 tests share the same error string.
 - Cap the *Failing tests* line at the first 10 test names, comma-separated (no bullets), positioned below the summary. If more than 10 failed, suffix with `, and N more` where N is the remaining count.
 - Use `<url|label>` for links.
-- *Known manual fixes*: emit only when at least one failing test name in this run matches the *Well-known manual fixes* table; one bullet per matching test, with the table's manual fix quoted verbatim, followed by a closing `See team's internal wiki for more details.` line. Do not invent manual fixes, and do not include any URL (the wiki reference must stay neutral).
 - Length budget is enforced by Step 6 below — see that step for the target, the hard cap, and the drop-priority list.
 
 ### Step 6: Length check (mandatory before returning)
@@ -285,10 +263,9 @@ printf '%s' "<your summary>" | wc -c
 If `wc -c` reports more than 2900, compress in this order, re-measuring after each step until the count is under the cap:
 
 1. Drop the *Why confidence* line **and** the paired `If this ambiguity recurs, …` nudge together if confidence is medium (keep both on low — that's where they matter most). The two lines must always be present or absent together; never emit one without the other.
-2. Drop the *Known manual fixes* section if confidence is high (the agent already classified cleanly; the fixes are nice-to-have at that point).
-3. Compress the *TL;DR* to one short sentence.
-4. Reduce the *Failing tests* cap from 10 to 5 (suffix with `, and N more`).
-5. Collapse *Other failures* bullets onto a single line, e.g., `*Other failures*: Cloud capacity 5, Timeout 12, Cleanup 3`.
+2. Compress the *TL;DR* to one short sentence.
+3. Reduce the *Failing tests* cap from 10 to 5 (suffix with `, and N more`).
+4. Collapse *Other failures* bullets onto a single line, e.g., `*Other failures*: Cloud capacity 5, Timeout 12, Cleanup 3`.
 
 ## Key Learnings
 
@@ -299,7 +276,6 @@ If `wc -c` reports more than 2900, compress in this order, re-measuring after ea
 - Cleanup-class indicators (CIDR overlap, `still exists`, leftover principal) are root causes; a timeout on the same test is their downstream symptom. Classify by root cause (category 5), not symptom.
 - When `gh api .../jobs/{id}/logs` returns 404 or empty, surface as "Logs unavailable" in the summary body and set confidence to medium — never guess the category.
 - HTTP 404 on a secondary step after a successful Create is eventual-consistency flake (category 4). Reserve category 3 for 404s on the initial Create or lookup.
-- Some failing tests have well-known recurring root causes — match the failing test name against the *Well-known manual fixes* table and surface the matching manual fix when applicable.
 - `unexpected state 'FAILED', wanted target '...'` from terraform-plugin-sdk's retry helper is a category 3 polled-state failure: Atlas reported a terminal failure during state polling. Don't conflate with category 4 timeouts (no `timeout while waiting`) or category 1 (no provider bug).
 - Cross-cloud propagation lag (Atlas creates an identity, GCP / AWS / Azure returns "does not exist" on it shortly after) is category 4 (eventual-consistency flake), not category 3 — same shape as the within-Atlas 404 case but the HTTP code may be 400 because the downstream cloud rejects the reference rather than the lookup itself.
 - Atlas-internal cross-resource propagation lag (e.g. a `stream_processor` step referencing a `stream_connection` created earlier in the same apply and getting `HTTP 400 STREAM_PROCESSOR_GENERIC_ERROR` _"connection X does not exist"_) is also category 4. The wire shape can be a non-404 HTTP code and a generic Atlas error code. The prior create is implicit (helpers fail loud, Terraform aborts on failed dependencies); the only check needed is name-match between the error and earlier creates — if the names don't match, it's a test misconfig (category 3).

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -1247,6 +1247,9 @@ jobs:
           AWS_SUBNET_ID: ${{ vars.AWS_SUBNET_ID }}
           AWS_SECURITY_GROUP_ID: ${{ vars.AWS_SECURITY_GROUP_ID }}
           AZURE_DIRECTORY_ID: ${{ secrets.azure_directory_id }}
+          AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
+          AZURE_CLIENT_ID: ${{ secrets.azure_client_id }}
+          AZURE_APP_SECRET: ${{ secrets.azure_app_secret }}
           AZURE_RESOURCE_GROUP_NAME: ${{ secrets.azure_resource_group_name }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.azure_subscription_id }}
           AZURE_VNET_NAME: ${{ secrets.azure_vnet_name }}

--- a/internal/service/networkpeering/resource_test.go
+++ b/internal/service/networkpeering/resource_test.go
@@ -38,7 +38,7 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t); acc.CleanAzurePeeringConnections(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,
 		Steps: []resource.TestStep{
@@ -85,7 +85,7 @@ func TestAccNetworkRSNetworkPeering_AzureFailedStatus(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t); acc.CleanAzurePeeringConnections(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,
 		Steps: []resource.TestStep{

--- a/internal/service/networkpeering/resource_test.go
+++ b/internal/service/networkpeering/resource_test.go
@@ -37,7 +37,7 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 		providerName      = "AZURE"
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t); acc.CleanAzurePeeringConnections(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,
@@ -84,7 +84,7 @@ func TestAccNetworkRSNetworkPeering_AzureFailedStatus(t *testing.T) {
 		providerName      = "AZURE"
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t); acc.CleanAzurePeeringConnections(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,

--- a/internal/testutil/acc/azure.go
+++ b/internal/testutil/acc/azure.go
@@ -59,7 +59,8 @@ func cleanPeeringsForVNet(tb testing.TB, client *http.Client, subscriptionID, re
 			Name string `json:"name"`
 		} `json:"value"`
 	}
-	if err := json.NewDecoder(listResp.Body).Decode(&listResult); err != nil || len(listResult.Value) == 0 {
+	require.NoError(tb, json.NewDecoder(listResp.Body).Decode(&listResult), "decode peerings response for vnet %s", vnetName)
+	if len(listResult.Value) == 0 {
 		return
 	}
 	for _, p := range listResult.Value {

--- a/internal/testutil/acc/azure.go
+++ b/internal/testutil/acc/azure.go
@@ -1,0 +1,74 @@
+package acc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const azureManagementAPIVersion = "2024-01-01"
+
+// CleanAzurePeeringConnections deletes any dangling Azure VNet peering connections
+// left by previous test runs. Called in PreCheck of Azure network peering tests.
+// Silently returns if required env vars are not set.
+func CleanAzurePeeringConnections(tb testing.TB) {
+	tb.Helper()
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	clientSecret := os.Getenv("AZURE_APP_SECRET")
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	resourceGroupName := os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+	if tenantID == "" || clientID == "" || clientSecret == "" || subscriptionID == "" || resourceGroupName == "" {
+		return
+	}
+	conf := &clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID),
+		Scopes:       []string{"https://management.azure.com/.default"},
+	}
+	httpClient := conf.Client(context.Background())
+	for _, vnetName := range []string{os.Getenv("AZURE_VNET_NAME"), os.Getenv("AZURE_VNET_NAME_UPDATED")} {
+		if vnetName == "" {
+			continue
+		}
+		cleanPeeringsForVNet(tb, httpClient, subscriptionID, resourceGroupName, vnetName)
+	}
+}
+
+func cleanPeeringsForVNet(tb testing.TB, client *http.Client, subscriptionID, resourceGroupName, vnetName string) {
+	tb.Helper()
+	baseURL := fmt.Sprintf(
+		"https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/virtualNetworkPeerings",
+		subscriptionID, resourceGroupName, vnetName,
+	)
+	listReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"?api-version="+azureManagementAPIVersion, http.NoBody)
+	require.NoError(tb, err)
+	listResp, err := client.Do(listReq)
+	require.NoError(tb, err)
+	defer listResp.Body.Close()
+	require.Equal(tb, http.StatusOK, listResp.StatusCode, "list peerings for vnet %s", vnetName)
+	var listResult struct {
+		Value []struct {
+			Name string `json:"name"`
+		} `json:"value"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&listResult); err != nil || len(listResult.Value) == 0 {
+		return
+	}
+	for _, p := range listResult.Value {
+		deleteURL := fmt.Sprintf("%s/%s?api-version=%s", baseURL, p.Name, azureManagementAPIVersion)
+		delReq, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, deleteURL, http.NoBody)
+		require.NoError(tb, err)
+		delResp, err := client.Do(delReq)
+		require.NoError(tb, err)
+		delResp.Body.Close()
+		require.Less(tb, delResp.StatusCode, 300, "delete peering %s in vnet %s", p.Name, vnetName)
+	}
+}


### PR DESCRIPTION
## Description

Automate Azure VNet peering cleanup to prevent flaky network peering tests. When a run fails, dangling connections in the shared test VNets require manual portal cleanup. `CleanAzurePeeringConnections` in `PreCheck` deletes them via the Azure management API. Both tests are also serialized to prevent their `PreCheck`s from racing.

Also adds missing CI env vars (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_APP_SECRET`) to the network job and removes stale entries from the `summarize-test-suite` skill.

Link to any related issue(s): CLOUDP-258699

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments