### PR TITLE
fix: Treat HTTP 500 as transient in search deployment state polling

### DIFF
--- a/.changelog/4494.txt
+++ b/.changelog/4494.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_search_deployment: Treats HTTP 500 responses as transient during delete state polling, consistent with existing HTTP 503 handling, to avoid aborting the poller on intermittent backend errors
+resource/mongodbatlas_search_deployment: Treats HTTP 500 responses as transient during delete state polling
 ```

--- a/.changelog/4494.txt
+++ b/.changelog/4494.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_search_deployment: Treats HTTP 500 responses as transient during delete state polling
+resource/mongodbatlas_search_deployment: Treats HTTP 500 responses as transient during state polling
 ```

--- a/.changelog/4494.txt
+++ b/.changelog/4494.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_search_deployment: Treats HTTP 500 responses as transient during delete state polling, consistent with existing HTTP 503 handling, to avoid aborting the poller on intermittent backend errors
+```

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -56,7 +56,7 @@ func TestAccSearchDeployment_basic(t *testing.T) {
 	})
 }
 
-const deleteTimeout = 30 * time.Minute
+const deleteTimeout = 60 * time.Minute
 
 func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 	var (

--- a/internal/service/searchdeployment/state_transition.go
+++ b/internal/service/searchdeployment/state_transition.go
@@ -60,7 +60,7 @@ func searchDeploymentRefreshFunc(ctx context.Context, projectID, clusterName str
 			if validate.StatusNotFound(resp) && strings.Contains(err.Error(), SearchDeploymentDoesNotExistsError) {
 				return "", retrystrategy.RetryStrategyDeletedState, nil
 			}
-			if validate.StatusServiceUnavailable(resp) {
+			if validate.StatusServiceUnavailable(resp) || validate.StatusInternalServerError(resp) {
 				return "", retrystrategy.RetryStrategyUpdatingState, nil
 			}
 			return nil, "", err

--- a/internal/service/searchdeployment/state_transition_test.go
+++ b/internal/service/searchdeployment/state_transition_test.go
@@ -19,6 +19,7 @@ var (
 	updating = "UPDATING"
 	idle     = "IDLE"
 	unknown  = ""
+	sc400    = conversion.IntPtr(400)
 	sc404    = conversion.IntPtr(404)
 	sc500    = conversion.IntPtr(500)
 	sc503    = conversion.IntPtr(503)
@@ -72,7 +73,15 @@ func TestSearchDeploymentStateTransition(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Error when API responds with error",
+			name: "Error when API responds with non-transient HTTP error",
+			mockResponses: []response{
+				{statusCode: sc400, err: errors.New("bad request")},
+			},
+			expectedState: nil,
+			expectedError: true,
+		},
+		{
+			name: "Error when API responds with network error",
 			mockResponses: []response{
 				{err: errors.New("network error")},
 			},
@@ -117,7 +126,14 @@ func TestSearchDeploymentStateTransitionForDelete(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Error when API responds with error",
+			name: "Error when API responds with non-transient HTTP error",
+			mockResponses: []response{
+				{statusCode: sc400, err: errors.New("bad request")},
+			},
+			expectedError: true,
+		},
+		{
+			name: "Error when API responds with network error",
 			mockResponses: []response{
 				{err: errors.New("network error")},
 			},

--- a/internal/service/searchdeployment/state_transition_test.go
+++ b/internal/service/searchdeployment/state_transition_test.go
@@ -53,6 +53,16 @@ func TestSearchDeploymentStateTransition(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "Successful transition to IDLE with 500 error in between",
+			mockResponses: []response{
+				{state: &updating},
+				{statusCode: sc500, err: errors.New("Internal Server Error")},
+				{state: &idle},
+			},
+			expectedState: &idle,
+			expectedError: false,
+		},
+		{
 			name: "Error when transitioning to an unknown state",
 			mockResponses: []response{
 				{state: &updating},
@@ -64,7 +74,7 @@ func TestSearchDeploymentStateTransition(t *testing.T) {
 		{
 			name: "Error when API responds with error",
 			mockResponses: []response{
-				{statusCode: sc500, err: errors.New("Internal server error")},
+				{err: errors.New("network error")},
 			},
 			expectedState: nil,
 			expectedError: true,
@@ -98,9 +108,18 @@ func TestSearchDeploymentStateTransitionForDelete(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "Successful transition to DELETED with 500 error in between",
+			mockResponses: []response{
+				{state: &updating},
+				{statusCode: sc500, err: errors.New("Internal Server Error")},
+				{statusCode: sc404, err: errors.New(searchdeployment.SearchDeploymentDoesNotExistsError)},
+			},
+			expectedError: false,
+		},
+		{
 			name: "Error when API responds with error",
 			mockResponses: []response{
-				{statusCode: sc500, err: errors.New("Internal server error")},
+				{err: errors.New("network error")},
 			},
 			expectedError: true,
 		},


### PR DESCRIPTION
## Description

Treat HTTP 500 as transient in `search_deployment` state polling. `searchDeploymentRefreshFunc` (shared by create, update, and delete) already handled 503 but aborted on 500, causing spurious test failures during slow operations.

- `state_transition.go`: adds 500 alongside 503 in the transient check. Same precedent as `projectipaccesslist`.
- `resource_test.go`: increases `deleteTimeout` from 30 to 60 min for `TestAccSearchDeployment_timeoutTest` `PreConfig` cleanup waits.

**Same 503-only pattern in** (not changed, no observed 500s): `advanced_cluster`, `cluster`, `online_archive`, `cloud_backup_snapshot_export_bucket`, `serverless_instance`.

Link to any related issue(s): CLOUDP-411124

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments