### PR TITLE
test: Re-enable wave assignment acceptance test in CI

### DIFF
--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -193,9 +193,6 @@ func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay 
 }
 
 func TestAccConfigRSMaintenanceWindow_waveAssignment(t *testing.T) {
-	// TODO: Remove SkipTestForCI once wave fields are promoted to the stable SDK.
-	acc.SkipTestForCI(t)
-
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()


### PR DESCRIPTION
## Description

Removes the `acc.SkipTestForCI` call from `TestAccConfigRSMaintenanceWindow_waveAssignment`. The test was skipped while the `wave_assignment` and `effective_wave_assignment` fields were unavailable in the Atlas SDK stable release. The dev branch is pinned to SDK `v20250312020`, which includes those fields, so the test can safely run in CI again.

Link to any related issue(s): CLOUDP-306618

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fix and verified my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

No changelog entry needed (test-only change).