### PR TITLE
chore: Revert "chore: Normalize stream processor pipeline JSON numbers to prevent spurious diffs"

### DIFF
--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -3,7 +3,6 @@ package streamprocessor
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -208,44 +207,18 @@ func convertDlqToTF(ctx context.Context, dlq *admin.StreamsDLQ) (*types.Object, 
 	return &dlqObject, nil
 }
 func convertPipelineToTF(pipeline []any) (jsontypes.Normalized, diag.Diagnostics) {
-	// Atlas returns whole numbers in pipeline as doubles (e.g. 10.0). Normalize json.Number values to avoid spurious plan diffs.
-	pipelineJSON, err := json.Marshal(NormalizeNumbers(pipeline))
+	pipelineJSON, err := json.Marshal(pipeline)
 	if err != nil {
 		return jsontypes.NewNormalizedValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal pipeline", err.Error())}
 	}
 	return jsontypes.NewNormalizedValue(string(pipelineJSON)), nil
 }
 
-func NormalizeNumbers(v any) any {
-	switch val := v.(type) {
-	case json.Number:
-		return normalizeNumber(val)
-	case []any:
-		for i, elem := range val {
-			val[i] = NormalizeNumbers(elem)
-		}
-	case map[string]any:
-		for k, elem := range val {
-			val[k] = NormalizeNumbers(elem)
-		}
-	}
-	return v
-}
-
-func normalizeNumber(n json.Number) json.Number {
-	s := string(n)
-	if idx := strings.IndexByte(s, '.'); idx != -1 && strings.TrimLeft(s[idx+1:], "0") == "" {
-		return json.Number(s[:idx])
-	}
-	return n
-}
-
 func convertStatsToTF(stats any) (types.String, diag.Diagnostics) {
 	if stats == nil {
 		return types.StringNull(), nil
 	}
-	// Normalize json.Number values as in pipeline.
-	statsJSON, err := json.Marshal(NormalizeNumbers(stats))
+	statsJSON, err := json.Marshal(stats)
 	if err != nil {
 		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal stats", err.Error())}
 	}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -484,36 +484,3 @@ func TestGetWorkspaceOrInstanceName(t *testing.T) {
 		})
 	}
 }
-
-func TestNormalizeNumbers(t *testing.T) {
-	testCases := map[string]struct {
-		input    any
-		expected any
-	}{
-		"whole float normalized": {
-			input:    json.Number("10.0"),
-			expected: json.Number("10"),
-		},
-		"non-zero fractional preserved": {
-			input:    json.Number("10.5"),
-			expected: json.Number("10.5"),
-		},
-		"integer unchanged": {
-			input:    json.Number("10"),
-			expected: json.Number("10"),
-		},
-		"nested map normalized": {
-			input:    map[string]any{"interval": map[string]any{"size": json.Number("10.0"), "count": json.Number("10"), "ratio": json.Number("10.5")}},
-			expected: map[string]any{"interval": map[string]any{"size": json.Number("10"), "count": json.Number("10"), "ratio": json.Number("10.5")}},
-		},
-		"slice normalized": {
-			input:    []any{json.Number("10.0"), json.Number("10"), json.Number("10.5")},
-			expected: []any{json.Number("10"), json.Number("10"), json.Number("10.5")},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, streamprocessor.NormalizeNumbers(tc.input))
-		})
-	}
-}


### PR DESCRIPTION
Reverts mongodb/terraform-provider-mongodbatlas#4447

This is a revert from GH UI, the Atlas issue has been fixed and acc tests are passing now.

Ticket: CLOUDP-406930