### PR TITLE
chore: Add explicit permissions to release workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,8 @@ jobs:
       && needs.release-config.outputs.creates_new_tag == 'true'
       && needs.release-config.outputs.is_official_release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -124,6 +126,8 @@ jobs:
       && needs.release-config.outputs.creates_new_tag == 'true'
       && needs.release-config.outputs.is_official_release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -171,6 +175,9 @@ jobs:
       !cancelled()
       && !contains(needs.*.result, 'failure')
       && needs.release-config.outputs.runs_tests == 'true'
+    permissions:
+      id-token: write
+      contents: read
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:
@@ -212,6 +219,8 @@ jobs:
 
   compliance:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [ release-config, release ]
     if: >-
       !cancelled()
@@ -248,6 +257,8 @@ jobs:
       && needs.release-config.outputs.is_official_release == 'true'
       && needs.compliance.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -276,6 +287,7 @@ jobs:
       !cancelled()
       && needs.release.result == 'success'
       && needs.release-config.outputs.skip_jira != 'true'
+    permissions: {}
     secrets: inherit
     uses: ./.github/workflows/jira-release-version.yml
     with:


### PR DESCRIPTION
## Description

Addresses the 6 open CodeQL `actions/missing-workflow-permissions` alerts ([code scanning](https://github.com/mongodb/terraform-provider-mongodbatlas/security/code-scanning?query=is%3Aopen)) by adding explicit least-privilege `permissions` blocks to the remaining jobs in `release.yml`:

- `update-examples-reference-in-docs`, `update-changelog-header`, `generate-ssdlc-report`: `contents: read` (checkout only; commits are pushed via the APIx bot PAT, not the workflow token).
- `run-qa-acceptance-tests`: `id-token: write, contents: read`, matching what the called reusable workflow `acceptance-tests.yml` declares.
- `compliance`: `contents: write` (uploads the SBOM as a release artifact with `GITHUB_TOKEN`).
- `jira-release-version`: `permissions: {}`, matching the called reusable workflow `jira-release-version.yml` which already declares an empty token.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
