### PR TITLE
chore: Revert "fix: Emit warning when use_effective_fields and auto-scaling are enabled and spec fields change"

### DIFF
--- a/.agents/skills/pr-and-documentation-standards/SKILL.md
+++ b/.agents/skills/pr-and-documentation-standards/SKILL.md
@@ -7,17 +7,6 @@ description: Standards for pull requests, documentation, and code review in this
 
 ## Pull Request Structure
 
-### PR Title Format
-
-PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/): `fix:`, `feat:`, `chore:`, `doc:`, `test:`, `refactor:`, `ci:`, etc. The subject after the colon must start with an uppercase letter.
-
-```text
-fix: Emit warning when use_effective_fields and auto-scaling are enabled
-feat: Add search deployment resource
-```
-
-Do **not** include a scope in parentheses (e.g. `fix(resource/mongodbatlas_advanced_cluster): ...`). The repo convention uses the bare prefix without a scope.
-
 ### Separate Refactoring from Feature Changes
 
 Avoid mixing refactoring with functional changes in the same PR. Reviewers need to clearly distinguish which changed lines are behavioral vs structural.

--- a/.agents/skills/pr-and-documentation-standards/SKILL.md
+++ b/.agents/skills/pr-and-documentation-standards/SKILL.md
@@ -7,6 +7,17 @@ description: Standards for pull requests, documentation, and code review in this
 
 ## Pull Request Structure
 
+### PR Title Format
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/): `fix:`, `feat:`, `chore:`, `doc:`, `test:`, `refactor:`, `ci:`, etc. The subject after the colon must start with an uppercase letter.
+
+```text
+fix: Emit warning when use_effective_fields and auto-scaling are enabled
+feat: Add search deployment resource
+```
+
+Do **not** include a scope in parentheses (e.g. `fix(resource/mongodbatlas_advanced_cluster): ...`). The repo convention uses the bare prefix without a scope.
+
 ### Separate Refactoring from Feature Changes
 
 Avoid mixing refactoring with functional changes in the same PR. Reviewers need to clearly distinguish which changed lines are behavioral vs structural.

--- a/.changelog/4405.txt
+++ b/.changelog/4405.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/mongodbatlas_advanced_cluster: Emits a warning during plan when `use_effective_fields` is true, auto-scaling is enabled, and `instance_size`, `disk_size_gb`, or `disk_iops` is modified, as Atlas silently ignores these changes in that combination
-```

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -2,10 +2,6 @@ package advancedcluster
 
 import (
 	"context"
-	"fmt"
-	"maps"
-	"slices"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -15,17 +11,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 )
 
-type RegionAutoScaling struct {
-	RCPrefix                string
-	ComputeEnabled          bool
-	DiskGBEnabled           bool
-	AnalyticsComputeEnabled bool
-}
-
 var (
-	// Spec fields that Atlas controls when auto-scaling is active.
-	autoScalingManagedSpecFields = []string{"instance_size", "disk_size_gb", "disk_iops"}
-
 	// Change mappings uses `attribute_name`, it doesn't care about the nested level.
 	attributeRootChangeMapping = map[string][]string{
 		"replication_specs":      {},
@@ -76,98 +62,6 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
-	configs := extractAutoScalingConfigs(ctx, diags, plan)
-	if !diags.HasError() {
-		WarnIgnoredSpecChange(diags, plan.UseEffectiveFields.ValueBool(), attributeChanges, configs)
-	}
-}
-
-// WarnIgnoredSpecChange warns when use_effective_fields=true, auto-scaling is enabled, and the user
-// changed instance_size, disk_size_gb, or disk_iops — fields Atlas silently ignores in that case.
-func WarnIgnoredSpecChange(diags *diag.Diagnostics, useEffectiveFields bool, attributeChanges schemafunc.AttributeChanges, configs []RegionAutoScaling) {
-	if !useEffectiveFields {
-		return
-	}
-	ignoredFields := collectIgnoredSpecChanges(attributeChanges, configs)
-	if len(ignoredFields) == 0 {
-		return
-	}
-	diags.AddWarning(
-		"Spec change ignored when use_effective_fields is true and auto-scaling is enabled",
-		fmt.Sprintf("Your changes to %s will be stored in Terraform state but will not modify the actual cluster in Atlas. "+
-			"When use_effective_fields is true and auto-scaling is enabled, Atlas controls instance_size, disk_size_gb, and disk_iops values. "+
-			"To apply your changes, disable auto-scaling and apply, then re-enable auto-scaling in a separate apply. "+
-			"See: https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster#manually-updating-specs-with-use_effective_fields",
-			strings.Join(ignoredFields, ", ")),
-	)
-}
-
-func collectIgnoredSpecChanges(attributeChanges schemafunc.AttributeChanges, configs []RegionAutoScaling) []string {
-	ignoredSet := map[string]struct{}{}
-	for _, cfg := range configs {
-		addIgnoredSpecChangesForRegionConfig(cfg, attributeChanges, ignoredSet)
-	}
-	if len(ignoredSet) == 0 {
-		return nil
-	}
-	return slices.Sorted(maps.Keys(ignoredSet))
-}
-
-// addIgnoredSpecChangesForRegionConfig adds field names that will be silently ignored by Atlas.
-// Per Atlas docs: when compute OR disk auto-scaling is enabled, Atlas ignores instanceSize, diskSizeGB, and diskIOPS
-// for electable and read-only nodes. For analytics nodes, only instanceSize is ignored (and only when compute is enabled).
-// https://www.mongodb.com/docs/atlas/cluster-autoscaling/#enhance-auto-scaling-with-effective-fields-in-terraform
-func addIgnoredSpecChangesForRegionConfig(cfg RegionAutoScaling, attributeChanges schemafunc.AttributeChanges, ignored map[string]struct{}) {
-	autoScalingActive := cfg.ComputeEnabled || cfg.DiskGBEnabled
-	electablePrefix := cfg.RCPrefix + ".electable_specs."
-	readOnlyPrefix := cfg.RCPrefix + ".read_only_specs."
-	analyticsPrefix := cfg.RCPrefix + ".analytics_specs."
-	for _, change := range attributeChanges {
-		switch {
-		case autoScalingActive && strings.HasPrefix(change, electablePrefix):
-			if field := strings.TrimPrefix(change, electablePrefix); slices.Contains(autoScalingManagedSpecFields, field) {
-				ignored[field] = struct{}{}
-			}
-		case autoScalingActive && strings.HasPrefix(change, readOnlyPrefix):
-			if field := strings.TrimPrefix(change, readOnlyPrefix); slices.Contains(autoScalingManagedSpecFields, field) {
-				ignored[field] = struct{}{}
-			}
-		case cfg.AnalyticsComputeEnabled && change == analyticsPrefix+"instance_size":
-			ignored["instance_size"] = struct{}{}
-		}
-	}
-}
-
-// extractAutoScalingConfigs reads per-region-config auto-scaling flags from the plan model.
-func extractAutoScalingConfigs(ctx context.Context, diags *diag.Diagnostics, plan *TFModel) []RegionAutoScaling {
-	planRepSpecs := TFModelList[TFReplicationSpecsModel](ctx, diags, plan.ReplicationSpecs)
-	if diags.HasError() {
-		return nil
-	}
-	var configs []RegionAutoScaling
-	for i := range planRepSpecs {
-		planRegionConfigs := TFModelList[TFRegionConfigsModel](ctx, diags, planRepSpecs[i].RegionConfigs)
-		if diags.HasError() {
-			return nil
-		}
-		for j := range planRegionConfigs {
-			regionConfig := &planRegionConfigs[j]
-			autoScaling := TFModelObject[TFAutoScalingModel](ctx, regionConfig.AutoScaling)
-			analyticsAutoScaling := TFModelObject[TFAutoScalingModel](ctx, regionConfig.AnalyticsAutoScaling)
-			cfg := RegionAutoScaling{
-				RCPrefix: fmt.Sprintf("replication_specs[%d].region_configs[%d]", i, j),
-			}
-			if autoScaling != nil {
-				cfg.ComputeEnabled = autoScaling.ComputeEnabled.ValueBool()
-				cfg.DiskGBEnabled = autoScaling.DiskGBEnabled.ValueBool()
-			}
-			if analyticsAutoScaling != nil {
-				cfg.AnalyticsComputeEnabled = analyticsAutoScaling.ComputeEnabled.ValueBool()
-			}
-			configs = append(configs, cfg)
-		}
-	}
-	return configs
 }
 
 // adjustRegionConfigsChildren modifies the planned values of region configs based on the current state.
@@ -274,26 +168,28 @@ func findDefinedElectableSpecInReplicationSpec(ctx context.Context, regionConfig
 }
 
 func determineKeepUnknownsAutoScaling(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) []string {
-	if !autoScalingUsed(ctx, diags, state) && !autoScalingUsed(ctx, diags, plan) {
+	if !autoScalingUsed(ctx, diags, state, plan) {
 		return nil
 	}
 	// When either compute or disk auto-scaling is enabled, all three fields may be adjusted by Atlas
-	return slices.Clone(autoScalingManagedSpecFields)
+	return []string{"instance_size", "disk_size_gb", "disk_iops"}
 }
 
-// autoScalingUsed checks if auto-scaling is enabled in the given cluster model.
-func autoScalingUsed(ctx context.Context, diags *diag.Diagnostics, model *TFModel) bool {
-	repSpecsTF := TFModelList[TFReplicationSpecsModel](ctx, diags, model.ReplicationSpecs)
-	for i := range repSpecsTF {
-		regiongConfigsTF := TFModelList[TFRegionConfigsModel](ctx, diags, repSpecsTF[i].RegionConfigs)
-		for j := range regiongConfigsTF {
-			for _, autoScalingTF := range []types.Object{regiongConfigsTF[j].AutoScaling, regiongConfigsTF[j].AnalyticsAutoScaling} {
-				autoscaling := TFModelObject[TFAutoScalingModel](ctx, autoScalingTF)
-				if autoscaling == nil {
-					continue
-				}
-				if autoscaling.ComputeEnabled.ValueBool() || autoscaling.DiskGBEnabled.ValueBool() {
-					return true
+// autoScalingUsed checks if auto-scaling was enabled (state) or will be enabled (plan).
+func autoScalingUsed(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) bool {
+	for _, model := range []*TFModel{state, plan} {
+		repSpecsTF := TFModelList[TFReplicationSpecsModel](ctx, diags, model.ReplicationSpecs)
+		for i := range repSpecsTF {
+			regiongConfigsTF := TFModelList[TFRegionConfigsModel](ctx, diags, repSpecsTF[i].RegionConfigs)
+			for j := range regiongConfigsTF {
+				for _, autoScalingTF := range []types.Object{regiongConfigsTF[j].AutoScaling, regiongConfigsTF[j].AnalyticsAutoScaling} {
+					autoscaling := TFModelObject[TFAutoScalingModel](ctx, autoScalingTF)
+					if autoscaling == nil {
+						continue
+					}
+					if autoscaling.ComputeEnabled.ValueBool() || autoscaling.DiskGBEnabled.ValueBool() {
+						return true
+					}
 				}
 			}
 		}

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -3,13 +3,10 @@ package advancedcluster_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/stretchr/testify/assert"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
 )
 
@@ -82,108 +79,4 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 			unit.MockPlanChecksAndRun(t, baseConfig.WithPlanCheckTest(testCase))
 		})
 	}
-}
-
-func TestAdvancedCluster_WarnIgnoredSpecChange(t *testing.T) {
-	const rc00 = "replication_specs[0].region_configs[0]"
-
-	testCases := map[string]struct {
-		attributeChanges []string
-		configs          []advancedcluster.RegionAutoScaling
-		expectWarning    bool
-	}{
-		"warns when compute auto-scaling on and electable instance_size changed": {
-			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
-			expectWarning:    true,
-		},
-		"warns when disk auto-scaling on and electable disk fields changed": {
-			attributeChanges: []string{rc00 + ".electable_specs.disk_size_gb", rc00 + ".electable_specs.disk_iops"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, DiskGBEnabled: true}},
-			expectWarning:    true,
-		},
-		"warns when compute auto-scaling on and electable disk_size_gb changed": {
-			attributeChanges: []string{rc00 + ".electable_specs.disk_size_gb"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
-			expectWarning:    true,
-		},
-		"warns when disk auto-scaling on and electable instance_size changed": {
-			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, DiskGBEnabled: true}},
-			expectWarning:    true,
-		},
-		"warns when compute auto-scaling on and read_only instance_size changed": {
-			attributeChanges: []string{rc00 + ".read_only_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
-			expectWarning:    true,
-		},
-		"warns when analytics compute auto-scaling on and analytics instance_size changed": {
-			attributeChanges: []string{rc00 + ".analytics_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, AnalyticsComputeEnabled: true}},
-			expectWarning:    true,
-		},
-		"no warning when auto-scaling is disabled": {
-			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00}},
-			expectWarning:    false,
-		},
-		"no warning when auto-scaling is on but no managed spec fields changed": {
-			attributeChanges: nil,
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
-			expectWarning:    false,
-		},
-		"no warning when auto-scaling is on but only node_count changed": {
-			attributeChanges: []string{rc00 + ".electable_specs.node_count"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
-			expectWarning:    false,
-		},
-		"no warning when only analytics compute auto-scaling on but electable instance_size changed": {
-			attributeChanges: []string{rc00 + ".electable_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, AnalyticsComputeEnabled: true}},
-			expectWarning:    false,
-		},
-		"no warning when only electable auto-scaling on but analytics instance_size changed": {
-			attributeChanges: []string{rc00 + ".analytics_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}},
-			expectWarning:    false,
-		},
-		"no warning when only electable auto-scaling on but analytics disk_size_gb changed": {
-			attributeChanges: []string{rc00 + ".analytics_specs.disk_size_gb"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, DiskGBEnabled: true}},
-			expectWarning:    false,
-		},
-		"no warning when analytics compute auto-scaling on and analytics disk_size_gb changed": {
-			attributeChanges: []string{rc00 + ".analytics_specs.disk_size_gb"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, AnalyticsComputeEnabled: true}},
-			expectWarning:    false,
-		},
-		"no warning when analytics instance_size changed without analytics compute auto-scaling": {
-			// Confirmed via repro: analytics disk_gb_enabled alone does not cause Atlas to ignore instance_size.
-			attributeChanges: []string{rc00 + ".analytics_specs.instance_size"},
-			configs:          []advancedcluster.RegionAutoScaling{{RCPrefix: rc00}},
-			expectWarning:    false,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var diags diag.Diagnostics
-			advancedcluster.WarnIgnoredSpecChange(&diags, true, tc.attributeChanges, tc.configs)
-			assert.False(t, diags.HasError())
-			if tc.expectWarning {
-				assert.Equal(t, 1, diags.WarningsCount())
-				assert.Contains(t, diags[0].Summary(), "Spec change ignored")
-			} else {
-				assert.Equal(t, 0, diags.WarningsCount())
-			}
-		})
-	}
-
-	t.Run("no warning when use_effective_fields is false", func(t *testing.T) {
-		var diags diag.Diagnostics
-		configs := []advancedcluster.RegionAutoScaling{{RCPrefix: rc00, ComputeEnabled: true}}
-		advancedcluster.WarnIgnoredSpecChange(&diags, false, []string{rc00 + ".electable_specs.instance_size"}, configs)
-		assert.False(t, diags.HasError())
-		assert.Equal(t, 0, diags.WarningsCount())
-	})
 }


### PR DESCRIPTION
Reverts mongodb/terraform-provider-mongodbatlas#4405.

Keep `pr-and-documentation-standards` skill changes.