### PR TITLE
chore: Pin SDK v20250312020 for maintenance_window wave assignment fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
+	go.mongodb.org/atlas-sdk/v20250312020 v20250312020.1.0
 	go.mongodb.org/atlas-sdk/v20250312021 v20250312021.0.0
 	golang.org/x/oauth2 v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,8 @@ go.mongodb.org/atlas-sdk/v20240530005 v20240530005.0.0 h1:d/gbYJ+obR0EM/3DZf7+ZM
 go.mongodb.org/atlas-sdk/v20240530005 v20240530005.0.0/go.mod h1:O47ZrMMfcWb31wznNIq2PQkkdoFoK0ea2GlmRqGJC2s=
 go.mongodb.org/atlas-sdk/v20241113005 v20241113005.0.0 h1:aaU2E4rtzYXuEDxv9MoSON2gOEAA9M2gsDf2CqjcGj8=
 go.mongodb.org/atlas-sdk/v20241113005 v20241113005.0.0/go.mod h1:eV9REWR36iVMrpZUAMZ5qPbXEatoVfmzwT+Ue8yqU+U=
+go.mongodb.org/atlas-sdk/v20250312020 v20250312020.1.0 h1:Ba+iX5yraZiwXGs6mCyjWxMDbs5bC7kLGYpHu3R8RGM=
+go.mongodb.org/atlas-sdk/v20250312020 v20250312020.1.0/go.mod h1:8OGHqMpalr/OTRHA9kjSSg2EKfig5lrNEeNaVYphYYo=
 go.mongodb.org/atlas-sdk/v20250312021 v20250312021.0.0 h1:bZYcZVnXNr7QO6uIRawTMxmEk2otUY4U3JC57DfKHgw=
 go.mongodb.org/atlas-sdk/v20250312021 v20250312021.0.0/go.mod h1:zp4x/Ub4/nYjlMRSSVd+IRr5AgZDE+tmBtRcTpNEPs4=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -12,6 +12,7 @@ import (
 
 	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
 	admin20241113 "go.mongodb.org/atlas-sdk/v20241113005/admin"
+	admin20250312020 "go.mongodb.org/atlas-sdk/v20250312020/admin" // TODO: Remove before merging to master.
 	"go.mongodb.org/atlas-sdk/v20250312021/admin"
 	matlasClient "go.mongodb.org/atlas/mongodbatlas"
 	realmAuth "go.mongodb.org/realm/auth"
@@ -105,14 +106,15 @@ func tfLoggingInterceptor(base http.RoundTripper) http.RoundTripper {
 
 // MongoDBClient contains the mongodbatlas clients and configurations.
 type MongoDBClient struct {
-	Atlas            *matlasClient.Client
-	AtlasV2          *admin.APIClient
-	AtlasPreview     *adminpreview.APIClient
-	AtlasV220240530  *admin20240530.APIClient // Used in cluster to support deprecated attributes default_read_concern and fail_index_key_too_long in advanced_configuration.
-	AtlasV220241113  *admin20241113.APIClient // Used in teams and atlas_users to avoid breaking changes. Also used for serverless instances and shared tier, whose APIs were sunset and are no longer available in newer SDK versions.
-	Realm            *RealmClient
-	BaseURL          string // Needed by organization resource.
-	TerraformVersion string // Needed by organization resource.
+	Atlas              *matlasClient.Client
+	AtlasV2            *admin.APIClient
+	AtlasPreview       *adminpreview.APIClient
+	AtlasV220240530    *admin20240530.APIClient    // Used in cluster to support deprecated attributes default_read_concern and fail_index_key_too_long in advanced_configuration.
+	AtlasV220241113    *admin20241113.APIClient    // Used in teams and atlas_users to avoid breaking changes. Also used for serverless instances and shared tier, whose APIs were sunset and are no longer available in newer SDK versions.
+	AtlasV220250312020 *admin20250312020.APIClient // TODO: Remove before merging to master — pinned for maintenance_window wave fields until OpenAPI spec includes them.
+	Realm              *RealmClient
+	BaseURL            string // Needed by organization resource.
+	TerraformVersion   string // Needed by organization resource.
 }
 
 type RealmClient struct {
@@ -156,15 +158,21 @@ func NewClient(c *Credentials, terraformVersion string) (*MongoDBClient, error) 
 	if err != nil {
 		return nil, err
 	}
+	// TODO: Remove before merging to master.
+	sdkV220250312020Client, err := newSDKV220250312020Client(client, c.BaseURL, userAgent)
+	if err != nil {
+		return nil, err
+	}
 
 	clients := &MongoDBClient{
-		Atlas:            atlasClient,
-		AtlasV2:          sdkV2Client,
-		AtlasPreview:     sdkPreviewClient,
-		AtlasV220240530:  sdkV220240530Client,
-		AtlasV220241113:  sdkV220241113Client,
-		BaseURL:          c.BaseURL,
-		TerraformVersion: terraformVersion,
+		Atlas:              atlasClient,
+		AtlasV2:            sdkV2Client,
+		AtlasPreview:       sdkPreviewClient,
+		AtlasV220240530:    sdkV220240530Client,
+		AtlasV220241113:    sdkV220241113Client,
+		AtlasV220250312020: sdkV220250312020Client, // TODO: Remove before merging to master.
+		BaseURL:            c.BaseURL,
+		TerraformVersion:   terraformVersion,
 		Realm: &RealmClient{
 			publicKey:        c.PublicKey,
 			privateKey:       c.PrivateKey,
@@ -245,6 +253,16 @@ func newSDKV220241113Client(client *http.Client, baseURL, userAgent string) (*ad
 		admin20241113.UseUserAgent(userAgent),
 		admin20241113.UseBaseURL(baseURL),
 		admin20241113.UseDebug(false),
+	)
+}
+
+// TODO: Remove before merging to master.
+func newSDKV220250312020Client(client *http.Client, baseURL, userAgent string) (*admin20250312020.APIClient, error) {
+	return admin20250312020.NewClient(
+		admin20250312020.UseHTTPClient(client),
+		admin20250312020.UseUserAgent(userAgent),
+		admin20250312020.UseBaseURL(baseURL),
+		admin20250312020.UseDebug(false),
 	)
 }
 

--- a/internal/service/maintenancewindow/data_source_maintenance_window.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window.go
@@ -71,7 +71,7 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
 	projectID := d.Get("project_id").(string)
 
 	maintenance, _, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(ctx, projectID).Execute()

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"go.mongodb.org/atlas-sdk/v20250312021/admin"
+	admin "go.mongodb.org/atlas-sdk/v20250312020/admin" // TODO: Remove before merging to master — pinned for wave fields.
 )
 
 const (
@@ -112,7 +112,7 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
 	projectID := d.Get("project_id").(string)
 
 	if deferValue := d.Get("defer").(bool); deferValue {
@@ -168,7 +168,7 @@ func newProtectedHours(d *schema.ResourceData) *admin.ProtectedHours {
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
 	projectID := d.Id()
 
 	maintenanceWindow, resp, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(ctx, projectID).Execute()
@@ -248,7 +248,7 @@ func clearMaintenanceWave(ctx context.Context, client *config.MongoDBClient, pro
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
 	projectID := d.Id()
 
 	if d.HasChange("defer") {
@@ -312,7 +312,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
 	projectID := d.Id()
 
 	_, err := connV2.MaintenanceWindowsApi.ResetMaintenanceWindow(ctx, projectID).Execute()

--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -193,6 +193,7 @@ func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay 
 }
 
 func TestAccConfigRSMaintenanceWindow_waveAssignment(t *testing.T) {
+	// Skipped in CI until wave fields are promoted to the stable SDK (CLOUDP-306618).
 	acc.SkipTestForCI(t)
 
 	var (

--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -193,7 +193,7 @@ func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay 
 }
 
 func TestAccConfigRSMaintenanceWindow_waveAssignment(t *testing.T) {
-	// Skipped in CI until wave fields are promoted to the stable SDK.
+	// TODO: Remove SkipTestForCI once wave fields are promoted to the stable SDK.
 	acc.SkipTestForCI(t)
 
 	var (

--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -193,7 +193,7 @@ func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay 
 }
 
 func TestAccConfigRSMaintenanceWindow_waveAssignment(t *testing.T) {
-	// Skipped in CI until wave fields are promoted to the stable SDK (CLOUDP-306618).
+	// Skipped in CI until wave fields are promoted to the stable SDK.
 	acc.SkipTestForCI(t)
 
 	var (

--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -193,6 +193,8 @@ func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay 
 }
 
 func TestAccConfigRSMaintenanceWindow_waveAssignment(t *testing.T) {
+	acc.SkipTestForCI(t)
+
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()


### PR DESCRIPTION
## Description

The SDK update in #4526 promoted `AtlasV2` from `v20250312020` to `v20250312021` across the dev branch. However, the `wave_assignment` and `effective_wave_assignment` fields on `GroupMaintenanceWindow` only exist in the preview SDK (`v20250312020`) and are not yet available in `v20250312021`.

This PR restores a compilable state for `dev/CLOUDP-306618_Maintenance_Waves_Non_Prod` branch after latest changes from `master` updated the SDK to its latest version. This PR is pinning `v20250312020` as a dedicated client (`AtlasV220250312020`) for the `maintenance_window` resource, following the same pattern already used for `AtlasV220240530` and `AtlasV220241113`.

This PR allows to merge https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4513 into a working state branch

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
