### PR TITLE
chore: Support x-xgen-array-semantic extension in terraform autogen for list vs set typing

### DIFF
--- a/tools/codegen/codespec/api_spec_schema.go
+++ b/tools/codegen/codespec/api_spec_schema.go
@@ -1,6 +1,8 @@
 package codespec
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"slices"
 
@@ -9,6 +11,18 @@ import (
 )
 
 const discriminatorExtensionKey = "x-xgen-discriminator"
+
+const arraySemanticExtensionKey = "x-xgen-array-semantic"
+
+const (
+	arraySemanticList = "list"
+	arraySemanticSet  = "set"
+)
+
+// ErrInvalidArraySemantic is returned when the x-xgen-array-semantic extension carries a value
+// other than "list" or "set". It is a sentinel so callers can distinguish a malformed extension
+// (which must fail generation) from a response/parameter schema that simply could not be mapped.
+var ErrInvalidArraySemantic = errors.New("invalid " + arraySemanticExtensionKey + " value")
 
 // DiscriminatorExtension represents the raw x-xgen-discriminator extension as declared in the OpenAPI spec.
 type DiscriminatorExtension struct {
@@ -84,4 +98,29 @@ func (s *APISpecSchema) GetXGenDiscriminator() *DiscriminatorExtension {
 	}
 
 	return &result
+}
+
+// GetXGenArraySemantic returns the declared array semantic ("list" or "set"), or nil if the
+// extension is absent. It returns an error wrapping ErrInvalidArraySemantic when the value is
+// malformed or not one of the allowed values, so generation fails wherever the property appears.
+func (s *APISpecSchema) GetXGenArraySemantic() (*string, error) {
+	if s.Schema.Extensions == nil {
+		return nil, nil
+	}
+
+	node, ok := s.Schema.Extensions.Get(arraySemanticExtensionKey)
+	if !ok || node == nil {
+		return nil, nil
+	}
+
+	var value string
+	if err := node.Decode(&value); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidArraySemantic, err)
+	}
+
+	if value != arraySemanticList && value != arraySemanticSet {
+		return nil, fmt.Errorf("%w: %q, expected %q or %q", ErrInvalidArraySemantic, value, arraySemanticList, arraySemanticSet)
+	}
+
+	return &value, nil
 }

--- a/tools/codegen/codespec/api_spec_test.go
+++ b/tools/codegen/codespec/api_spec_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/codespec"
 )
 
@@ -127,6 +128,65 @@ func TestBuildSchema(t *testing.T) {
 				assert.Contains(t, err.Error(), tc.errorContains)
 				assert.Nil(t, result)
 			}
+		})
+	}
+}
+
+func TestGetXGenArraySemantic(t *testing.T) {
+	tests := map[string]struct {
+		expectedValue    *string
+		schemaDefinition string
+		expectInvalid    bool
+	}{
+		"absent extension returns nil": {
+			schemaDefinition: `      type: array
+      items:
+        type: string`,
+			expectedValue: nil,
+		},
+		"set value": {
+			schemaDefinition: `      type: array
+      x-xgen-array-semantic: set
+      items:
+        type: string`,
+			expectedValue: conversion.StringPtr("set"),
+		},
+		"list value": {
+			schemaDefinition: `      type: array
+      x-xgen-array-semantic: list
+      items:
+        type: string`,
+			expectedValue: conversion.StringPtr("list"),
+		},
+		"invalid value returns sentinel error": {
+			schemaDefinition: `      type: array
+      x-xgen-array-semantic: unordered
+      items:
+        type: string`,
+			expectInvalid: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			openAPIDoc := fmt.Sprintf(openAPIDocTemplate, tc.schemaDefinition)
+			doc, err := libopenapi.NewDocument([]byte(openAPIDoc))
+			require.NoError(t, err)
+			model, err := doc.BuildV3Model()
+			require.NoError(t, err)
+			schemaProxy := model.Model.Components.Schemas.GetOrZero("TestSchema")
+			require.NotNil(t, schemaProxy)
+			result, err := codespec.BuildSchema(schemaProxy)
+			require.NoError(t, err)
+
+			semantic, err := result.GetXGenArraySemantic()
+			if tc.expectInvalid {
+				require.ErrorIs(t, err, codespec.ErrInvalidArraySemantic)
+				assert.Nil(t, semantic)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedValue, semantic)
 		})
 	}
 }

--- a/tools/codegen/codespec/api_to_provider_spec_mapper.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper.go
@@ -150,7 +150,10 @@ func apiSpecResourceToCodeSpecModel(oasResource APISpecResource, resourceConfig 
 		if err != nil {
 			return nil, fmt.Errorf("failed to process create request attributes for %s: %w", name, err)
 		}
-		createResponseAttributes, _ = opResponseToAttributes(createOp, configuredVersion)
+		createResponseAttributes, _, err = opResponseToAttributes(createOp, configuredVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process create response attributes for %s: %w", name, err)
+		}
 	}
 
 	if resourceConfig.Update != nil && !resourceConfig.Update.SchemaIgnore {
@@ -160,7 +163,10 @@ func apiSpecResourceToCodeSpecModel(oasResource APISpecResource, resourceConfig 
 		}
 	}
 	if resourceConfig.Read != nil && !resourceConfig.Read.SchemaIgnore && readOp != nil {
-		readResponseAttributes, responseDisc = opResponseToAttributes(readOp, configuredVersion)
+		readResponseAttributes, responseDisc, err = opResponseToAttributes(readOp, configuredVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process read response attributes for %s: %w", name, err)
+		}
 	}
 
 	attributes := mergeAttributes(&attributeDefinitionSources{
@@ -287,9 +293,9 @@ func pathParamsToAttributes(createOp *high.Operation) Attributes {
 	return pathAttributes
 }
 
-func queryParamsToAttributes(op *high.Operation) Attributes {
+func queryParamsToAttributes(op *high.Operation) (Attributes, error) {
 	if op == nil {
-		return Attributes{}
+		return Attributes{}, nil
 	}
 
 	queryParams := op.Parameters
@@ -309,12 +315,17 @@ func queryParamsToAttributes(op *high.Operation) Attributes {
 		s.Schema.Description = param.Description
 		parameterAttribute, err := s.buildResourceAttr(paramName, "", Optional, false)
 		if err != nil {
+			// A malformed declarative-tooling extension must fail generation; other mapping failures
+			// stay tolerant (warn and drop) to preserve existing behavior.
+			if errors.Is(err, ErrInvalidArraySemantic) {
+				return nil, fmt.Errorf("query param %s could not be mapped: %w", paramName, err)
+			}
 			log.Printf("[WARN] Query param %s could not be mapped: %s", paramName, err)
 			continue
 		}
 		queryAttributes = append(queryAttributes, *parameterAttribute)
 	}
-	return queryAttributes
+	return queryAttributes, nil
 }
 
 func opRequestToAttributes(op *high.Operation, configuredVersion *string) (Attributes, *Discriminator, error) {
@@ -334,7 +345,7 @@ func opRequestToAttributes(op *high.Operation, configuredVersion *string) (Attri
 	return requestAttributes, extractDiscriminator(requestSchema), nil
 }
 
-func opResponseToAttributes(op *high.Operation, configuredVersion *string) (Attributes, *Discriminator) {
+func opResponseToAttributes(op *high.Operation, configuredVersion *string) (Attributes, *Discriminator, error) {
 	responseSchema, err := buildSchemaFromResponse(op, configuredVersion)
 	if err != nil {
 		if errors.Is(err, errSchemaNotFound) {
@@ -342,14 +353,19 @@ func opResponseToAttributes(op *high.Operation, configuredVersion *string) (Attr
 		} else {
 			log.Printf("[WARN] Operation response body schema could not be mapped (OperationId: %s): %s", op.OperationId, err)
 		}
-		return nil, nil
+		return nil, nil, nil
 	}
 	responseAttributes, err := buildResourceAttrs(responseSchema, "", false)
 	if err != nil {
+		// A malformed declarative-tooling extension must fail generation wherever it appears; other
+		// mapping failures stay tolerant (warn and drop) to preserve existing behavior.
+		if errors.Is(err, ErrInvalidArraySemantic) {
+			return nil, nil, fmt.Errorf("response attributes could not be mapped (OperationId: %s): %w", op.OperationId, err)
+		}
 		log.Printf("[WARN] Operation response body schema could not be mapped (OperationId: %s): %s", op.OperationId, err)
-		return nil, nil
+		return nil, nil, nil
 	}
-	return responseAttributes, extractDiscriminator(responseSchema)
+	return responseAttributes, extractDiscriminator(responseSchema), nil
 }
 
 func getAPISpecResource(spec *high.Document, resourceConfig *config.Resource, name string) (APISpecResource, error) {
@@ -461,7 +477,10 @@ func apiSpecToDataSourcesModel(spec *high.Document, resourceConfig *config.Resou
 			return nil, fmt.Errorf("unable to extract data source read operation: %w", err)
 		}
 
-		readResponseAttributes, singularDisc := opResponseToAttributes(oasReadOp, configuredVersion)
+		readResponseAttributes, singularDisc, err := opResponseToAttributes(oasReadOp, configuredVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process data source read response attributes: %w", err)
+		}
 		pathParams := pathParamsToAttributes(oasReadOp)
 		singularAttributes := mergeDataSourceAttributes(pathParams, readResponseAttributes, dsConfig.SchemaOptions.Aliases)
 
@@ -489,9 +508,16 @@ func apiSpecToDataSourcesModel(spec *high.Document, resourceConfig *config.Resou
 			return nil, fmt.Errorf("unable to extract data source read operation: %w", err)
 		}
 
-		readResponseAttributes, pluralDisc := opResponseToAttributes(oasListOp, configuredVersion)
+		readResponseAttributes, pluralDisc, err := opResponseToAttributes(oasListOp, configuredVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process data source list response attributes: %w", err)
+		}
 		params := pathParamsToAttributes(oasListOp)
-		params = append(params, queryParamsToAttributes(oasListOp)...)
+		queryParams, err := queryParamsToAttributes(oasListOp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process data source list query params: %w", err)
+		}
+		params = append(params, queryParams...)
 		pluralAttributes := mergeDataSourceAttributes(params, readResponseAttributes, dsConfig.SchemaOptions.Aliases)
 
 		listOp = &APIOperation{

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -1189,6 +1189,134 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 	assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 }
 
+func TestConvertToProviderSpec_arraySemanticExtension(t *testing.T) {
+	tc := convertToSpecTestCase{
+		inputOpenAPISpecPath: testDataAPISpecPath,
+		inputConfigPath:      testDataConfigPath,
+		inputResourceName:    "test_resource_with_array_semantic",
+
+		expectedResult: &codespec.Model{
+			Resources: []codespec.Resource{{
+				Schema: &codespec.Schema{
+					Description: conversion.StringPtr(testResourceDesc),
+					Attributes: codespec.Attributes{
+						{
+							TFSchemaName:             "group_id",
+							TFModelName:              "GroupId",
+							APIName:                  "groupId",
+							ComputedOptionalRequired: codespec.Required,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr(testPathParamDesc),
+							ReqBodyUsage:             codespec.OmitAlways,
+							CreateOnly:               true,
+						},
+						{
+							// uniqueItems heuristic would yield a set, but the extension wins → list
+							TFSchemaName:             "list_from_extension",
+							TFModelName:              "ListFromExtension",
+							APIName:                  "listFromExtension",
+							ComputedOptionalRequired: codespec.Required,
+							CustomType:               codespec.NewCustomListType(codespec.String),
+							List:                     &codespec.ListAttribute{ElementType: codespec.String},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+						{
+							TFSchemaName:             "nested_set_from_extension",
+							TFModelName:              "NestedSetFromExtension",
+							APIName:                  "nestedSetFromExtension",
+							ComputedOptionalRequired: codespec.Required,
+							CustomType:               codespec.NewCustomNestedSetType("NestedSetFromExtension"),
+							SetNested: &codespec.SetNestedAttribute{
+								NestedObject: codespec.NestedAttributeObject{
+									Attributes: codespec.Attributes{
+										{
+											TFSchemaName:             "inner_attr",
+											TFModelName:              "InnerAttr",
+											APIName:                  "innerAttr",
+											ComputedOptionalRequired: codespec.Optional,
+											String:                   &codespec.StringAttribute{},
+											ReqBodyUsage:             codespec.AllRequestBodies,
+											PresentInAnyResponse:     true,
+										},
+									},
+								},
+							},
+							ReqBodyUsage:         codespec.AllRequestBodies,
+							PresentInAnyResponse: true,
+						},
+						{
+							// extension declares set, but config.yml type override wins → list
+							TFSchemaName:             "overridden_to_list",
+							TFModelName:              "OverriddenToList",
+							APIName:                  "overriddenToList",
+							ComputedOptionalRequired: codespec.Required,
+							CustomType:               codespec.NewCustomListType(codespec.String),
+							List:                     &codespec.ListAttribute{ElementType: codespec.String},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+						{
+							// plain array (no format/uniqueItems), extension declares set → set
+							TFSchemaName:             "set_from_extension",
+							TFModelName:              "SetFromExtension",
+							APIName:                  "setFromExtension",
+							ComputedOptionalRequired: codespec.Required,
+							CustomType:               codespec.NewCustomSetType(codespec.String),
+							Set:                      &codespec.SetAttribute{ElementType: codespec.String},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+					},
+				},
+				Name:        "test_resource_with_array_semantic",
+				PackageName: "testresourcewitharraysemantic",
+				Operations: codespec.APIOperations{
+					Create: &codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceArraySemantic",
+						HTTPMethod: "POST",
+					},
+					Read: &codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceArraySemantic",
+						HTTPMethod: "GET",
+					},
+					Update: &codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceArraySemantic",
+						HTTPMethod: "PATCH",
+					},
+					Delete: &codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceArraySemantic",
+						HTTPMethod: "DELETE",
+					},
+					VersionHeader: "application/vnd.atlas.2023-01-01+json",
+				},
+			}},
+		},
+	}
+
+	result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, &tc.inputResourceName, nil)
+	require.NoError(t, err)
+	assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
+}
+
+func TestConvertToProviderSpec_arraySemanticExtension_invalidValue(t *testing.T) {
+	tests := map[string]string{
+		// invalid value carried in a request body schema
+		"invalid value in request schema": "test_resource_array_semantic_invalid_request",
+		// invalid value carried only in a response body schema (validates sentinel propagation
+		// out of opResponseToAttributes, which is otherwise tolerant of mapping failures)
+		"invalid value in response schema": "test_resource_array_semantic_invalid_response",
+	}
+
+	for name, resourceName := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := codespec.ToCodeSpecModel(testDataAPISpecPath, testDataConfigPath, &resourceName, nil)
+			require.ErrorIs(t, err, codespec.ErrInvalidArraySemantic)
+			assert.Contains(t, err.Error(), "x-xgen-array-semantic")
+		})
+	}
+}
+
 func TestConvertToProviderSpec_dynamicJSONProperties(t *testing.T) {
 	tc := convertToSpecTestCase{
 		inputOpenAPISpecPath: testDataAPISpecPath,

--- a/tools/codegen/codespec/attribute.go
+++ b/tools/codegen/codespec/attribute.go
@@ -216,17 +216,22 @@ func (s *APISpecSchema) buildArrayAttr(name, ancestorsName string, computability
 
 	itemSchema, err := BuildSchema(s.Schema.Items.A)
 	if err != nil {
-		return nil, fmt.Errorf("error while building nested schema: %s", name)
+		return nil, fmt.Errorf("error while building nested schema %s: %w", name, err)
 	}
 
 	isSet := s.Schema.Format == OASFormatSet || (s.Schema.UniqueItems != nil && *s.Schema.UniqueItems)
+	if semantic, err := s.GetXGenArraySemantic(); err != nil {
+		return nil, fmt.Errorf("property %q: %w", name, err)
+	} else if semantic != nil {
+		isSet = *semantic == arraySemanticSet // extension overrides the format/uniqueItems heuristic in both directions
+	}
 	tfModelName := stringcase.Capitalize(name)
 
 	if itemSchema.Type == OASTypeObject {
 		fullName := ancestorsName + tfModelName
 		objectAttributes, err := buildResourceAttrs(itemSchema, fullName, isFromRequest)
 		if err != nil {
-			return nil, fmt.Errorf("error while building nested schema: %s", name)
+			return nil, fmt.Errorf("error while building nested schema %s: %w", name, err)
 		}
 
 		nestedObject := NestedAttributeObject{
@@ -245,7 +250,7 @@ func (s *APISpecSchema) buildArrayAttr(name, ancestorsName string, computability
 
 	elemType, err := itemSchema.buildElementType()
 	if err != nil {
-		return nil, fmt.Errorf("error while building nested schema: %s", name)
+		return nil, fmt.Errorf("error while building nested schema %s: %w", name, err)
 	}
 
 	result := s.buildRegularCollectionAttribute(name, tfModelName, computability, isSet, elemType)

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -527,6 +527,172 @@ paths:
       summary: Enable the Test Resource feature for a project
       tags:
         - Test Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceArraySemantic":
+    get:
+      description: GET API description
+      operationId: getTestResourceArraySemantic
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              schema:
+                $ref: "#/components/schemas/TestResourceArraySemantic"
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the array-semantic test resource
+      tags:
+        - Test Resource
+    patch:
+      description: PATCH API description
+      operationId: updateTestResourceArraySemantic
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceArraySemantic"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Update the array-semantic test resource
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceArraySemantic
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceArraySemantic"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Create the array-semantic test resource
+      tags:
+        - Test Resource
+    delete:
+      description: DELETE API description
+      operationId: deleteTestResourceArraySemantic
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Delete the array-semantic test resource
+      tags:
+        - Test Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceArraySemanticInvalidRequest":
+    get:
+      description: GET API description
+      operationId: getTestResourceArraySemanticInvalidRequest
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the invalid-request array-semantic test resource
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceArraySemanticInvalidRequest
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceArraySemanticInvalid"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Create the invalid-request array-semantic test resource
+      tags:
+        - Test Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceArraySemanticInvalidResponse":
+    get:
+      description: GET API description
+      operationId: getTestResourceArraySemanticInvalidResponse
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              schema:
+                $ref: "#/components/schemas/TestResourceArraySemanticInvalid"
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the invalid-response array-semantic test resource
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceArraySemanticInvalidResponse
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              type: object
+              properties:
+                stringAttr:
+                  type: string
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Create the invalid-response array-semantic test resource
+      tags:
+        - Test Resource
   "/api/atlas/v2/dynamicJsonProperties":
     post:
       description: POST API description
@@ -1306,6 +1472,48 @@ components:
         - flag
         - listString
         - setString
+    TestResourceArraySemantic:
+      type: object
+      properties:
+        setFromExtension:
+          type: array
+          x-xgen-array-semantic: set
+          items:
+            type: string
+        listFromExtension:
+          type: array
+          uniqueItems: true
+          x-xgen-array-semantic: list
+          items:
+            type: string
+        nestedSetFromExtension:
+          type: array
+          x-xgen-array-semantic: set
+          items:
+            type: object
+            properties:
+              innerAttr:
+                type: string
+        overriddenToList:
+          type: array
+          x-xgen-array-semantic: set
+          items:
+            type: string
+      required:
+        - setFromExtension
+        - listFromExtension
+        - nestedSetFromExtension
+        - overriddenToList
+    TestResourceArraySemanticInvalid:
+      type: object
+      properties:
+        badArray:
+          type: array
+          x-xgen-array-semantic: unordered
+          items:
+            type: string
+      required:
+        - badArray
     SimpleTestResource:
       type: object
       properties:

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -85,6 +85,40 @@ resources:
         set_string:
           type: list
 
+  test_resource_with_array_semantic:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemantic
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemantic
+      method: GET
+    update:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemantic
+      method: PATCH
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemantic
+      method: DELETE
+    schema:
+      overrides:
+        overridden_to_list:
+          type: list
+
+  test_resource_array_semantic_invalid_request:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemanticInvalidRequest
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemanticInvalidRequest
+      method: GET
+
+  test_resource_array_semantic_invalid_response:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemanticInvalidResponse
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceArraySemanticInvalidResponse
+      method: GET
+
   test_dynamic_json_properties:
     create:
       path: /api/atlas/v2/dynamicJsonProperties


### PR DESCRIPTION
## Description

Consumes the new `x-xgen-array-semantic` OpenAPI extension in the autogen pipeline (`tools/codegen`): `set` generates a set-typed attribute, `list` (or absent) a list-typed one. Precedence is config.yml `type` override > extension > existing `format: set` / `uniqueItems` heuristics. An invalid value fails generation via a sentinel error (`ErrInvalidArraySemantic`) wherever it appears — request, response, or query-param schema.

Part of the IPA-131 declarative-tooling-extensions work (epic CLOUDP-356095). Tooling-only: no runtime resource or docs change, and existing generated resources are unaffected since no current spec carries the extension.

Note: the query-param invalid-value path uses the same sentinel wiring as request/response but isn't covered by a dedicated fixture — array-typed query params don't occur in the Atlas spec today.

Link to any related issue(s): CLOUDP-412579

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
