### PR TITLE
feat: Adds `roles` attribute to service_account_project_assignments data source

### DIFF
--- a/.changelog/4502.txt
+++ b/.changelog/4502.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/mongodbatlas_service_account_project_assignments: Adds `roles` attribute in `results`
+```

--- a/docs/data-sources/service_account_project_assignments.md
+++ b/docs/data-sources/service_account_project_assignments.md
@@ -62,5 +62,6 @@ output "service_account_assigned_projects" {
 Read-Only:
 
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project, also known as `groupId` in the official documentation.
+- `roles` (Set of String) A list of project roles assigned to the Service Account in this project.
 
 For more information, see [Return All Service Account Project Assignments](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-getorgserviceaccountgroups) in the MongoDB Atlas API documentation.

--- a/internal/serviceapi/serviceaccountprojectassignment/plural_data_source_schema.go
+++ b/internal/serviceapi/serviceaccountprojectassignment/plural_data_source_schema.go
@@ -32,6 +32,12 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 							Computed:            true,
 							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project, also known as `groupId` in the official documentation.",
 						},
+						"roles": dsschema.SetAttribute{
+							Computed:            true,
+							MarkdownDescription: "A list of project roles assigned to the Service Account in this project.",
+							CustomType:          customtypes.NewSetType[types.String](ctx),
+							ElementType:         types.StringType,
+						},
 					},
 				},
 			},
@@ -45,5 +51,6 @@ type TFPluralDSModel struct {
 	Results  customtypes.NestedListValue[TFPluralDSResultsModel] `tfsdk:"results" autogen:"omitjson"`
 }
 type TFPluralDSResultsModel struct {
-	ProjectId types.String `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
+	ProjectId types.String                       `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
+	Roles     customtypes.SetValue[types.String] `tfsdk:"roles" autogen:"omitjson"`
 }

--- a/internal/serviceapi/serviceaccountprojectassignment/resource_test.go
+++ b/internal/serviceapi/serviceaccountprojectassignment/resource_test.go
@@ -24,6 +24,7 @@ func TestAccServiceAccountProjectAssignment_singleAssignment(t *testing.T) {
 		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectIDs    = acc.MultipleProjectIDsExecution(t, 1)
 		resourceName0 = resourceName + "_0"
+		roles         = []string{"GROUP_OWNER", "GROUP_READ_ONLY"}
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,8 +33,8 @@ func TestAccServiceAccountProjectAssignment_singleAssignment(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(orgID, projectIDs, []string{"GROUP_OWNER", "GROUP_READ_ONLY"}),
-				Check:  checkBasic(projectIDs),
+				Config: configBasic(orgID, projectIDs, roles),
+				Check:  checkBasic(projectIDs, roles),
 			},
 			{
 				ResourceName:                         resourceName0,
@@ -52,6 +53,7 @@ func TestAccServiceAccountProjectAssignment_multipleAssignments(t *testing.T) {
 		projectIDs    = acc.MultipleProjectIDsExecution(t, 2)
 		resourceName0 = resourceName + "_0"
 		resourceName1 = resourceName + "_1"
+		roles         = []string{"GROUP_OWNER", "GROUP_READ_ONLY"}
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -60,8 +62,8 @@ func TestAccServiceAccountProjectAssignment_multipleAssignments(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(orgID, projectIDs, []string{"GROUP_OWNER", "GROUP_READ_ONLY"}),
-				Check:  checkBasic(projectIDs),
+				Config: configBasic(orgID, projectIDs, roles),
+				Check:  checkBasic(projectIDs, roles),
 			},
 			{
 				ResourceName:                         resourceName0,
@@ -123,9 +125,10 @@ func configBasic(orgID string, projectIDs, roles []string) string {
 	`, orgID, assignmentsStr.String(), resourceNamesStr)
 }
 
-func checkBasic(projectIDs []string) resource.TestCheckFunc {
+func checkBasic(projectIDs, roles []string) resource.TestCheckFunc {
+	rolesCount := strconv.Itoa(len(roles))
 	attrsSet := []string{"client_id", "project_id"}
-	attrsMap := map[string]string{"roles.#": "2"}
+	attrsMap := map[string]string{"roles.#": rolesCount}
 	checks := []resource.TestCheckFunc{}
 	for i := range projectIDs {
 		resourceName := fmt.Sprintf("%s_%d", resourceName, i)
@@ -137,13 +140,14 @@ func checkBasic(projectIDs []string) resource.TestCheckFunc {
 		))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr(dataSourcePluralName, "results.#", strconv.Itoa(len(projectIDs))))
-	for i := range projectIDs { // all assignments use the same roles so index-based checks are order-independent
+	for i := range projectIDs { // all assignments use the same roles, so index-based checks are order-independent.
 		checks = append(checks,
 			resource.TestCheckResourceAttrSet(dataSourcePluralName, fmt.Sprintf("results.%d.project_id", i)),
-			resource.TestCheckResourceAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.#", i), "2"),
-			resource.TestCheckTypeSetElemAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.*", i), "GROUP_OWNER"),
-			resource.TestCheckTypeSetElemAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.*", i), "GROUP_READ_ONLY"),
+			resource.TestCheckResourceAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.#", i), rolesCount),
 		)
+		for _, role := range roles {
+			checks = append(checks, resource.TestCheckTypeSetElemAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.*", i), role))
+		}
 	}
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }

--- a/internal/serviceapi/serviceaccountprojectassignment/resource_test.go
+++ b/internal/serviceapi/serviceaccountprojectassignment/resource_test.go
@@ -137,6 +137,14 @@ func checkBasic(projectIDs []string) resource.TestCheckFunc {
 		))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr(dataSourcePluralName, "results.#", strconv.Itoa(len(projectIDs))))
+	for i := range projectIDs { // all assignments use the same roles so index-based checks are order-independent
+		checks = append(checks,
+			resource.TestCheckResourceAttrSet(dataSourcePluralName, fmt.Sprintf("results.%d.project_id", i)),
+			resource.TestCheckResourceAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.#", i), "2"),
+			resource.TestCheckTypeSetElemAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.*", i), "GROUP_OWNER"),
+			resource.TestCheckTypeSetElemAttr(dataSourcePluralName, fmt.Sprintf("results.%d.roles.*", i), "GROUP_READ_ONLY"),
+		)
+	}
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 

--- a/tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
+++ b/tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
@@ -25666,7 +25666,7 @@ info:
   termsOfService: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
   title: MongoDB Atlas Administration API
   version: "2.0"
-  x-xgen-sha: c95c8952291967a1bbc06f6f0121a816baed16f7
+  x-xgen-sha: b8876cb0901b68bb1f12a801c197ccb5e6eb30c5
 openapi: 3.0.1
 paths:
   /api/atlas/v2:

--- a/tools/codegen/atlasapispec/raw-multi-version-api-spec.yml
+++ b/tools/codegen/atlasapispec/raw-multi-version-api-spec.yml
@@ -43621,7 +43621,7 @@ info:
     termsOfService: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
     title: MongoDB Atlas Administration API
     version: "2.0"
-    x-xgen-sha: c95c8952291967a1bbc06f6f0121a816baed16f7
+    x-xgen-sha: b8876cb0901b68bb1f12a801c197ccb5e6eb30c5
 openapi: 3.0.1
 paths:
     /api/atlas/v2:

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -1147,6 +1147,17 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 							PresentInAnyResponse: true,
 						},
 						{
+							TFSchemaName:             "list_string2",
+							TFModelName:              "ListString2",
+							APIName:                  "listString2",
+							ComputedOptionalRequired: codespec.Required,
+							// List overridden to list, no-op
+							CustomType:           codespec.NewCustomListType(codespec.String),
+							List:                 &codespec.ListAttribute{ElementType: codespec.String},
+							ReqBodyUsage:         codespec.AllRequestBodies,
+							PresentInAnyResponse: true,
+						},
+						{
 							TFSchemaName:             "set_string",
 							TFModelName:              "SetString",
 							APIName:                  "setString",
@@ -1154,6 +1165,17 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 							// Set overridden to list
 							CustomType:           codespec.NewCustomListType(codespec.String),
 							List:                 &codespec.ListAttribute{ElementType: codespec.String},
+							ReqBodyUsage:         codespec.AllRequestBodies,
+							PresentInAnyResponse: true,
+						},
+						{
+							TFSchemaName:             "set_string2",
+							TFModelName:              "SetString2",
+							APIName:                  "setString2",
+							ComputedOptionalRequired: codespec.Required,
+							// Set overridden to set, no-op
+							CustomType:           codespec.NewCustomSetType(codespec.String),
+							Set:                  &codespec.SetAttribute{ElementType: codespec.String},
 							ReqBodyUsage:         codespec.AllRequestBodies,
 							PresentInAnyResponse: true,
 						},

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -273,7 +273,7 @@ func requestOnlyRequiredOnCreateTransformation(attr *Attribute, _ *attrPaths, _ 
 func applyTypeOverride(override *config.Override, attr *Attribute) error {
 	switch *override.Type {
 	case config.Set:
-		if attr.Set != nil || attr.SetNested != nil { // no-op if the attribute already has the target type, e.g. an override applying to both the singular and plural data sources
+		if attr.Set != nil || attr.SetNested != nil { // no-op if the attribute already has the target type, for example, an override applying to both the singular and plural data sources.
 			return nil
 		}
 		if attr.List != nil {

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -273,6 +273,9 @@ func requestOnlyRequiredOnCreateTransformation(attr *Attribute, _ *attrPaths, _ 
 func applyTypeOverride(override *config.Override, attr *Attribute) error {
 	switch *override.Type {
 	case config.Set:
+		if attr.Set != nil || attr.SetNested != nil { // no-op if the attribute already has the target type, e.g. an override applying to both the singular and plural data sources
+			return nil
+		}
 		if attr.List != nil {
 			if attr.CustomType != nil {
 				attr.CustomType = NewCustomSetType(attr.List.ElementType)
@@ -290,6 +293,9 @@ func applyTypeOverride(override *config.Override, attr *Attribute) error {
 			return nil
 		}
 	case config.List:
+		if attr.List != nil || attr.ListNested != nil {
+			return nil
+		}
 		if attr.Set != nil {
 			if attr.CustomType != nil {
 				attr.CustomType = NewCustomListType(attr.Set.ElementType)

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -1297,7 +1297,16 @@ components:
           type: array
           items:
             type: string
+        listString2:
+          type: array
+          items:
+            type: string
         setString:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        setString2:
           type: array
           items:
             type: string
@@ -1305,7 +1314,9 @@ components:
       required:
         - flag
         - listString
+        - listString2
         - setString
+        - setString2
     SimpleTestResource:
       type: object
       properties:

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -82,8 +82,12 @@ resources:
       overrides:
         list_string:
           type: set
+        list_string2:
+          type: list # no-op, attribute already has the target type
         set_string:
           type: list
+        set_string2:
+          type: set # no-op, attribute already has the target type
 
   test_dynamic_json_properties:
     create:

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -1162,6 +1162,8 @@ resources:
             description: *org_id_description
           project_id:
             description: *project_id_description
+          roles:
+            type: set # Align with the roles attribute in the resource and singular data source, the API spec lacks uniqueItems for this property.
 
   project_ip_access_list:
     datasources:

--- a/tools/codegen/models/service_account_project_assignment.yaml
+++ b/tools/codegen/models/service_account_project_assignment.yaml
@@ -134,6 +134,22 @@ data_sources:
                           create_only: false
                           present_in_any_response: false
                           request_only_required_on_create: false
+                        - set:
+                            element_type: 4
+                          description: A list of project roles assigned to the Service Account in this project.
+                          custom_type:
+                            package: customtypes
+                            model: customtypes.SetValue[types.String]
+                            schema: customtypes.NewSetType[types.String](ctx)
+                          computed_optional_required: computed
+                          tf_schema_name: roles
+                          tf_model_name: Roles
+                          api_name: roles
+                          req_body_usage: omit_always
+                          sensitive: false
+                          create_only: false
+                          present_in_any_response: false
+                          request_only_required_on_create: false
               description: List of returned documents that MongoDB Cloud provides when completing this request.
               custom_type:
                 package: customtypes


### PR DESCRIPTION
## Description

This PR incorporates the change surfaced by autogen visibility PR #4484: each `results` element of the
`mongodbatlas_service_account_project_assignments` data source now exposes the project `roles`.

- `roles` is generated as a **Set** to align with the resource and singular data source, via a `type: set` override in `tools/codegen/config.yml` (the API spec lacks `uniqueItems: true` on `ServiceAccountGroup.roles`).
- Codegen: collection type overrides are now a no-op when the attribute already has the target type. Needed because override keys are matched after stripping the `results.` prefix, so the `roles` override also reaches the singular data source where `roles` is already a Set (previously a hard error).
- Acceptance tests assert `results.*.roles` in the plural data source checks; regenerated docs and added changelog entry.

Note: a follow-up PR can align `overrides` with how `aliases`/`ignores` handle plural paths by requiring full paths (e.g. `results.roles`) instead of stripping the prefix; today `results.`-prefixed override keys are silently ignored.

Link to any related issue(s): CLOUDP-413373

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
