### PR TITLE
chore: Support x-xgen-server-computed-immutable extension in terraform autogen

### DIFF
--- a/tools/codegen/codespec/api_spec_schema.go
+++ b/tools/codegen/codespec/api_spec_schema.go
@@ -10,6 +10,8 @@ import (
 
 const discriminatorExtensionKey = "x-xgen-discriminator"
 
+const serverComputedImmutableExtensionKey = "x-xgen-server-computed-immutable"
+
 // DiscriminatorExtension represents the raw x-xgen-discriminator extension as declared in the OpenAPI spec.
 type DiscriminatorExtension struct {
 	Mapping      map[string]DiscriminatorExtensionType `yaml:"mapping"`
@@ -84,4 +86,26 @@ func (s *APISpecSchema) GetXGenDiscriminator() *DiscriminatorExtension {
 	}
 
 	return &result
+}
+
+// GetXGenServerComputedImmutable reports whether the property is annotated with the
+// x-xgen-server-computed-immutable extension set to true. Returns false if the extension is absent
+// or cannot be decoded.
+func (s *APISpecSchema) GetXGenServerComputedImmutable() bool {
+	if s.Schema.Extensions == nil {
+		return false
+	}
+
+	node, ok := s.Schema.Extensions.Get(serverComputedImmutableExtensionKey)
+	if !ok || node == nil {
+		return false
+	}
+
+	var value bool
+	if err := node.Decode(&value); err != nil {
+		log.Printf("[WARN] Failed to decode %s extension: %s", serverComputedImmutableExtensionKey, err)
+		return false
+	}
+
+	return value
 }

--- a/tools/codegen/codespec/api_spec_test.go
+++ b/tools/codegen/codespec/api_spec_test.go
@@ -130,3 +130,48 @@ func TestBuildSchema(t *testing.T) {
 		})
 	}
 }
+
+func TestGetXGenServerComputedImmutable(t *testing.T) {
+	tests := map[string]struct {
+		schemaDefinition string
+		expected         bool
+	}{
+		"absent extension returns false": {
+			schemaDefinition: `      type: string`,
+			expected:         false,
+		},
+		"true value": {
+			schemaDefinition: `      type: string
+      readOnly: true
+      x-xgen-server-computed-immutable: true`,
+			expected: true,
+		},
+		"false value": {
+			schemaDefinition: `      type: string
+      readOnly: true
+      x-xgen-server-computed-immutable: false`,
+			expected: false,
+		},
+		"non-boolean value returns false": {
+			schemaDefinition: `      type: string
+      x-xgen-server-computed-immutable: maybe`,
+			expected: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			openAPIDoc := fmt.Sprintf(openAPIDocTemplate, tc.schemaDefinition)
+			doc, err := libopenapi.NewDocument([]byte(openAPIDoc))
+			require.NoError(t, err)
+			model, err := doc.BuildV3Model()
+			require.NoError(t, err)
+			schemaProxy := model.Model.Components.Schemas.GetOrZero("TestSchema")
+			require.NotNil(t, schemaProxy)
+			result, err := codespec.BuildSchema(schemaProxy)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, result.GetXGenServerComputedImmutable())
+		})
+	}
+}

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -1189,6 +1189,81 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 	assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 }
 
+// findAttr returns the attribute with the given TFSchemaName, searching nested objects recursively.
+func findAttr(attrs codespec.Attributes, tfSchemaName string) *codespec.Attribute {
+	for i := range attrs {
+		if attrs[i].TFSchemaName == tfSchemaName {
+			return &attrs[i]
+		}
+		if nested := attrs[i].NestedObject(); nested != nil {
+			if found := findAttr(nested.Attributes, tfSchemaName); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+func TestConvertToProviderSpec_serverComputedImmutableExtension(t *testing.T) {
+	t.Run("readOnly fields get the flag, non-readOnly are ignored", func(t *testing.T) {
+		resourceName := "test_resource_with_immutable_computed"
+		result, err := codespec.ToCodeSpecModel(testDataAPISpecPath, testDataConfigPath, &resourceName, nil)
+		require.NoError(t, err)
+		require.Len(t, result.Resources, 1)
+		attrs := result.Resources[0].Schema.Attributes
+
+		// readOnly + extension → computed with the immutable plan modifier flag
+		fingerprint := findAttr(attrs, "fingerprint")
+		require.NotNil(t, fingerprint)
+		assert.Equal(t, codespec.Computed, fingerprint.ComputedOptionalRequired)
+		assert.True(t, fingerprint.ImmutableComputed)
+
+		// extension on a non-readOnly property is ignored
+		nonReadonly := findAttr(attrs, "non_readonly_immutable")
+		require.NotNil(t, nonReadonly)
+		assert.False(t, nonReadonly.ImmutableComputed)
+
+		// extension applies to nested readOnly properties and survives the merge
+		innerFingerprint := findAttr(attrs, "inner_fingerprint")
+		require.NotNil(t, innerFingerprint)
+		assert.Equal(t, codespec.Computed, innerFingerprint.ComputedOptionalRequired)
+		assert.True(t, innerFingerprint.ImmutableComputed)
+
+		// data source attributes never carry the resource-only plan modifier flag
+		require.NotNil(t, result.Resources[0].DataSources)
+		require.NotNil(t, result.Resources[0].DataSources.Singular)
+		dsFingerprint := findAttr(result.Resources[0].DataSources.Singular.Attributes, "fingerprint")
+		require.NotNil(t, dsFingerprint)
+		assert.False(t, dsFingerprint.ImmutableComputed)
+	})
+
+	t.Run("flag is dropped when the attribute does not resolve to computed", func(t *testing.T) {
+		// groupId is a required path param that also appears as a readOnly property carrying the
+		// extension in the response; the guard must clear the flag since it resolves to required.
+		resourceName := "test_resource_immutable_guard"
+		result, err := codespec.ToCodeSpecModel(testDataAPISpecPath, testDataConfigPath, &resourceName, nil)
+		require.NoError(t, err)
+		require.Len(t, result.Resources, 1)
+
+		groupID := findAttr(result.Resources[0].Schema.Attributes, "group_id")
+		require.NotNil(t, groupID)
+		assert.Equal(t, codespec.Required, groupID.ComputedOptionalRequired)
+		assert.False(t, groupID.ImmutableComputed)
+	})
+
+	t.Run("config immutable_computed override wins over extension", func(t *testing.T) {
+		resourceName := "test_resource_immutable_config_override"
+		result, err := codespec.ToCodeSpecModel(testDataAPISpecPath, testDataConfigPath, &resourceName, nil)
+		require.NoError(t, err)
+		require.Len(t, result.Resources, 1)
+
+		fingerprint := findAttr(result.Resources[0].Schema.Attributes, "fingerprint")
+		require.NotNil(t, fingerprint)
+		// extension would set the flag, but the config override forces it off
+		assert.False(t, fingerprint.ImmutableComputed)
+	})
+}
+
 func TestConvertToProviderSpec_dynamicJSONProperties(t *testing.T) {
 	tc := convertToSpecTestCase{
 		inputOpenAPISpecPath: testDataAPISpecPath,

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -1262,6 +1262,21 @@ func TestConvertToProviderSpec_serverComputedImmutableExtension(t *testing.T) {
 		// extension would set the flag, but the config override forces it off
 		assert.False(t, fingerprint.ImmutableComputed)
 	})
+
+	t.Run("flag is kept when the attribute resolves to computed_optional", func(t *testing.T) {
+		// cfgField is an optional request field with a default (computed_optional) that is also a
+		// readOnly property carrying the extension in the response; the guard must keep the flag
+		// because the attribute resolves to computed_optional, not required/optional.
+		resourceName := "test_resource_immutable_computed_optional"
+		result, err := codespec.ToCodeSpecModel(testDataAPISpecPath, testDataConfigPath, &resourceName, nil)
+		require.NoError(t, err)
+		require.Len(t, result.Resources, 1)
+
+		cfgField := findAttr(result.Resources[0].Schema.Attributes, "cfg_field")
+		require.NotNil(t, cfgField)
+		assert.Equal(t, codespec.ComputedOptional, cfgField.ComputedOptionalRequired)
+		assert.True(t, cfgField.ImmutableComputed)
+	})
 }
 
 func TestConvertToProviderSpec_dynamicJSONProperties(t *testing.T) {

--- a/tools/codegen/codespec/attribute.go
+++ b/tools/codegen/codespec/attribute.go
@@ -3,6 +3,7 @@ package codespec
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/stringcase"
 	"github.com/pb33f/libopenapi/orderedmap"
@@ -32,6 +33,13 @@ func buildResourceAttrs(s *APISpecSchema, ancestorsName string, isFromRequest bo
 		}
 
 		if attribute != nil {
+			if schema.GetXGenServerComputedImmutable() {
+				if schema.Schema.ReadOnly != nil && *schema.Schema.ReadOnly {
+					attribute.ImmutableComputed = true
+				} else {
+					log.Printf("[WARN] Ignoring %s on non-readOnly property %q", serverComputedImmutableExtensionKey, name)
+				}
+			}
 			objectAttributes = append(objectAttributes, *attribute)
 		}
 	}

--- a/tools/codegen/codespec/merge_attributes.go
+++ b/tools/codegen/codespec/merge_attributes.go
@@ -65,6 +65,9 @@ func updateAttrWithNewSource(existingAttr, newAttr *Attribute, reqBodyUsage Attr
 		existingAttr.Description = newAttr.Description
 	}
 
+	// the immutable-computed signal can be declared on any source for the property; preserve it if any source set it
+	existingAttr.ImmutableComputed = existingAttr.ImmutableComputed || newAttr.ImmutableComputed
+
 	// when property is in both request and response values computablity and reqBodyUsage will ignore information from response
 	if !isFromResponse {
 		existingAttr.ReqBodyUsage = reqBodyUsage
@@ -181,6 +184,12 @@ func updateNestedComputabilityAndReqBodyUsage(attrs *Attributes, parentIsCompute
 			attr.ReqBodyUsage = OmitAlways
 		}
 
+		// the immutable-computed plan modifier is only meaningful for computed attributes; drop it
+		// if the attribute ultimately resolved to required/optional (e.g. also a required path param)
+		if attr.ImmutableComputed && attr.ComputedOptionalRequired != Computed && attr.ComputedOptionalRequired != ComputedOptional {
+			attr.ImmutableComputed = false
+		}
+
 		attrIsComputed := attr.ComputedOptionalRequired == Computed
 		attrIsOmittedInReqBody := attr.ReqBodyUsage == OmitAlways
 
@@ -258,6 +267,8 @@ func mergeDataSourceAttributes(params, responseAttrs Attributes, aliases map[str
 func setAttributeComputedRecursive(attr *Attribute) {
 	attr.ComputedOptionalRequired = Computed
 	attr.ReqBodyUsage = OmitAlways
+	// the immutable-computed plan modifier is resource-only; data source schemas never emit plan modifiers
+	attr.ImmutableComputed = false
 
 	if nested := attr.NestedObject(); nested != nil {
 		for i := range nested.Attributes {

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -653,6 +653,87 @@ paths:
       summary: Create the immutable-computed guard test resource
       tags:
         - Test Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceImmutableComputedOptional":
+    get:
+      description: GET API description
+      operationId: getTestResourceImmutableComputedOptional
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              schema:
+                $ref: "#/components/schemas/TestResourceImmutableComputedOptionalResponse"
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the computed-optional immutable test resource
+      tags:
+        - Test Resource
+    patch:
+      description: PATCH API description
+      operationId: updateTestResourceImmutableComputedOptional
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceImmutableComputedOptionalRequest"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Update the computed-optional immutable test resource
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceImmutableComputedOptional
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceImmutableComputedOptionalRequest"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Create the computed-optional immutable test resource
+      tags:
+        - Test Resource
+    delete:
+      description: DELETE API description
+      operationId: deleteTestResourceImmutableComputedOptional
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Delete the computed-optional immutable test resource
+      tags:
+        - Test Resource
   "/api/atlas/v2/dynamicJsonProperties":
     post:
       description: POST API description
@@ -1462,6 +1543,22 @@ components:
           x-xgen-server-computed-immutable: true
         name:
           type: string
+    TestResourceImmutableComputedOptionalRequest:
+      type: object
+      properties:
+        # optional request field with a default resolves to computed_optional; the same field is
+        # readOnly + immutable in the response, so the merged attribute stays computed_optional
+        # while carrying the immutable flag (exercises the guard's computed_optional branch).
+        cfgField:
+          type: string
+          default: default-value
+    TestResourceImmutableComputedOptionalResponse:
+      type: object
+      properties:
+        cfgField:
+          type: string
+          readOnly: true
+          x-xgen-server-computed-immutable: true
     SimpleTestResource:
       type: object
       properties:

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -527,6 +527,132 @@ paths:
       summary: Enable the Test Resource feature for a project
       tags:
         - Test Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceImmutable":
+    get:
+      description: GET API description
+      operationId: getTestResourceImmutable
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              schema:
+                $ref: "#/components/schemas/TestResourceImmutable"
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the immutable-computed test resource
+      tags:
+        - Test Resource
+    patch:
+      description: PATCH API description
+      operationId: updateTestResourceImmutable
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceImmutable"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Update the immutable-computed test resource
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceImmutable
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceImmutable"
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Create the immutable-computed test resource
+      tags:
+        - Test Resource
+    delete:
+      description: DELETE API description
+      operationId: deleteTestResourceImmutable
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Delete the immutable-computed test resource
+      tags:
+        - Test Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceImmutableGuard":
+    get:
+      description: GET API description
+      operationId: getTestResourceImmutableGuard
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              schema:
+                $ref: "#/components/schemas/TestResourceImmutableGuard"
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the immutable-computed guard test resource
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceImmutableGuard
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+            x-xgen-version: 2023-01-01
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Create the immutable-computed guard test resource
+      tags:
+        - Test Resource
   "/api/atlas/v2/dynamicJsonProperties":
     post:
       description: POST API description
@@ -1306,6 +1432,36 @@ components:
         - flag
         - listString
         - setString
+    TestResourceImmutable:
+      type: object
+      properties:
+        fingerprint:
+          type: string
+          readOnly: true
+          x-xgen-server-computed-immutable: true
+        nonReadonlyImmutable:
+          type: string
+          x-xgen-server-computed-immutable: true
+        nestedObject:
+          type: object
+          properties:
+            innerName:
+              type: string
+            innerFingerprint:
+              type: string
+              readOnly: true
+              x-xgen-server-computed-immutable: true
+      required:
+        - nestedObject
+    TestResourceImmutableGuard:
+      type: object
+      properties:
+        groupId:
+          type: string
+          readOnly: true
+          x-xgen-server-computed-immutable: true
+        name:
+          type: string
     SimpleTestResource:
       type: object
       properties:

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -129,6 +129,20 @@ resources:
       path: /api/atlas/v2/groups/{groupId}/testResourceImmutableGuard
       method: GET
 
+  test_resource_immutable_computed_optional:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutableComputedOptional
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutableComputedOptional
+      method: GET
+    update:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutableComputedOptional
+      method: PATCH
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutableComputedOptional
+      method: DELETE
+
   test_dynamic_json_properties:
     create:
       path: /api/atlas/v2/dynamicJsonProperties

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -85,6 +85,50 @@ resources:
         set_string:
           type: list
 
+  test_resource_with_immutable_computed:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: GET
+    update:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: PATCH
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: DELETE
+    datasources:
+      read:
+        path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+        method: GET
+
+  test_resource_immutable_config_override:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: GET
+    update:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: PATCH
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutable
+      method: DELETE
+    schema:
+      overrides:
+        fingerprint:
+          immutable_computed: false
+
+  test_resource_immutable_guard:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutableGuard
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceImmutableGuard
+      method: GET
+
   test_dynamic_json_properties:
     create:
       path: /api/atlas/v2/dynamicJsonProperties


### PR DESCRIPTION
## Description

Consumes the new `x-xgen-server-computed-immutable` OpenAPI extension in the autogen pipeline (`tools/codegen`): when set on a `readOnly` property, the generated attribute gets the existing `ImmutableComputed` flag, which emits the `UseStateForUnknown` plan modifier to suppress "(known after apply)" plan noise. The extension is ignored (with a warning) on non-readOnly properties, the flag is dropped when the attribute does not resolve to computed (e.g. a field that is also a required path param), and it is cleared for data sources. config.yml `immutable_computed` overrides still take precedence.

Part of the IPA-131 declarative-tooling-extensions work (epic CLOUDP-356095). Tooling-only: no runtime resource or docs change, and existing generated resources are unaffected since no current spec carries the extension.

Link to any related issue(s): CLOUDP-412581

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
