### PR TITLE
chore: Support x-xgen-server-computed-when-client-omitted extension in terraform autogen

### DIFF
--- a/tools/codegen/codespec/api_spec_schema.go
+++ b/tools/codegen/codespec/api_spec_schema.go
@@ -10,6 +10,8 @@ import (
 
 const discriminatorExtensionKey = "x-xgen-discriminator"
 
+const serverComputedWhenClientOmittedExtensionKey = "x-xgen-server-computed-when-client-omitted"
+
 // DiscriminatorExtension represents the raw x-xgen-discriminator extension as declared in the OpenAPI spec.
 type DiscriminatorExtension struct {
 	Mapping      map[string]DiscriminatorExtensionType `yaml:"mapping"`
@@ -84,4 +86,26 @@ func (s *APISpecSchema) GetXGenDiscriminator() *DiscriminatorExtension {
 	}
 
 	return &result
+}
+
+// GetXGenServerComputedWhenClientOmitted reports whether the property is annotated with the
+// x-xgen-server-computed-when-client-omitted extension set to true. Returns false if the extension
+// is absent or cannot be decoded.
+func (s *APISpecSchema) GetXGenServerComputedWhenClientOmitted() bool {
+	if s.Schema.Extensions == nil {
+		return false
+	}
+
+	node, ok := s.Schema.Extensions.Get(serverComputedWhenClientOmittedExtensionKey)
+	if !ok || node == nil {
+		return false
+	}
+
+	var value bool
+	if err := node.Decode(&value); err != nil {
+		log.Printf("[WARN] Failed to decode %s extension: %s", serverComputedWhenClientOmittedExtensionKey, err)
+		return false
+	}
+
+	return value
 }

--- a/tools/codegen/codespec/api_spec_test.go
+++ b/tools/codegen/codespec/api_spec_test.go
@@ -130,3 +130,46 @@ func TestBuildSchema(t *testing.T) {
 		})
 	}
 }
+
+func TestGetXGenServerComputedWhenClientOmitted(t *testing.T) {
+	tests := map[string]struct {
+		schemaDefinition string
+		expected         bool
+	}{
+		"absent extension returns false": {
+			schemaDefinition: `      type: string`,
+			expected:         false,
+		},
+		"true value": {
+			schemaDefinition: `      type: string
+      x-xgen-server-computed-when-client-omitted: true`,
+			expected: true,
+		},
+		"false value": {
+			schemaDefinition: `      type: string
+      x-xgen-server-computed-when-client-omitted: false`,
+			expected: false,
+		},
+		"non-boolean value returns false": {
+			schemaDefinition: `      type: string
+      x-xgen-server-computed-when-client-omitted: maybe`,
+			expected: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			openAPIDoc := fmt.Sprintf(openAPIDocTemplate, tc.schemaDefinition)
+			doc, err := libopenapi.NewDocument([]byte(openAPIDoc))
+			require.NoError(t, err)
+			model, err := doc.BuildV3Model()
+			require.NoError(t, err)
+			schemaProxy := model.Model.Components.Schemas.GetOrZero("TestSchema")
+			require.NotNil(t, schemaProxy)
+			result, err := codespec.BuildSchema(schemaProxy)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, result.GetXGenServerComputedWhenClientOmitted())
+		})
+	}
+}

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -1189,6 +1189,132 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 	assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 }
 
+func TestConvertToProviderSpec_serverComputedWhenClientOmittedExtension(t *testing.T) {
+	serverComputedOperations := codespec.APIOperations{
+		Create: &codespec.APIOperation{
+			Path:       "/api/atlas/v2/groups/{groupId}/testResourceServerComputed",
+			HTTPMethod: "POST",
+		},
+		Read: &codespec.APIOperation{
+			Path:       "/api/atlas/v2/groups/{groupId}/testResourceServerComputed",
+			HTTPMethod: "GET",
+		},
+		Update: &codespec.APIOperation{
+			Path:       "/api/atlas/v2/groups/{groupId}/testResourceServerComputed",
+			HTTPMethod: "PATCH",
+		},
+		Delete: &codespec.APIOperation{
+			Path:       "/api/atlas/v2/groups/{groupId}/testResourceServerComputed",
+			HTTPMethod: "DELETE",
+		},
+		VersionHeader: "application/vnd.atlas.2023-01-01+json",
+	}
+
+	groupIDAttr := codespec.Attribute{
+		TFSchemaName:             "group_id",
+		TFModelName:              "GroupId",
+		APIName:                  "groupId",
+		ComputedOptionalRequired: codespec.Required,
+		String:                   &codespec.StringAttribute{},
+		Description:              conversion.StringPtr(testPathParamDesc),
+		ReqBodyUsage:             codespec.OmitAlways,
+		CreateOnly:               true,
+	}
+
+	t.Run("extension maps optional fields to computed_optional and ignores boolean/required", func(t *testing.T) {
+		resourceName := "test_resource_with_server_computed"
+		expected := &codespec.Model{
+			Resources: []codespec.Resource{{
+				Schema: &codespec.Schema{
+					Description: conversion.StringPtr(testResourceDesc),
+					Attributes: codespec.Attributes{
+						{
+							// boolean property: extension ignored, stays optional
+							TFSchemaName:             "bool_computed_when_omitted",
+							TFModelName:              "BoolComputedWhenOmitted",
+							APIName:                  "boolComputedWhenOmitted",
+							ComputedOptionalRequired: codespec.Optional,
+							Bool:                     &codespec.BoolAttribute{},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+						{
+							// optional property: extension promotes to computed_optional
+							TFSchemaName:             "computed_when_omitted",
+							TFModelName:              "ComputedWhenOmitted",
+							APIName:                  "computedWhenOmitted",
+							ComputedOptionalRequired: codespec.ComputedOptional,
+							String:                   &codespec.StringAttribute{},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+						groupIDAttr,
+						{
+							TFSchemaName:             "nested_object",
+							TFModelName:              "NestedObject",
+							APIName:                  "nestedObject",
+							ComputedOptionalRequired: codespec.Required,
+							CustomType:               codespec.NewCustomObjectType("NestedObject"),
+							SingleNested: &codespec.SingleNestedAttribute{
+								NestedObject: codespec.NestedAttributeObject{
+									Attributes: codespec.Attributes{
+										{
+											// extension applies to nested optional fields too
+											TFSchemaName:             "inner_computed_when_omitted",
+											TFModelName:              "InnerComputedWhenOmitted",
+											APIName:                  "innerComputedWhenOmitted",
+											ComputedOptionalRequired: codespec.ComputedOptional,
+											String:                   &codespec.StringAttribute{},
+											ReqBodyUsage:             codespec.AllRequestBodies,
+											PresentInAnyResponse:     true,
+										},
+									},
+								},
+							},
+							ReqBodyUsage:         codespec.AllRequestBodies,
+							PresentInAnyResponse: true,
+						},
+						{
+							// required property: extension ignored, stays required
+							TFSchemaName:             "required_computed_when_omitted",
+							TFModelName:              "RequiredComputedWhenOmitted",
+							APIName:                  "requiredComputedWhenOmitted",
+							ComputedOptionalRequired: codespec.Required,
+							String:                   &codespec.StringAttribute{},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+							PresentInAnyResponse:     true,
+						},
+					},
+				},
+				Name:        resourceName,
+				PackageName: "testresourcewithservercomputed",
+				Operations:  serverComputedOperations,
+			}},
+		}
+
+		result, err := codespec.ToCodeSpecModel(testDataAPISpecPath, testDataConfigPath, &resourceName, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, result, "Expected result to match the specified structure")
+	})
+
+	t.Run("config computability override wins over extension", func(t *testing.T) {
+		resourceName := "test_resource_server_computed_config_override"
+		result, err := codespec.ToCodeSpecModel(testDataAPISpecPath, testDataConfigPath, &resourceName, nil)
+		require.NoError(t, err)
+		require.Len(t, result.Resources, 1)
+
+		var computedWhenOmitted *codespec.Attribute
+		for i := range result.Resources[0].Schema.Attributes {
+			if result.Resources[0].Schema.Attributes[i].TFSchemaName == "computed_when_omitted" {
+				computedWhenOmitted = &result.Resources[0].Schema.Attributes[i]
+			}
+		}
+		require.NotNil(t, computedWhenOmitted)
+		// extension would yield ComputedOptional, but the config override forces plain Optional
+		assert.Equal(t, codespec.Optional, computedWhenOmitted.ComputedOptionalRequired)
+	})
+}
+
 func TestConvertToProviderSpec_dynamicJSONProperties(t *testing.T) {
 	tc := convertToSpecTestCase{
 		inputOpenAPISpecPath: testDataAPISpecPath,

--- a/tools/codegen/codespec/attribute.go
+++ b/tools/codegen/codespec/attribute.go
@@ -3,6 +3,7 @@ package codespec
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/stringcase"
 	"github.com/pb33f/libopenapi/orderedmap"
@@ -26,7 +27,20 @@ func buildResourceAttrs(s *APISpecSchema, ancestorsName string, isFromRequest bo
 			continue
 		}
 
-		attribute, err := schema.buildResourceAttr(name, ancestorsName, s.GetComputability(name), isFromRequest)
+		computability := s.GetComputability(name)
+		if isFromRequest && schema.GetXGenServerComputedWhenClientOmitted() {
+			switch {
+			case schema.Type == OASTypeBoolean:
+				// booleans must default to false rather than carry this extension (see IPA-111)
+				log.Printf("[WARN] Ignoring %s on boolean property %q", serverComputedWhenClientOmittedExtensionKey, name)
+			case computability == Required:
+				log.Printf("[WARN] Ignoring %s on required property %q (kept required)", serverComputedWhenClientOmittedExtensionKey, name)
+			case computability == Optional:
+				computability = ComputedOptional
+			}
+		}
+
+		attribute, err := schema.buildResourceAttr(name, ancestorsName, computability, isFromRequest)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -527,6 +527,87 @@ paths:
       summary: Enable the Test Resource feature for a project
       tags:
         - Test Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceServerComputed":
+    get:
+      description: GET API description
+      operationId: getTestResourceServerComputed
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              schema:
+                $ref: "#/components/schemas/TestResourceServerComputed"
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the server-computed test resource
+      tags:
+        - Test Resource
+    patch:
+      description: PATCH API description
+      operationId: updateTestResourceServerComputed
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceServerComputed"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Update the server-computed test resource
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceServerComputed
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceServerComputed"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Create the server-computed test resource
+      tags:
+        - Test Resource
+    delete:
+      description: DELETE API description
+      operationId: deleteTestResourceServerComputed
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Delete the server-computed test resource
+      tags:
+        - Test Resource
   "/api/atlas/v2/dynamicJsonProperties":
     post:
       description: POST API description
@@ -1306,6 +1387,27 @@ components:
         - flag
         - listString
         - setString
+    TestResourceServerComputed:
+      type: object
+      properties:
+        computedWhenOmitted:
+          type: string
+          x-xgen-server-computed-when-client-omitted: true
+        boolComputedWhenOmitted:
+          type: boolean
+          x-xgen-server-computed-when-client-omitted: true
+        requiredComputedWhenOmitted:
+          type: string
+          x-xgen-server-computed-when-client-omitted: true
+        nestedObject:
+          type: object
+          properties:
+            innerComputedWhenOmitted:
+              type: string
+              x-xgen-server-computed-when-client-omitted: true
+      required:
+        - requiredComputedWhenOmitted
+        - nestedObject
     SimpleTestResource:
       type: object
       properties:

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -85,6 +85,40 @@ resources:
         set_string:
           type: list
 
+  test_resource_with_server_computed:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: GET
+    update:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: PATCH
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: DELETE
+
+  test_resource_server_computed_config_override:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: GET
+    update:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: PATCH
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/testResourceServerComputed
+      method: DELETE
+    schema:
+      overrides:
+        computed_when_omitted:
+          computability:
+            optional: true
+            computed: false
+
   test_dynamic_json_properties:
     create:
       path: /api/atlas/v2/dynamicJsonProperties


### PR DESCRIPTION
## Description

Consumes the new `x-xgen-server-computed-when-client-omitted` OpenAPI extension in the autogen pipeline (`tools/codegen`): when set on an optional request property, the generated attribute becomes Optional + Computed, preventing spurious drift when the client omits the field. The extension is ignored (with a warning) on boolean properties and on required properties. config.yml computability overrides still take precedence.

Out of scope: skipping the field on Update payloads when unchanged.

Part of the IPA-131 declarative-tooling-extensions work (epic CLOUDP-356095). Tooling-only: no runtime resource or docs change, and existing generated resources are unaffected since no current spec carries the extension.

Link to any related issue(s): CLOUDP-412580

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
