### PR TITLE
doc: DOCSP-57784 -- [TF] Add support for role_id field attribute in encryption_at_rest Azure provider

### DIFF
--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -107,28 +107,6 @@ For Azure environments using static credentials (`client_id`, `tenant_id`, and `
 The following example shows how to configure role-based authentication for Azure Key Vault by obtaining an Atlas-managed role through Cloud Provider Access and passing the resulting `role_id` to the encryption at rest configuration.
 
 ```terraform
-resource "mongodbatlas_cloud_provider_access_setup" "this" {
-  project_id    = var.atlas_project_id
-  provider_name = "AZURE"
-
-  azure_config {
-    atlas_azure_app_id   = var.atlas_azure_app_id
-    service_principal_id = var.azure_service_principal_id
-    tenant_id            = var.azure_tenant_id
-  }
-}
-
-resource "mongodbatlas_cloud_provider_access_authorization" "this" {
-  project_id = var.atlas_project_id
-  role_id    = mongodbatlas_cloud_provider_access_setup.this.role_id
-
-  azure {
-    atlas_azure_app_id   = var.atlas_azure_app_id
-    service_principal_id = var.azure_service_principal_id
-    tenant_id            = var.azure_tenant_id
-  }
-}
-
 resource "mongodbatlas_encryption_at_rest" "test" {
   project_id = var.atlas_project_id
 
@@ -136,11 +114,12 @@ resource "mongodbatlas_encryption_at_rest" "test" {
     enabled           = true
     azure_environment = "AZURE"
 
-    subscription_id     = var.azure_subscription_id
+    subscription_id = var.azure_subscription_id
+
     resource_group_name = var.azure_resource_group_name
     key_vault_name      = var.azure_key_vault_name
     key_identifier      = var.azure_key_identifier
-    role_id             = mongodbatlas_cloud_provider_access_authorization.this.role_id
+    role_id             = var.azure_role_id
   }
 }
 

--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -102,7 +102,33 @@ resource "mongodbatlas_encryption_at_rest" "default" {
 ```
 
 ### Configuring encryption at rest using customer key management in Azure
+For Azure environments using static credentials (`client_id`, `tenant_id`, and `secret`), we recommend migrating to role-based authentication. For more details see our [Migration Guide: Encryption at Rest (Azure) Client Credentials to Role-based Auth](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/encryption-at-rest-azure-role-based-migration).
+
+The following example shows how to configure role-based authentication for Azure Key Vault by obtaining an Atlas-managed role through Cloud Provider Access and passing the resulting `role_id` to the encryption at rest configuration.
+
 ```terraform
+resource "mongodbatlas_cloud_provider_access_setup" "this" {
+  project_id    = var.atlas_project_id
+  provider_name = "AZURE"
+
+  azure_config {
+    atlas_azure_app_id   = var.atlas_azure_app_id
+    service_principal_id = var.azure_service_principal_id
+    tenant_id            = var.azure_tenant_id
+  }
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "this" {
+  project_id = var.atlas_project_id
+  role_id    = mongodbatlas_cloud_provider_access_setup.this.role_id
+
+  azure {
+    atlas_azure_app_id   = var.atlas_azure_app_id
+    service_principal_id = var.azure_service_principal_id
+    tenant_id            = var.azure_tenant_id
+  }
+}
+
 resource "mongodbatlas_encryption_at_rest" "test" {
   project_id = var.atlas_project_id
 
@@ -110,12 +136,11 @@ resource "mongodbatlas_encryption_at_rest" "test" {
     enabled           = true
     azure_environment = "AZURE"
 
-    subscription_id = var.azure_subscription_id
-
+    subscription_id     = var.azure_subscription_id
     resource_group_name = var.azure_resource_group_name
     key_vault_name      = var.azure_key_vault_name
     key_identifier      = var.azure_key_identifier
-    role_id             = var.azure_role_id
+    role_id             = mongodbatlas_cloud_provider_access_authorization.this.role_id
   }
 }
 

--- a/templates/resources/encryption_at_rest.md.tmpl
+++ b/templates/resources/encryption_at_rest.md.tmpl
@@ -47,6 +47,10 @@ resource "mongodbatlas_encryption_at_rest" "default" {
 ```
 
 ### Configuring encryption at rest using customer key management in Azure
+For Azure environments using static credentials (`client_id`, `tenant_id`, and `secret`), we recommend migrating to role-based authentication. For more details see our [Migration Guide: Encryption at Rest (Azure) Client Credentials to Role-based Auth](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/encryption-at-rest-azure-role-based-migration).
+
+The following example shows how to configure role-based authentication for Azure Key Vault by obtaining an Atlas-managed role through Cloud Provider Access and passing the resulting `role_id` to the encryption at rest configuration.
+
 {{ tffile (printf "examples/%s/azure/main.tf" .Name )}}
 
 #### Manage Customer Keys with Azure Key Vault Over Private Endpoints


### PR DESCRIPTION
## Description

Updates the `mongodbatlas_encryption_at_rest` resource documentation to add context for the Azure Key Vault `role_id` field introduced in PR #4187. Adds a migration guide note and lead-in sentence to the Azure section in both the documentation template and the generated output, so readers understand how `role_id` fits into the role-based authentication flow and where to find migration instructions.

Link to any related issue(s): [DOCSP-57784](https://jira.mongodb.org/browse/DOCSP-57784)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
