### PR TITLE
chore: Improvements on mongodbatlas_org_maintenance_settings resource after API improvements

### DIFF
--- a/internal/serviceapi/orgmaintenancesettings/data_source_schema.go
+++ b/internal/serviceapi/orgmaintenancesettings/data_source_schema.go
@@ -23,7 +23,7 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 			},
 			"wave_assignment_mode": dsschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Mode configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when unset. Atlas uses read-only `effectiveWaveAssignmentMode` (not this field) for scheduling. In a cross-organization billing hierarchy, a linked non-paying organization cannot update its `effectiveWaveAssignmentMode` field, which inherits from the paying organization's `waveAssignmentMode`. In this case, a linked non-paying organization's `effectiveWaveAssignmentMode` and `waveAssignmentMode` might differ.",
+				MarkdownDescription: "Mode explicitly configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Omitted from the response when no explicit preference has been set; in that case `effectiveWaveAssignmentMode` reflects the value the system uses (`MANUAL` by default). Atlas uses read-only `effectiveWaveAssignmentMode` (not this field) for scheduling. In a cross-organization billing hierarchy, a linked non-paying organization cannot update its `effectiveWaveAssignmentMode` field, which inherits from the paying organization's `waveAssignmentMode`. In this case, a linked non-paying organization's `effectiveWaveAssignmentMode` and `waveAssignmentMode` might differ.",
 			},
 		},
 	}

--- a/internal/serviceapi/orgmaintenancesettings/resource.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource.go
@@ -146,11 +146,9 @@ func deleteRequest(r *rs, client *config.MongoDBClient, model *TFModel, diags *d
 		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
-			RelativePath:  "/api/atlas/v2/orgs/{orgId}/maintenanceSettings",
+			RelativePath:  "/api/atlas/v2/orgs/{orgId}/maintenanceSettings:reset",
 			PathParams:    pathParams,
-			Method:        "PATCH",
+			Method:        "POST",
 		},
-		StaticRequestBody: `{"waveAssignmentMode": null}`,
-		ResetsToDefaults:  true,
 	}
 }

--- a/internal/serviceapi/orgmaintenancesettings/resource_schema.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource_schema.go
@@ -20,7 +20,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers:       []planmodifier.String{customplanmodifier.CreateOnly()},
 			},
 			"wave_assignment_mode": schema.StringAttribute{
-				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Mode configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when unset. Only this field can be updated; Atlas derives read-only `effectiveWaveAssignmentMode` on GET responses and uses that value for scheduling when it differs from `waveAssignmentMode`. Omit this field to leave the current value unchanged. Specify null to reset to the default value (`MANUAL`).",
 			},

--- a/internal/serviceapi/orgmaintenancesettings/resource_test.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource_test.go
@@ -23,16 +23,16 @@ func TestAccOrgMaintenanceSettings_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithMode(orgID, "MANUAL"),
-				Check:  checkWithMode(orgID, "MANUAL"),
+				Config: configWithMode(orgID, "ENV_TAG_MAPPING"),
+				Check:  checkWithMode(orgID, "ENV_TAG_MAPPING"),
 			},
 			{
-				Config:   configWithMode(orgID, "MANUAL"),
+				Config:   configWithMode(orgID, "ENV_TAG_MAPPING"),
 				PlanOnly: true,
 			},
 			{
-				Config: configWithMode(orgID, "ENV_TAG_MAPPING"),
-				Check:  checkWithMode(orgID, "ENV_TAG_MAPPING"),
+				Config: configWithMode(orgID, "MANUAL"),
+				Check:  checkWithMode(orgID, "MANUAL"),
 			},
 			{
 				ResourceName:                         resourceName,
@@ -89,12 +89,11 @@ func checkWithMode(orgID, waveAssignmentMode string) resource.TestCheckFunc {
 }
 
 func checkEmpty(orgID string) resource.TestCheckFunc {
-	// When wave_assignment_mode is removed from config, the provider sends null to the API which resets it to the default (MANUAL).
 	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
-		resource.TestCheckResourceAttrSet(resourceName, "wave_assignment_mode"),
+		resource.TestCheckNoResourceAttr(resourceName, "wave_assignment_mode"),
 		resource.TestCheckResourceAttr(dataSourceName, "org_id", orgID),
-		resource.TestCheckResourceAttrSet(dataSourceName, "wave_assignment_mode"),
+		resource.TestCheckNoResourceAttr(dataSourceName, "wave_assignment_mode"),
 		resource.TestCheckResourceAttrSet(dataSourceName, "effective_wave_assignment_mode"),
 	)
 }

--- a/internal/serviceapi/orgmaintenancesettings/resource_test.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource_test.go
@@ -27,10 +27,6 @@ func TestAccOrgMaintenanceSettings_basic(t *testing.T) {
 				Check:  checkWithMode(orgID, "ENV_TAG_MAPPING"),
 			},
 			{
-				Config:   configWithMode(orgID, "ENV_TAG_MAPPING"),
-				PlanOnly: true,
-			},
-			{
 				Config: configWithMode(orgID, "MANUAL"),
 				Check:  checkWithMode(orgID, "MANUAL"),
 			},
@@ -47,7 +43,7 @@ func TestAccOrgMaintenanceSettings_basic(t *testing.T) {
 			},
 			{
 				Config:   configEmpty(orgID),
-				PlanOnly: true,
+				PlanOnly: true, // Check that wave_assignment_mode was correctly unset in API.
 			},
 		},
 	})

--- a/internal/serviceapi/orgmaintenancesettings/resource_test.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource_test.go
@@ -22,7 +22,7 @@ func TestAccOrgMaintenanceSettings_basic(t *testing.T) {
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
-			// TODO: CLOUDP-418087 to track behaviour of setting an org for the first time to MANUAL.
+			// TODO: CLOUDP-418087 to track behavior of setting an org for the first time to MANUAL.
 			// We need to ensure that feature is working as expected before merging to master
 			// Tests are passing in this org because it was set to ENV_TAG_MAPPING after
 			{

--- a/internal/serviceapi/orgmaintenancesettings/resource_test.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource_test.go
@@ -22,13 +22,16 @@ func TestAccOrgMaintenanceSettings_basic(t *testing.T) {
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
-			{
-				Config: configWithMode(orgID, "ENV_TAG_MAPPING"),
-				Check:  checkWithMode(orgID, "ENV_TAG_MAPPING"),
-			},
+			// TODO: This test failure is known, upstream team is investigating the issue.
+			// Will update this comment with the relevant CLOUDP once it's open
+			// Before merging to master, this behavior will need to be workin as expected
 			{
 				Config: configWithMode(orgID, "MANUAL"),
 				Check:  checkWithMode(orgID, "MANUAL"),
+			},
+			{
+				Config: configWithMode(orgID, "ENV_TAG_MAPPING"),
+				Check:  checkWithMode(orgID, "ENV_TAG_MAPPING"),
 			},
 			{
 				ResourceName:                         resourceName,

--- a/internal/serviceapi/orgmaintenancesettings/resource_test.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource_test.go
@@ -22,9 +22,9 @@ func TestAccOrgMaintenanceSettings_basic(t *testing.T) {
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
-			// TODO: This test failure is known, upstream team is investigating the issue.
-			// Will update this comment with the relevant CLOUDP once it's open
-			// Before merging to master, this behavior will need to be workin as expected
+			// TODO: CLOUDP-418087 to track behaviour of setting an org for the first time to MANUAL.
+			// We need to ensure that feature is working as expected before merging to master
+			// Tests are passing in this org because it was set to ENV_TAG_MAPPING after
 			{
 				Config: configWithMode(orgID, "MANUAL"),
 				Check:  checkWithMode(orgID, "MANUAL"),

--- a/tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
+++ b/tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml
@@ -404,11 +404,13 @@ components:
       properties:
         cidrBlock:
           description: Range of IP addresses in Classless Inter-Domain Routing (CIDR) notation that found in this project's access list.
+          nullable: true
           pattern: ^((([0-9]{1,3}\.){3}[0-9]{1,3})|(:{0,2}([0-9a-f]{1,4}:){0,7}[0-9a-f]{1,4}[:]{0,2}))((%2[fF]|/)[0-9]{1,3})+$
           readOnly: true
           type: string
         ipAddress:
           description: IP address included in the API access list.
+          nullable: true
           pattern: ^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}|([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}$
           readOnly: true
           type: string
@@ -572,6 +574,21 @@ components:
       required:
         - id
       type: object
+    AdditionalData:
+      description: Additional metadata associated with the line item.
+      properties:
+        processorId:
+          description: Identifier of the stream processor associated with the line item.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          type: string
+        processorName:
+          description: Name of the stream processor associated with the line item.
+          type: string
+        workspace:
+          description: Workspace associated with the line item.
+          type: string
+      type: object
     AdvancedAutoScalingSettings:
       description: Options that determine how this cluster handles resource scaling.
       properties:
@@ -656,6 +673,7 @@ components:
           enum:
             - FULLY_WARMED
             - VISIBLE_EARLIER
+            - ENHANCED_FULLY_WARMED
           externalDocs:
             description: Reduce Secondary Disk Warming Impact
             url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -893,6 +911,7 @@ components:
         lastUsedAt:
           description: UTC date when the API key was last used. This parameter is formatted as an ISO 8601 timestamp.
           example: 2026-01-15T16:47:49.855000+00:00
+          nullable: true
           readOnly: true
           type: string
         maskedSecret:
@@ -910,6 +929,7 @@ components:
           description: "The full API key secret used for interacting with the embedding / reranking service. Note: this will only be fully populated in the response to a create API key request. Responses to get, list, and update requests will not include the secret."
           example: al-jZsluhPMzPM9CFXepRWwMwvpZDDra6tZMgoAZKdodu2
           format: password
+          nullable: true
           readOnly: true
           type: string
         status:
@@ -1580,6 +1600,14 @@ components:
           description: 'Routing key that MongoDB Cloud needs to send alert notifications to Splunk On-Call. The resource requires this parameter when `"notifications.[n].typeName" : "VICTOR_OPS"`. If the key later becomes invalid, MongoDB Cloud sends an email to the project owners. If the key remains invalid, MongoDB Cloud removes it.'
           example: test routing
           type: string
+        webhookBodyTemplate:
+          description: Template, using ${field} interpolation, that renders the HTTP body MongoDB Cloud sends with each webhook notification. Must render valid JSON. When unset, MongoDB Cloud sends its default JSON payload.
+          format: password
+          type: string
+        webhookHeadersTemplate:
+          description: Template, using ${field} interpolation, that renders the HTTP headers MongoDB Cloud sends with each webhook notification. Must render a JSON object mapping header name to header value. The webhook secret and the signature header are NOT exposed to templates.
+          format: password
+          type: string
         webhookSecret:
           description: |-
             Authentication secret for a webhook-based alert.
@@ -1721,6 +1749,278 @@ components:
             - DEFAULT
           type: string
       type: object
+    ApiAtlasClusterDescriptionPreview:
+      properties:
+        acceptDataRisksAndForceReplicaSetReconfig:
+          description: If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set `acceptDataRisksAndForceReplicaSetReconfig` to the current date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+          externalDocs:
+            description: Reconfiguring a Replica Set during a regional outage
+            url: https://dochub.mongodb.org/core/regional-outage-reconfigure-replica-set
+          format: date-time
+          type: string
+        adaptiveCapacity:
+          description: Governs adaptive capacity behavior of Azure nodes in single-cloud Azure clusters or multi-cloud clusters that include Azure nodes. Adaptive capacity enables fallback hardware selection when the primary instance family is unavailable. ``ENABLED`` means the cluster explicitly opts in to adaptive capacity. ``DISABLED`` means the cluster explicitly opts out; the cluster receives capacity errors instead of being placed on fallback hardware. ``null`` means the field is unset; Azure clusters use adaptive capacity by default when the feature is enabled at the group level. Setting this field for single-cloud AWS or GCP clusters is a no-op.
+          enum:
+            - ENABLED
+            - DISABLED
+          nullable: true
+          type: string
+        advancedConfiguration:
+          $ref: "#/components/schemas/ApiAtlasClusterAdvancedConfigurationView"
+        backupEnabled:
+          default: false
+          description: Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses Cloud Backups for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.
+          externalDocs:
+            description: Cloud Backups
+            url: https://docs.atlas.mongodb.com/backup/cloud-backup/overview/
+          type: boolean
+        biConnector:
+          $ref: "#/components/schemas/BiConnector"
+        clusterType:
+          description: Configuration of nodes that comprise the cluster.
+          enum:
+            - REPLICASET
+            - SHARDED
+            - GEOSHARDED
+          type: string
+        configServerManagementMode:
+          default: ATLAS_MANAGED
+          description: Config Server Management Mode for creating or updating a sharded cluster. When configured as `ATLAS_MANAGED`, Atlas may automatically switch the cluster's config server type for optimal performance and savings. When configured as `FIXED_TO_DEDICATED`, the cluster will always use a dedicated config server.
+          enum:
+            - ATLAS_MANAGED
+            - FIXED_TO_DEDICATED
+          externalDocs:
+            description: MongoDB Sharded Cluster Config Servers
+            url: https://dochub.mongodb.org/docs/manual/core/sharded-cluster-config-servers
+          type: string
+        configServerType:
+          description: Describes a sharded cluster's config server type.
+          enum:
+            - DEDICATED
+            - EMBEDDED
+          externalDocs:
+            description: MongoDB Sharded Cluster Config Servers
+            url: https://dochub.mongodb.org/docs/manual/core/sharded-cluster-config-servers
+          readOnly: true
+          type: string
+        connectionStrings:
+          $ref: "#/components/schemas/ClusterConnectionStrings"
+        createDate:
+          description: Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.
+          format: date-time
+          readOnly: true
+          type: string
+        diskWarmingMode:
+          default: FULLY_WARMED
+          description: Disk warming mode selection.
+          enum:
+            - FULLY_WARMED
+            - VISIBLE_EARLIER
+            - ENHANCED_FULLY_WARMED
+          externalDocs:
+            description: Reduce Secondary Disk Warming Impact
+            url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
+          type: string
+        effectiveReplicationSpecs:
+          description: List of settings that represent the actual cluster state. This is read-only and always returned in the response. It reflects the current cluster configuration, which may differ from `replicationSpecs` due to system-managed changes.
+          items:
+            $ref: "#/components/schemas/ReplicationSpec20240805"
+          readOnly: true
+          type: array
+        encryptionAtRestProvider:
+          description: 'Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster `replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize` setting must be `M10` or higher and `"backupEnabled" : false` or omitted entirely.'
+          enum:
+            - NONE
+            - AWS
+            - AZURE
+            - GCP
+          externalDocs:
+            description: Encryption at Rest using Customer Key Management
+            url: https://www.mongodb.com/docs/atlas/security-kms-encryption/
+          type: string
+        featureCompatibilityVersion:
+          description: Feature compatibility version of the cluster. This will always appear regardless of whether FCV is pinned.
+          readOnly: true
+          type: string
+        featureCompatibilityVersionExpirationDate:
+          description: Feature compatibility version expiration date. Will only appear if FCV is pinned. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+          format: date-time
+          readOnly: true
+          type: string
+        globalClusterSelfManagedSharding:
+          description: |-
+            Set this field to configure the Sharding Management Mode when creating a new Global Cluster.
+
+            When set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.
+
+            When set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.
+
+            This setting cannot be changed once the cluster is deployed.
+          externalDocs:
+            description: Creating a Global Cluster
+            url: https://dochub.mongodb.org/core/global-cluster-management
+          type: boolean
+        groupId:
+          description: Unique 24-hexadecimal character string that identifies the project.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          readOnly: true
+          type: string
+        id:
+          description: Unique 24-hexadecimal digit string that identifies the cluster.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          readOnly: true
+          type: string
+        internalClusterRole:
+          description: "Internal classification of the cluster's role. Possible values: `NONE` (regular user cluster), `SYSTEM_CLUSTER` (system cluster for backup), `INTERNAL_SHADOW_CLUSTER` (internal use shadow cluster for testing)."
+          enum:
+            - NONE
+            - SYSTEM_CLUSTER
+            - INTERNAL_SHADOW_CLUSTER
+          readOnly: true
+          type: string
+        labels:
+          deprecated: true
+          description: |-
+            Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.
+
+            Cluster labels are deprecated and will be removed in a future release. We strongly recommend that you use Resource Tags instead.
+          externalDocs:
+            description: Resource Tags
+            url: https://dochub.mongodb.org/core/add-cluster-tag-atlas
+          items:
+            $ref: "#/components/schemas/ComponentLabel"
+          type: array
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        mongoDBEmployeeAccessGrant:
+          $ref: "#/components/schemas/EmployeeAccessGrantView"
+        mongoDBMajorVersion:
+          description: |-
+            MongoDB major version of the cluster. Set to the binary major version. 
+
+            On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLtsVersions).
+
+             On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version.
+          externalDocs:
+            description: Available MongoDB Versions in Atlas
+            url: https://www.mongodb.com/docs/atlas/reference/faq/database/#which-versions-of-mongodb-do-service-clusters-use-
+          type: string
+        mongoDBVersion:
+          description: Version of MongoDB that the cluster runs.
+          pattern: ([\d]+\.[\d]+\.[\d]+)
+          readOnly: true
+          type: string
+        mongosTopology:
+          $ref: "#/components/schemas/MongosTopology"
+        name:
+          description: Human-readable label that identifies the cluster.
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+          type: string
+        paused:
+          description: Flag that indicates whether the cluster is paused.
+          type: boolean
+        pitEnabled:
+          description: Flag that indicates whether the cluster uses continuous cloud backups.
+          externalDocs:
+            description: Continuous Cloud Backups
+            url: https://docs.atlas.mongodb.com/backup/cloud-backup/overview/
+          type: boolean
+        redactClientLogData:
+          description: |-
+            Enable or disable log redaction.
+
+            This setting configures the ``mongod`` or ``mongos`` to redact any document field contents from a message accompanying a given log event before logging. This prevents the program from writing potentially sensitive data stored on the database to the diagnostic log. Metadata such as error or operation codes, line numbers, and source file names are still visible in the logs.
+
+            Use ``redactClientLogData`` in conjunction with Encryption at Rest and TLS/SSL (Transport Encryption) to assist compliance with regulatory requirements.
+
+            *Note*: changing this setting on a cluster will trigger a rolling restart as soon as the cluster is updated.
+          externalDocs:
+            description: Log Redaction
+            url: https://www.mongodb.com/docs/manual/administration/monitoring/#log-redaction
+          type: boolean
+        replicaSetScalingStrategy:
+          default: WORKLOAD_TYPE
+          description: |-
+            Set this field to configure the replica set scaling mode for your cluster.
+
+            By default, Atlas scales under `WORKLOAD_TYPE`. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.
+
+            When configured as `SEQUENTIAL`, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.
+
+            When configured as `NODE_TYPE`, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.
+          enum:
+            - SEQUENTIAL
+            - WORKLOAD_TYPE
+            - NODE_TYPE
+          externalDocs:
+            description: Modify the Replica Set Scaling Mode
+            url: https://dochub.mongodb.org/core/scale-nodes
+          type: string
+        replicationSpecs:
+          description: List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations.
+          items:
+            $ref: "#/components/schemas/ReplicationSpec20240805"
+          type: array
+        retainBackups:
+          default: false
+          description: Flag that indicates whether the cluster retains backups.
+          type: boolean
+        rootCertType:
+          default: ISRGROOTX1
+          description: Root Certificate Authority that MongoDB Atlas cluster uses. MongoDB Cloud supports Internet Security Research Group.
+          enum:
+            - ISRGROOTX1
+          type: string
+        stateName:
+          description: |-
+            Human-readable label that indicates any current activity being taken on this cluster by the Atlas control plane. With the exception of CREATING and DELETING states, clusters should always be available and have a Primary node even when in states indicating ongoing activity.
+
+             - `IDLE`: Atlas is making no changes to this cluster and all changes requested via the UI or API can be assumed to have been applied.
+             - `CREATING`: A cluster being provisioned for the very first time returns state CREATING until it is ready for connections. Ensure IP Access List and DB Users are configured before attempting to connect.
+             - `UPDATING`: A change requested via the UI, API, AutoScaling, or other scheduled activity is taking place.
+             - `DELETING`: The cluster is in the process of deletion and will soon be deleted.
+             - `REPAIRING`: One or more nodes in the cluster are being returned to service by the Atlas control plane. Other nodes should continue to provide service as normal.
+          enum:
+            - IDLE
+            - CREATING
+            - UPDATING
+            - DELETING
+            - REPAIRING
+          readOnly: true
+          type: string
+        tags:
+          description: List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.
+          externalDocs:
+            description: Resource Tags
+            url: https://dochub.mongodb.org/core/add-cluster-tag-atlas
+          items:
+            $ref: "#/components/schemas/ResourceTag"
+          type: array
+        terminationProtectionEnabled:
+          default: false
+          description: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.
+          type: boolean
+        useAwsTimeBasedSnapshotCopyForFastInitialSync:
+          default: false
+          description: Flag that indicates whether AWS time-based snapshot copies will be used instead of slower standard snapshot copies during fast Atlas cross-region initial syncs. This flag is only relevant for clusters containing AWS nodes.
+          type: boolean
+        versionReleaseSystem:
+          default: LTS
+          description: Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify `mongoDBMajorVersion`.
+          enum:
+            - LTS
+            - CONTINUOUS
+          type: string
+      type: object
     ApiAtlasCollectionRestoreCollectionStateResponse:
       description: Collection-level state within a collection restore job.
       properties:
@@ -1810,9 +2110,11 @@ components:
       type: object
     ApiAtlasCollectionRestoreJobRequest:
       description: Request body for creating a collection restore job.
+      nullable: true
       properties:
         collectionSuffix:
           description: Optional suffix applied to restored collection names.
+          nullable: true
           type: string
         collections:
           description: List of collections to restore (up to 100 items).
@@ -1822,6 +2124,7 @@ components:
           type: array
         databaseSuffix:
           description: Optional suffix applied to restored database names.
+          nullable: true
           type: string
         databases:
           description: List of databases to restore (up to 100 items).
@@ -1839,10 +2142,12 @@ components:
         oplogInc:
           description: Oplog increment for point-in-time restore.
           format: int32
+          nullable: true
           type: integer
         oplogTs:
           description: Oplog timestamp (seconds part) for point-in-time restore.
           format: int32
+          nullable: true
           type: integer
         overwriteStrategy:
           description: Strategy for overwriting existing data (new if exists or overwrite if exists).
@@ -1853,6 +2158,7 @@ components:
         pointInTimeUtcSeconds:
           description: Point-in-time restore time in seconds since UNIX epoch.
           format: int32
+          nullable: true
           type: integer
         snapshotId:
           description: ID of the snapshot to restore.
@@ -2251,6 +2557,7 @@ components:
       properties:
         description:
           description: Description of the atlas resource policy.
+          nullable: true
           type: string
         name:
           description: Human-readable label that describes the atlas resource policy.
@@ -2268,9 +2575,11 @@ components:
       properties:
         description:
           description: Description of the atlas resource policy.
+          nullable: true
           type: string
         name:
           description: Human-readable label that describes the atlas resource policy.
+          nullable: true
           type: string
         policies:
           description: List of policies that make up the atlas resource policy.
@@ -2512,6 +2821,19 @@ components:
       readOnly: true
       title: BSON Timestamp
       type: object
+    ApiChartsDashboardImportResponseView:
+      description: Imported dashboard and associated imported items.
+      properties:
+        dashboard:
+          $ref: "#/components/schemas/ImportedDashboard"
+        items:
+          description: Imported items.
+          items:
+            $ref: "#/components/schemas/ImportedItem"
+          type: array
+      required:
+        - items
+      type: object
     ApiCheckpointPartView:
       description: Metadata contained in one document that describes the complete snapshot taken for this node.
       properties:
@@ -2545,6 +2867,7 @@ components:
           $ref: "#/components/schemas/BadRequestDetail"
         detail:
           description: Describes the specific conditions or reasons that cause each type of error.
+          nullable: true
           type: string
         error:
           description: HTTP status code returned with this error.
@@ -2565,6 +2888,7 @@ components:
           type: array
         reason:
           description: Application error message returned with this error.
+          nullable: true
           readOnly: true
           type: string
       required:
@@ -2815,11 +3139,75 @@ components:
             - DESCENDING
           type: string
       type: object
-    ApiSearchDeploymentRequestSpecView:
+    ApiSearchDeploymentEffectiveSpecView:
       properties:
+        cloudProvider:
+          description: Cloud service provider on which Search Nodes are provisioned.
+          enum:
+            - AWS
+            - AZURE
+            - GCP
+          readOnly: true
+          type: string
         instanceSize:
           description: Hardware specification for the Search Node instance sizes.
           enum:
+            - S10_HIGHCPU
+            - S20_HIGHCPU_NVME
+            - S30_HIGHCPU_NVME
+            - S40_HIGHCPU_NVME
+            - S50_HIGHCPU_NVME
+            - S60_HIGHCPU_NVME
+            - S70_HIGHCPU_NVME
+            - S80_HIGHCPU_NVME
+            - S30_LOWCPU_NVME
+            - S40_LOWCPU_NVME
+            - S50_LOWCPU_NVME
+            - S60_LOWCPU_NVME
+            - S70_LOWCPU_NVME
+            - S80_LOWCPU_NVME
+            - S90_LOWCPU_NVME
+            - S100_LOWCPU_NVME
+            - S110_LOWCPU_NVME
+            - S120_LOWCPU_NVME
+            - S130_LOWCPU_NVME
+            - S135_LOWCPU_NVME
+            - S140_LOWCPU_NVME
+            - S40_STORAGE_NVME
+            - S50_STORAGE_NVME
+            - S60_STORAGE_NVME
+            - S80_STORAGE_NVME
+            - S90_STORAGE_NVME
+          readOnly: true
+          type: string
+        nodeCount:
+          description: Number of Search Nodes in this region.
+          example: 2
+          format: int32
+          maximum: 32
+          minimum: 2
+          readOnly: true
+          type: integer
+        regionName:
+          description: Cloud provider region where Search Nodes are provisioned.
+          example: US_EAST_1
+          readOnly: true
+          type: string
+      type: object
+    ApiSearchDeploymentRequestSpecView:
+      properties:
+        cloudProvider:
+          description: Cloud service provider that hosts the Search Nodes in this region. Required when a region is specified.
+          enum:
+            - AWS
+            - AZURE
+            - GCP
+          nullable: true
+          type: string
+        instanceSize:
+          description: Hardware specification for the Search Node instance sizes.
+          enum:
+            - S10_HIGHCPU
             - S20_HIGHCPU_NVME
             - S30_HIGHCPU_NVME
             - S40_HIGHCPU_NVME
@@ -2852,12 +3240,26 @@ components:
           format: int32
           maximum: 32
           minimum: 2
+          nullable: true
           type: integer
+        regionName:
+          description: Cloud provider region where Search Nodes are provisioned. Required when the request configures more than one region; optional for single-region requests.
+          example: US_EAST_1
+          nullable: true
+          type: string
       required:
         - instanceSize
       type: object
     ApiSearchDeploymentRequestView:
       properties:
+        defaultNodeCount:
+          description: Default number of Search Nodes per region. Applied to a region without an explicit override.
+          example: 2
+          format: int32
+          maximum: 32
+          minimum: 2
+          nullable: true
+          type: integer
         specs:
           description: List of settings that configure the Search Nodes for your cluster. Provide one element per region when configuring asymmetric deployments; a single element applies to all regions.
           items:
@@ -2869,6 +3271,12 @@ components:
       type: object
     ApiSearchDeploymentResponseView:
       properties:
+        effectiveSpecs:
+          description: List of settings that configure the Search Nodes for your cluster, with per-region detail including the region name and cloud provider.
+          items:
+            $ref: "#/components/schemas/ApiSearchDeploymentEffectiveSpecView"
+          readOnly: true
+          type: array
         encryptionAtRestProvider:
           description: Cloud service provider that manages your customer keys to provide an additional layer of Encryption At Rest for the cluster.
           enum:
@@ -2879,6 +3287,7 @@ components:
           externalDocs:
             description: Encryption at Rest using Customer Key Management
             url: https://www.mongodb.com/docs/atlas/security-kms-encryption/
+          nullable: true
           readOnly: true
           type: string
         groupId:
@@ -2894,7 +3303,8 @@ components:
           readOnly: true
           type: string
         specs:
-          description: List of settings that configure the Search Nodes for your cluster. The configuration will be returned for each region and shard.
+          deprecated: true
+          description: Deprecated. `specs` will be removed in a future release. We strongly recommend that you use `effectiveSpecs` instead.
           items:
             $ref: "#/components/schemas/ApiSearchDeploymentSpecView"
           readOnly: true
@@ -2914,6 +3324,7 @@ components:
         instanceSize:
           description: Hardware specification for the Search Node instance sizes.
           enum:
+            - S10_HIGHCPU
             - S20_HIGHCPU_NVME
             - S30_HIGHCPU_NVME
             - S40_HIGHCPU_NVME
@@ -3101,6 +3512,12 @@ components:
         - standbyLinkId
         - status
       type: object
+    ApiVersion:
+      properties:
+        version:
+          description: Object representing a version of the Atlas Admin API.
+          type: string
+      type: object
     AssociatedInvoice:
       description: An invoice associated with an organization.
       properties:
@@ -3161,6 +3578,48 @@ components:
           type: boolean
       required:
         - name
+      type: object
+    AtlasRateLimitBucketState:
+      description: Configuration and current state of a single rate limit token bucket.
+      properties:
+        capacity:
+          description: The capacity of the bucket.
+          format: int64
+          readOnly: true
+          type: integer
+        name:
+          description: The name of the bucket.
+          readOnly: true
+          type: string
+        remaining:
+          description: The remaining tokens of the bucket.
+          format: int64
+          readOnly: true
+          type: integer
+      type: object
+    AtlasRateLimitInspectionResponse:
+      description: Rate limit inspection response containing bucket states for debugging and monitoring.
+      properties:
+        limits:
+          description: List of bucket states.
+          items:
+            $ref: "#/components/schemas/AtlasRateLimitBucketState"
+          readOnly: true
+          type: array
+        scope:
+          description: The scope type of the rate limit.
+          enum:
+            - GROUP
+            - ORGANIZATION
+            - USER
+            - IP
+          readOnly: true
+          type: string
+        scopeId:
+          description: The scope id associated to the bucket.
+          nullable: true
+          readOnly: true
+          type: string
       type: object
     AtlasSearchAnalyzer:
       properties:
@@ -3265,6 +3724,7 @@ components:
           enum:
             - FULLY_WARMED
             - VISIBLE_EARLIER
+            - ENHANCED_FULLY_WARMED
           externalDocs:
             description: Reduce Secondary Disk Warming Impact
             url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -4268,6 +4728,7 @@ components:
           type: string
         clusterName:
           description: Human-readable label that identifies the cluster.
+          nullable: true
           readOnly: true
           type: string
         complete:
@@ -4430,6 +4891,7 @@ components:
       type: object
     BadRequestDetail:
       description: Bad request detail.
+      nullable: true
       properties:
         fields:
           description: Describes all violations in a client request.
@@ -4674,6 +5136,7 @@ components:
         - TOKYO_JPN
         - SINGAPORE_SGP
         - PARIS_FRA
+        - SEOUL_KOR
         - eastus
         - westus
         - eastus2
@@ -6862,6 +7325,7 @@ components:
           enum:
             - FULLY_WARMED
             - VISIBLE_EARLIER
+            - ENHANCED_FULLY_WARMED
           externalDocs:
             description: Reduce Secondary Disk Warming Impact
             url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -7901,12 +8365,14 @@ components:
             - TOTAL_OPS_P95_VALUE
             - TOTAL_OPS_P99_VALUE
           example: READS_OPS
+          nullable: true
           readOnly: true
           type: string
         units:
           description: Unit of measurement that applies to this metric.
           enum:
             - MILLISECONDS
+          nullable: true
           readOnly: true
           type: string
       readOnly: true
@@ -8184,6 +8650,7 @@ components:
           type: boolean
         identityProviderId:
           description: Legacy 20-hexadecimal digit string that identifies the UI access identity provider that this connected organization configuration is associated with. This id can be found within the Federation Management Console > Identity Providers tab by clicking the info icon in the IdP ID row of a configured identity provider.
+          nullable: true
           pattern: ^([a-f0-9]{20})$
           type: string
         orgId:
@@ -8203,6 +8670,7 @@ components:
               - ORG_BILLING_READ_ONLY
               - ORG_STREAM_PROCESSING_ADMIN
               - ORG_READ_ONLY
+            nullable: true
             type: string
           type: array
           uniqueItems: true
@@ -8309,7 +8777,7 @@ components:
               - Cloud Manager
               - Cloud Manager Standard/Premium
               - Legacy Backup
-              - AI Models
+              - AI Model APIs
               - Automated Embedding
               - Native Reranking
               - Flex Consulting
@@ -8356,6 +8824,7 @@ components:
               - ORG_BILLING_READ_ONLY
               - ORG_STREAM_PROCESSING_ADMIN
               - ORG_READ_ONLY
+            nullable: true
             type: string
           minItems: 1
           type: array
@@ -8491,6 +8960,64 @@ components:
           type: string
           writeOnly: true
       title: GCP Forwarding Rules
+      type: object
+    CreateGroupMcpConfigRequest:
+      properties:
+        ipAccessList:
+          description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+          items:
+            $ref: "#/components/schemas/ServiceAccountIPAccessListEntry"
+          maxItems: 200
+          type: array
+        mcpConfigName:
+          description: Human-readable name that identifies this MCP configuration.
+          minLength: 1
+          type: string
+        roles:
+          description: List of project roles to assign to this MCP configuration.
+          externalDocs:
+            description: Project-level Roles for Service Accounts
+            url: https://www.mongodb.com/docs/atlas/reference/user-roles/
+          items:
+            type: string
+          maxItems: 100
+          minItems: 1
+          type: array
+      required:
+        - mcpConfigName
+        - roles
+      type: object
+    CreateOrgMcpConfigRequest:
+      properties:
+        ipAccessList:
+          description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+          items:
+            $ref: "#/components/schemas/ServiceAccountIPAccessListEntry"
+          maxItems: 200
+          type: array
+        mcpConfigName:
+          description: Human-readable name that identifies this MCP configuration.
+          minLength: 1
+          type: string
+        roles:
+          description: List of organization roles to assign to this MCP configuration.
+          items:
+            description: Organization roles available for Service Accounts.
+            enum:
+              - ORG_MEMBER
+              - ORG_READ_ONLY
+              - ORG_BILLING_ADMIN
+              - ORG_BILLING_READ_ONLY
+              - ORG_STREAM_PROCESSING_ADMIN
+              - ORG_GROUP_CREATOR
+              - ORG_OWNER
+            type: string
+          maxItems: 100
+          minItems: 1
+          type: array
+      required:
+        - mcpConfigName
+        - roles
       type: object
     CreateOrganizationRequest:
       properties:
@@ -8645,6 +9172,7 @@ components:
       externalDocs:
         description: Built-in Roles
         url: https://www.mongodb.com/docs/atlas/mongodb-users-roles-and-privileges/#mongodb-atlasrole-atlasAdmin
+      nullable: true
       properties:
         links:
           description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
@@ -9648,6 +10176,10 @@ components:
             - LIST_STREAM_PROCESSORS
             - LIST_CONNECTIONS
             - STREAM_PROCESSOR_STATS
+            - CREATE_SEARCH_INDEX
+            - DROP_SEARCH_INDEX
+            - LIST_SEARCH_INDEXES
+            - UPDATE_SEARCH_INDEX
           type: string
         resources:
           description: List of resources on which you grant the action.
@@ -9921,6 +10453,7 @@ components:
         defaultLimit:
           description: Default limit value. Returns null if no default exists.
           format: int32
+          nullable: true
           readOnly: true
           type: integer
         description:
@@ -9930,6 +10463,7 @@ components:
         maximumLimit:
           description: Maximum limit value. Returns null if no maximum exists.
           format: int32
+          nullable: true
           readOnly: true
           type: integer
         name:
@@ -10027,6 +10561,7 @@ components:
           type: string
         privateLinkId:
           description: Represents the endpoint to use when the host schema type is `PRIVATE_LINK`.
+          nullable: true
           type: string
       required:
         - clusterName
@@ -10410,6 +10945,7 @@ components:
         - exportBucketId
       type: object
     DiskBackupExportJobRequest:
+      nullable: true
       properties:
         customData:
           description: Collection of key-value pairs that represent custom data to add to the metadata file that MongoDB Cloud uploads to the bucket when the export job finishes.
@@ -10969,6 +11505,7 @@ components:
       type: object
     DiskBackupSnapshotExportBucketRequest:
       description: Disk backup snapshot Export Bucket Request.
+      nullable: true
       properties:
         cloudProvider:
           description: Human-readable label that identifies the cloud provider.
@@ -12161,6 +12698,7 @@ components:
         - PROJECT_SCHEDULED_MAINTENANCE
         - PROJECT_LIMIT_UPDATED
         - PROJECT_ENABLE_EXTENDED_STORAGE_SIZES_UPDATED
+        - PROJECT_ENABLE_DATA_VALIDATION_UPDATED
         - PROJECT_COLLECT_DATABASE_STATISTICS_UPDATED
         - OS_MAINTENANCE
         - OS_MAINTENANCE_RESTART
@@ -12252,6 +12790,7 @@ components:
         - SERVERLESS_UPGRADE_TO_DEDICATED_SUCCESSFUL
         - SERVERLESS_UPGRADE_TO_DEDICATED_FAILED
         - CLUSTER_FORCE_RECONFIG_REQUESTED
+        - AGENT_FORCE_RESTART_REQUESTED
         - CLUSTER_RESET_FORCE_RECONFIG_REQUESTED
         - PROJECT_BYPASSED_MAINTENANCE
         - FEATURE_FLAG_MAINTENANCE
@@ -12354,6 +12893,7 @@ components:
         - MAINTENANCE_WAVE_ASSIGNMENT_REMOVED
         - CLUSTER_MONGUARD_ENABLED
         - CLUSTER_MONGUARD_DISABLED
+        - CLUSTER_MONGODB_VERSION_UPDATED
         - DB_CHECK_UPDATED
         - CLUSTER_SAMPLED_FOR_DB_CHECK
         - DB_CHECK_SCHEDULED_FOR_CLUSTER
@@ -12466,6 +13006,7 @@ components:
         - SETUP_SERVERLESS_INITIATED
         - MAX_PROCESSOR_COUNT_REACHED
         - STREAM_PROCESSOR_STATE_IS_FAILED
+        - STREAM_PROCESSOR_STARTED
         - INSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
         - OUTSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
         - CASE_CREATED
@@ -12513,11 +13054,12 @@ components:
         - SHARD_KEY_ANALYSIS_FINISHED
         - QUERY_SAMPLING_STARTED
         - QUERY_SAMPLING_STOPPED
-        - AI_MODELS_API_KEY_CREATED
-        - AI_MODELS_API_KEY_DELETED
-        - AI_MODELS_API_KEY_UPDATED
-        - AI_MODELS_RATE_LIMIT_UPDATED
-        - AI_MODELS_RATE_LIMIT_RESET
+        - AI_MODELS_APIS_API_KEY_CREATED
+        - AI_MODELS_APIS_API_KEY_DELETED
+        - AI_MODELS_APIS_API_KEY_UPDATED
+        - AI_MODELS_APIS_RATE_LIMIT_UPDATED
+        - AI_MODELS_APIS_RATE_LIMIT_RESET
+        - AI_MODELS_APIS_RATE_LIMIT_ADMIN_OVERRIDE
     EventTypeForOrg:
       type: string
       enum:
@@ -12676,6 +13218,7 @@ components:
         - ORG_LIMIT_UPDATED
         - SHADOW_CLUSTER_ORG_OPT_IN
         - SHADOW_CLUSTER_ORG_OPT_OUT
+        - ATLAS_MAINTENANCE_FLEET_ACTIVE_WAVE_CLOSED_BY_ADMIN
         - ORG_CREATED
         - CUSTOM_SESSION_TIMEOUT_MODIFIED
         - SECURITY_CONTACT_MODIFIED
@@ -12750,6 +13293,7 @@ components:
         - SANDBOX_DISABLED_FOR_ORG
         - SANDBOX_CONFIG_DELETED
         - SANDBOX_TEMPLATE_UPDATED
+        - ORG_DELEGATION_SETTINGS_UPDATED
         - ORGANIZATION_VOYAGE_SETTINGS_CREATED
         - ORGANIZATION_VOYAGE_SETTINGS_DELETED
         - ORG_WAVE_ASSIGNMENT_MODE_MANUAL
@@ -12801,7 +13345,19 @@ components:
         - RESOURCE_POLICY_MODIFIED
         - RESOURCE_POLICY_DELETED
         - RESOURCE_POLICY_VIOLATED
-        - AI_MODELS_USAGE_TIER_UPDATED
+        - AI_MODELS_APIS_USAGE_TIER_UPDATED
+        - AI_MODELS_APIS_FREE_TOKENS_ADMIN_ADJUSTED
+        - OAUTH_CLIENT_CREATED
+        - OAUTH_CLIENT_UPDATED
+        - OAUTH_CLIENT_DELETED
+        - OAUTH_CLIENT_SECRET_CREATED
+        - OAUTH_CLIENT_SECRET_DELETED
+        - OAUTH_AUTHORIZATION_GRANTED
+        - OAUTH_AUTHORIZATION_DENIED
+        - OAUTH_TOKEN_ISSUED
+        - OAUTH_TOKEN_REVOKED
+        - OAUTH_USER_CONSENT_GRANTED
+        - OAUTH_USER_CONSENT_REVOKED
     EventViewForNdsGroup:
       type: object
       properties:
@@ -12900,6 +13456,7 @@ components:
         targetPublicKey:
           description: Public part of the API key that this event targets.
           example: zmmrboas
+          nullable: true
           readOnly: true
           type: string
         whitelistEntry:
@@ -13003,6 +13560,7 @@ components:
           description: 'Email address for the console user that this event targets. The resource returns this parameter when `"eventTypeName" : "USER"`.'
           example: test.user@mongodb.com
           format: email
+          nullable: true
           readOnly: true
           type: string
         resourceId:
@@ -13151,6 +13709,7 @@ components:
         targetPublicKey:
           description: Public part of the API key that this event targets.
           example: zmmrboas
+          nullable: true
           readOnly: true
           type: string
         whitelistEntry:
@@ -13185,6 +13744,7 @@ components:
           description: 'Email address for the console user that this event targets. The resource returns this parameter when `"eventTypeName" : "USER"`.'
           example: test.user@mongodb.com
           format: email
+          nullable: true
           readOnly: true
           type: string
         resourceId:
@@ -13262,6 +13822,7 @@ components:
             - JVM_CURRENT_MEMORY
             - JVM_MAX_MEMORY
             - PAGE_FAULTS
+          nullable: true
           readOnly: true
           type: string
         units:
@@ -13280,6 +13841,7 @@ components:
             - SCALAR
             - SCALAR_PER_SECOND
             - SECONDS
+          nullable: true
           readOnly: true
           type: string
       readOnly: true
@@ -13333,6 +13895,7 @@ components:
           type: string
         description:
           description: The description of the identity provider.
+          nullable: true
           type: string
         displayName:
           description: Human-readable label that identifies the identity provider.
@@ -13354,6 +13917,7 @@ components:
           type: string
         oktaIdpId:
           description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+          nullable: true
           pattern: ^([a-f0-9]{20})$
           type: string
         protocol:
@@ -13365,10 +13929,12 @@ components:
         updatedAt:
           description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           format: date-time
+          nullable: true
           readOnly: true
           type: string
         acsUrl:
           description: URL that points to where to send the SAML response.
+          nullable: true
           type: string
         associatedDomains:
           description: List that contains the domains associated with the identity provider.
@@ -13378,6 +13944,7 @@ components:
           uniqueItems: true
         audienceUri:
           description: Unique string that identifies the intended audience of the SAML assertion.
+          nullable: true
           type: string
         pemFileInfo:
           $ref: "#/components/schemas/PemFileInfo"
@@ -13395,6 +13962,7 @@ components:
           type: string
         slug:
           description: Custom SSO URL for the identity provider.
+          nullable: true
           type: string
         ssoDebugEnabled:
           description: Flag that indicates whether the identity provider has SSO debug enabled.
@@ -13410,6 +13978,7 @@ components:
           type: string
         audience:
           description: Identifier of the intended recipient of the token.
+          nullable: true
           type: string
         authorizationType:
           description: Indicates whether authorization is granted based on group membership or user ID.
@@ -13419,9 +13988,11 @@ components:
           type: string
         clientId:
           description: Client identifier that is assigned to an application by the Identity Provider.
+          nullable: true
           type: string
         groupsClaim:
           description: Identifier of the claim which contains IdP Group IDs in the token.
+          nullable: true
           type: string
         requestedScopes:
           description: Scopes that MongoDB applications will request from the authorization endpoint.
@@ -13439,6 +14010,7 @@ components:
       properties:
         description:
           description: The description of the identity provider.
+          nullable: true
           type: string
         displayName:
           description: Human-readable label that identifies the identity provider.
@@ -13496,6 +14068,7 @@ components:
           enum:
             - ACTIVE
             - INACTIVE
+          nullable: true
           type: string
         audience:
           description: Identifier of the intended recipient of the token.
@@ -13531,6 +14104,7 @@ components:
           uniqueItems: true
         audience:
           description: Identifier of the intended recipient of the token.
+          nullable: true
           type: string
         authorizationType:
           description: Indicates whether authorization is granted based on group membership or user ID.
@@ -13545,12 +14119,14 @@ components:
           type: string
         description:
           description: The description of the identity provider.
+          nullable: true
           type: string
         displayName:
           description: Human-readable label that identifies the identity provider.
           type: string
         groupsClaim:
           description: Identifier of the claim which contains IdP Group IDs in the token.
+          nullable: true
           type: string
         id:
           description: Unique 24-hexadecimal digit string that identifies the identity provider.
@@ -13569,6 +14145,7 @@ components:
           type: string
         oktaIdpId:
           description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+          nullable: true
           pattern: ^([a-f0-9]{20})$
           type: string
         protocol:
@@ -13580,6 +14157,7 @@ components:
         updatedAt:
           description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           format: date-time
+          nullable: true
           readOnly: true
           type: string
         userClaim:
@@ -13593,6 +14171,7 @@ components:
           uniqueItems: true
         clientId:
           description: Client identifier that is assigned to an application by the Identity Provider.
+          nullable: true
           type: string
         requestedScopes:
           description: Scopes that MongoDB applications will request from the authorization endpoint.
@@ -13616,6 +14195,7 @@ components:
           type: string
         description:
           description: The description of the identity provider.
+          nullable: true
           type: string
         displayName:
           description: Human-readable label that identifies the identity provider.
@@ -13663,6 +14243,7 @@ components:
       properties:
         acsUrl:
           description: URL that points to where to send the SAML response.
+          nullable: true
           type: string
         associatedDomains:
           description: List that contains the domains associated with the identity provider.
@@ -13678,6 +14259,7 @@ components:
           uniqueItems: true
         audienceUri:
           description: Unique string that identifies the intended audience of the SAML assertion.
+          nullable: true
           type: string
         createdAt:
           description: Date that the identity provider was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
@@ -13686,6 +14268,7 @@ components:
           type: string
         description:
           description: The description of the identity provider.
+          nullable: true
           type: string
         displayName:
           description: Human-readable label that identifies the identity provider.
@@ -13707,6 +14290,7 @@ components:
           type: string
         oktaIdpId:
           description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+          nullable: true
           pattern: ^([a-f0-9]{20})$
           type: string
         pemFileInfo:
@@ -13731,6 +14315,7 @@ components:
           type: string
         slug:
           description: Custom SSO URL for the identity provider.
+          nullable: true
           type: string
         ssoDebugEnabled:
           description: Flag that indicates whether the identity provider has SSO debug enabled.
@@ -13747,6 +14332,7 @@ components:
         updatedAt:
           description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           format: date-time
+          nullable: true
           readOnly: true
           type: string
       required:
@@ -13764,6 +14350,7 @@ components:
           uniqueItems: true
         description:
           description: The description of the identity provider.
+          nullable: true
           type: string
         displayName:
           description: Human-readable label that identifies the identity provider.
@@ -13815,6 +14402,7 @@ components:
           enum:
             - ACTIVE
             - INACTIVE
+          nullable: true
           type: string
       required:
         - ssoDebugEnabled
@@ -14789,6 +15377,46 @@ components:
       required:
         - dayOfWeek
       type: object
+    GroupMcpConfigResponse:
+      properties:
+        clientId:
+          description: Unique identifier for the Service Account client associated with this MCP configuration. Use this Service Account to connect to the Atlas Remote MCP.
+          example: mdb_sa_id_1234567890abcdef12345678
+          pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+          readOnly: true
+          type: string
+        egressClientId:
+          description: Unique identifier for the egress Service Account client associated with this MCP configuration. This Service Account is managed by MongoDB Atlas.
+          example: mdb_sa_id_1234567890abcdef12345678
+          pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+          readOnly: true
+          type: string
+        ipAccessList:
+          description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+          items:
+            $ref: "#/components/schemas/ServiceAccountIPAccessListEntry"
+          maxItems: 200
+          type: array
+        mcpConfigId:
+          description: Unique 24-hexadecimal digit string that identifies this MCP configuration.
+          example: 32b6e34b3d91647adeabc012
+          pattern: ^[a-fA-F0-9]{24}$
+          readOnly: true
+          type: string
+        mcpConfigName:
+          description: Human-readable name that identifies this MCP configuration.
+          nullable: true
+          type: string
+        roles:
+          description: List of project roles associated with this MCP configuration.
+          externalDocs:
+            description: Project-level Roles for Service Accounts
+            url: https://www.mongodb.com/docs/atlas/reference/user-roles/
+          items:
+            type: string
+          maxItems: 100
+          type: array
+      type: object
     GroupMigrationRequest:
       properties:
         destinationOrgId:
@@ -14941,7 +15569,9 @@ components:
         secretExpiresAfterHours:
           description: The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.
           example: 8
+          exclusiveMinimum: true
           format: int32
+          minimum: 0
           type: integer
       required:
         - description
@@ -14970,12 +15600,14 @@ components:
           description: Human readable description for the Service Account.
           maxLength: 250
           minLength: 1
+          nullable: true
           pattern: ^[\p{L}\p{N}\-_.,' ]*$
           type: string
         name:
           description: Human-readable name for the Service Account. The name is modifiable and does not have to be unique.
           maxLength: 64
           minLength: 1
+          nullable: true
           pattern: ^[\p{L}\p{N}\-_.,' ]*$
           type: string
         roles:
@@ -15005,6 +15637,9 @@ components:
         isDataExplorerGenAISampleDocumentPassingEnabled:
           default: false
           description: Flag that indicates whether to enable the passing of sample field values with the use of generative AI features in the Data Explorer for the specified project.
+          type: boolean
+        isDataValidationEnabled:
+          description: Flag that indicates whether data validation is enabled for all clusters in the specified project.
           type: boolean
         isExtendedStorageSizesEnabled:
           description: Flag that indicates whether to enable extended storage sizes for the specified project.
@@ -15346,6 +15981,38 @@ components:
         - name
         - value
       type: object
+    ImportedDashboard:
+      description: Imported dashboard.
+      properties:
+        embeddingId:
+          description: Embedding ID of the item. This field only returns if embedding is enabled for the entity.
+          type: string
+        id:
+          description: ID of the dashboard.
+          type: string
+        title:
+          description: Title of the dashboard.
+          type: string
+      required:
+        - id
+        - title
+      type: object
+    ImportedItem:
+      description: Imported Item.
+      properties:
+        embeddingId:
+          description: Embedding ID of the item. This will only be returned if embedding is enabled for the entity.
+          type: string
+        id:
+          description: ID of the item.
+          type: string
+        title:
+          description: Title of the item.
+          type: string
+      required:
+        - id
+        - title
+      type: object
     InboundControlPlaneCloudProviderIPAddresses:
       description: List of inbound IP addresses to the Atlas control plane, categorized by cloud provider. If your application allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your API requests can reach the Atlas control plane.
       properties:
@@ -15511,6 +16178,28 @@ components:
           type: object
       type: object
       writeOnly: true
+    Info:
+      description: Information about the MongoDB Atlas Administration API OpenAPI Specification.
+      properties:
+        description:
+          description: Description of the MongoDB Atlas Administration API.
+          example: The MongoDB Atlas Administration API allows developers to manage all components in MongoDB Atlas.
+          type: string
+        license:
+          $ref: "#/components/schemas/License"
+        termsOfService:
+          description: Terms of Service URL.
+          example: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
+          type: string
+        title:
+          description: Title of the MongoDB Atlas Administration API.
+          example: MongoDB Atlas Administration API.
+          type: string
+        version:
+          description: Version of the MongoDB Atlas Administration API.
+          example: "2.0"
+          type: string
+      type: object
     IngestionPipelineRun:
       description: Run details of a Data Lake Pipeline.
       properties:
@@ -16054,6 +16743,7 @@ components:
           enum:
             - FULLY_WARMED
             - VISIBLE_EARLIER
+            - ENHANCED_FULLY_WARMED
           externalDocs:
             description: Reduce Secondary Disk Warming Impact
             url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -16385,6 +17075,7 @@ components:
           enum:
             - FULLY_WARMED
             - VISIBLE_EARLIER
+            - ENHANCED_FULLY_WARMED
           externalDocs:
             description: Reduce Secondary Disk Warming Impact
             url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -16647,6 +17338,18 @@ components:
           description: Human-readable label that identifies the zone in a Global Cluster. Provide this value only if `clusterType` is `GEOSHARDED`.
           type: string
       type: object
+    License:
+      description: License information of the MongoDB Atlas Administration API.
+      properties:
+        name:
+          description: Name of the license.
+          example: CC BY-NC-SA 3.0 US
+          type: string
+        url:
+          description: URL of the license.
+          example: https://creativecommons.org/licenses/by-nc-sa/3.0/us/
+          type: string
+      type: object
     Link:
       properties:
         href:
@@ -16859,6 +17562,7 @@ components:
             - FAILED
             - COMPLETE
             - EXPIRED
+          nullable: true
           readOnly: true
           type: string
       type: object
@@ -17441,6 +18145,7 @@ components:
           description: List that contains the Atlas Search index identifiers.
           items:
             description: Unique 24-hexadecimal digit string that identifies the index.
+            nullable: true
             type: string
           readOnly: true
           type: array
@@ -17838,6 +18543,48 @@ components:
           readOnly: true
           type: array
       type: object
+    MongosRegionConfig:
+      description: Dedicated mongos placement in one region.
+      properties:
+        nodeCount:
+          description: Number of dedicated mongos to run in this region.
+          format: int32
+          type: integer
+        providerName:
+          description: Cloud provider on which the dedicated mongos run.
+          enum:
+            - AWS
+            - AZURE
+            - GCP
+          type: string
+        regionName:
+          description: Region in which the dedicated mongos run.
+          type: string
+      type: object
+    MongosTier:
+      description: Hardware spec for the dedicated mongos tier.
+      properties:
+        instanceSize:
+          description: Instance size of the dedicated mongos hosts (for example, `M30`).
+          type: string
+        regionConfigs:
+          description: Per-region placement of the dedicated mongos hosts.
+          items:
+            $ref: "#/components/schemas/MongosRegionConfig"
+          type: array
+      type: object
+    MongosTopology:
+      description: "Configuration of the mongos routers for a sharded cluster: colocated on the shard nodes or running on a dedicated tier."
+      properties:
+        state:
+          description: Desired mongos topology. `COLOCATED` runs mongos on the shard nodes; `DEDICATED` runs mongos on a dedicated tier described by `tier`.
+          enum:
+            - COLOCATED
+            - DEDICATED
+          type: string
+        tier:
+          $ref: "#/components/schemas/MongosTier"
+      type: object
     NamespaceObj:
       description: Human-readable label that identifies the namespace on the specified host. The resource expresses this parameter value as `<database>.<collection>`.
       properties:
@@ -17965,7 +18712,38 @@ components:
             - AWS
           type: string
         regionName:
-          description: Cloud provider region in which the Object Storage private endpoint is located.
+          description: Cloud provider region of the S3 bucket that the Object Storage private endpoint accesses. For same-region endpoints, this is also the region where the VPC interface endpoint is deployed.
+          type: string
+          enum:
+            - US_GOV_WEST_1
+            - US_GOV_EAST_1
+            - US_EAST_1
+            - US_EAST_2
+            - US_WEST_1
+            - US_WEST_2
+            - CA_CENTRAL_1
+            - EU_NORTH_1
+            - EU_WEST_1
+            - EU_WEST_2
+            - EU_WEST_3
+            - EU_CENTRAL_1
+            - AP_EAST_1
+            - AP_NORTHEAST_1
+            - AP_NORTHEAST_2
+            - AP_NORTHEAST_3
+            - AP_SOUTHEAST_1
+            - AP_SOUTHEAST_2
+            - AP_SOUTHEAST_3
+            - AP_SOUTH_1
+            - SA_EAST_1
+            - CN_NORTH_1
+            - CN_NORTHWEST_1
+            - ME_SOUTH_1
+            - AF_SOUTH_1
+            - EU_SOUTH_1
+            - GLOBAL
+        vpcRegionName:
+          description: Cloud provider region in which the VPC interface endpoint is deployed. Omit to deploy the interface endpoint in the same region as the S3 bucket (same-region endpoint). Set to a region different from `regionName` to create a cross-region endpoint.
           type: string
           enum:
             - US_GOV_WEST_1
@@ -18018,7 +18796,7 @@ components:
           readOnly: true
           type: string
         regionName:
-          description: Cloud provider region in which the Object Storage private endpoint is located.
+          description: Cloud provider region in which the Object Storage bucket is located. For cross-region endpoints, this differs from `vpcRegionName`, which is the region in which the VPC interface endpoint is deployed.
           type: string
           enum:
             - US_GOV_WEST_1
@@ -18059,6 +18837,37 @@ components:
             - DELETING
           readOnly: true
           type: string
+        vpcRegionName:
+          description: Cloud provider region in which the VPC interface endpoint is deployed. Echoes `regionName` for same-region endpoints.
+          type: string
+          enum:
+            - US_GOV_WEST_1
+            - US_GOV_EAST_1
+            - US_EAST_1
+            - US_EAST_2
+            - US_WEST_1
+            - US_WEST_2
+            - CA_CENTRAL_1
+            - EU_NORTH_1
+            - EU_WEST_1
+            - EU_WEST_2
+            - EU_WEST_3
+            - EU_CENTRAL_1
+            - AP_EAST_1
+            - AP_NORTHEAST_1
+            - AP_NORTHEAST_2
+            - AP_NORTHEAST_3
+            - AP_SOUTHEAST_1
+            - AP_SOUTHEAST_2
+            - AP_SOUTHEAST_3
+            - AP_SOUTH_1
+            - SA_EAST_1
+            - CN_NORTH_1
+            - CN_NORTHWEST_1
+            - ME_SOUTH_1
+            - AF_SOUTH_1
+            - EU_SOUTH_1
+            - GLOBAL
       type: object
     OnlineArchiveSchedule:
       description: Regular frequency and duration when archiving process occurs.
@@ -18136,6 +18945,11 @@ components:
               - endMinute
               - startHour
               - startMinute
+    OpenApiInfo:
+      properties:
+        info:
+          $ref: "#/components/schemas/Info"
+      type: object
     OrgAssociatedInvoiceResponse:
       description: Response containing associated invoices for an organization.
       properties:
@@ -18152,6 +18966,70 @@ components:
           description: Four-digit number that represents the year of the associated invoices.
           example: "2024"
           type: string
+      type: object
+    OrgDelegationSettingsResponse:
+      properties:
+        delegatedMcpAccess:
+          description: Policy that controls how MCP (Model Context Protocol) delegated access is permitted within this organization. Possible values are `DISALLOWED`, `READ_ONLY`, and `READ_WRITE`. Defaults to `DISALLOWED`.
+          enum:
+            - DISALLOWED
+            - READ_ONLY
+            - READ_WRITE
+          nullable: true
+          type: string
+        delegatedPartnerAccess:
+          description: Policy that controls whether partner delegated access is permitted within this organization. Possible values are `DISALLOWED` and `READ_WRITE`. Defaults to `DISALLOWED`.
+          enum:
+            - DISALLOWED
+            - READ_WRITE
+          nullable: true
+          type: string
+        idleRefreshTokenLifetime:
+          description: Maximum number of seconds a refresh token may be idle before it expires. When not set, the system default applies.
+          format: int64
+          maximum: 31536000
+          minimum: 1
+          nullable: true
+          type: integer
+        maximumRefreshTokenLifetime:
+          description: Maximum lifetime of a refresh token in seconds, regardless of activity. When not set, the system default applies.
+          format: int64
+          maximum: 31536000
+          minimum: 1
+          nullable: true
+          type: integer
+      type: object
+    OrgDelegationSettingsUpdateRequest:
+      properties:
+        delegatedMcpAccess:
+          description: Policy that controls how MCP (Model Context Protocol) delegated access is permitted within this organization. Possible values are `DISALLOWED`, `READ_ONLY`, and `READ_WRITE`. Defaults to `DISALLOWED`.
+          enum:
+            - DISALLOWED
+            - READ_ONLY
+            - READ_WRITE
+          nullable: true
+          type: string
+        delegatedPartnerAccess:
+          description: Policy that controls whether partner delegated access is permitted within this organization. Possible values are `DISALLOWED` and `READ_WRITE`. Defaults to `DISALLOWED`.
+          enum:
+            - DISALLOWED
+            - READ_WRITE
+          nullable: true
+          type: string
+        idleRefreshTokenLifetime:
+          description: Maximum number of seconds a refresh token may be idle before it expires. Omit to leave unchanged; set to null to reset to the system default. Must be between 1 and 31536000 (1 year) when provided.
+          format: int64
+          maximum: 31536000
+          minimum: 1
+          nullable: true
+          type: integer
+        maximumRefreshTokenLifetime:
+          description: Maximum lifetime of a refresh token in seconds, regardless of activity. Omit to leave unchanged; set to null to reset to the system default. Must be between 1 and 31536000 (1 year) when provided.
+          format: int64
+          maximum: 31536000
+          minimum: 1
+          nullable: true
+          type: integer
       type: object
     OrgFederationSettings:
       description: Details that define how to connect one MongoDB Cloud organization to one federated authentication service.
@@ -18220,6 +19098,52 @@ components:
             readOnly: true
             type: string
           readOnly: true
+          type: array
+      type: object
+    OrgMcpConfigResponse:
+      properties:
+        clientId:
+          description: Unique identifier for the Service Account client associated with this MCP configuration. Use this Service Account to connect to the Atlas Remote MCP.
+          example: mdb_sa_id_1234567890abcdef12345678
+          pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+          readOnly: true
+          type: string
+        egressClientId:
+          description: Unique identifier for the egress Service Account client associated with this MCP configuration. This Service Account is managed by MongoDB Atlas.
+          example: mdb_sa_id_1234567890abcdef12345678
+          pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+          readOnly: true
+          type: string
+        ipAccessList:
+          description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+          items:
+            $ref: "#/components/schemas/ServiceAccountIPAccessListEntry"
+          maxItems: 200
+          type: array
+        mcpConfigId:
+          description: Unique 24-hexadecimal digit string that identifies this MCP configuration.
+          example: 32b6e34b3d91647adeabc012
+          pattern: ^[a-fA-F0-9]{24}$
+          readOnly: true
+          type: string
+        mcpConfigName:
+          description: Human-readable name that identifies this MCP configuration.
+          nullable: true
+          type: string
+        roles:
+          description: List of organization roles associated with this MCP configuration.
+          items:
+            description: Organization roles available for Service Accounts.
+            enum:
+              - ORG_MEMBER
+              - ORG_READ_ONLY
+              - ORG_BILLING_ADMIN
+              - ORG_BILLING_READ_ONLY
+              - ORG_STREAM_PROCESSING_ADMIN
+              - ORG_GROUP_CREATOR
+              - ORG_OWNER
+            type: string
+          maxItems: 100
           type: array
       type: object
     OrgPaginatedEventView:
@@ -18291,6 +19215,7 @@ components:
       type: object
     OrgServiceAccountRequest:
       description: Organization Service Account that Atlas creates for this organization. If omitted, Atlas doesn't create an organization Service Account for this organization. If specified, this object requires all body parameters. Note that API Keys cannot be specified in the same request.
+      nullable: true
       properties:
         description:
           description: Human readable description for the Service Account.
@@ -18322,7 +19247,9 @@ components:
         secretExpiresAfterHours:
           description: The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.
           example: 8
+          exclusiveMinimum: true
           format: int32
+          minimum: 0
           type: integer
       required:
         - description
@@ -18336,12 +19263,14 @@ components:
           description: Human readable description for the Service Account.
           maxLength: 250
           minLength: 1
+          nullable: true
           pattern: ^[\p{L}\p{N}\-_.,' ]*$
           type: string
         name:
           description: Human-readable name for the Service Account. The name is modifiable and does not have to be unique.
           maxLength: 64
           minLength: 1
+          nullable: true
           pattern: ^[\p{L}\p{N}\-_.,' ]*$
           type: string
         roles:
@@ -18726,6 +19655,33 @@ components:
             type: string
           type: array
           uniqueItems: true
+      type: object
+    OrganizationMaintenanceSettingsResponse:
+      description: Maintenance configuration settings for an organization.
+      properties:
+        effectiveWaveAssignmentMode:
+          description: Wave assignment mode that Atlas uses when scheduling maintenance for projects in this organization. This read-only field takes precedence over `waveAssignmentMode` for scheduling. It matches `waveAssignmentMode` except when cross-organization maintenance sequencing is enabled and this organization is a linked non-paying organization, in which case it reflects the paying organization's `waveAssignmentMode`. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when no mode is configured. Omitted from GET responses when maintenance sequencing is disabled for this organization.
+          enum:
+            - MANUAL
+            - ENV_TAG_MAPPING
+          readOnly: true
+          type: string
+        waveAssignmentMode:
+          description: Mode explicitly configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Omitted from the response when no explicit preference has been set; in that case `effectiveWaveAssignmentMode` reflects the value the system uses (`MANUAL` by default). Atlas uses read-only `effectiveWaveAssignmentMode` (not this field) for scheduling. In a cross-organization billing hierarchy, a linked non-paying organization cannot update its `effectiveWaveAssignmentMode` field, which inherits from the paying organization's `waveAssignmentMode`. In this case, a linked non-paying organization's `effectiveWaveAssignmentMode` and `waveAssignmentMode` might differ.
+          enum:
+            - MANUAL
+            - ENV_TAG_MAPPING
+          nullable: true
+          type: string
+      type: object
+    OrganizationMaintenanceSettingsUpdateRequest:
+      properties:
+        waveAssignmentMode:
+          description: Mode configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when unset. Only this field can be updated; Atlas derives read-only `effectiveWaveAssignmentMode` on GET responses and uses that value for scheduling when it differs from `waveAssignmentMode`. Omit this field to leave the current value unchanged. Specify null to reset to the default value (`MANUAL`).
+          enum:
+            - MANUAL
+            - ENV_TAG_MAPPING
+          type: string
       type: object
     OrganizationSettings:
       description: Collection of settings that configures the organization.
@@ -19454,6 +20410,32 @@ components:
       required:
         - results
       type: object
+    PaginatedApiStreamsFailoverConnection:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/StreamsConnection"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
     PaginatedApiStreamsPrivateLinkView:
       properties:
         links:
@@ -19532,6 +20514,58 @@ components:
       required:
         - results
       type: object
+    PaginatedApiStreamsTransitGatewayAttachmentResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/StreamsTransitGatewayAttachmentResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
+    PaginatedApiStreamsTransitGatewayRouteResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/StreamsTransitGatewayRouteResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
     PaginatedApiStreamsVPCPeeringConnectionView:
       properties:
         links:
@@ -19573,6 +20607,32 @@ components:
           description: List of returned documents that MongoDB Cloud provides when completing this request.
           items:
             $ref: "#/components/schemas/UserAccessListResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
+    PaginatedApiVersions:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/ApiVersion"
           readOnly: true
           type: array
         totalCount:
@@ -20136,6 +21196,32 @@ components:
       required:
         - results
       type: object
+    PaginatedGroupMcpConfigView:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/GroupMcpConfigResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
     PaginatedGroupServiceAccounts:
       description: A list of Project Service Accounts.
       properties:
@@ -20386,6 +21472,32 @@ components:
           description: List of returned documents that MongoDB Cloud provides when completing this request.
           items:
             $ref: "#/components/schemas/OrgGroup"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
+    PaginatedOrgMcpConfigView:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/OrgMcpConfigResponse"
           readOnly: true
           type: array
         totalCount:
@@ -20792,6 +21904,32 @@ components:
       required:
         - results
       type: object
+    PaginatedStreamsTransitGatewayInvitationsResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        results:
+          description: List of returned documents that MongoDB Cloud provides when completing this request.
+          items:
+            $ref: "#/components/schemas/StreamsTransitGatewayInvitationsResponse"
+          readOnly: true
+          type: array
+        totalCount:
+          description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+          format: int32
+          minimum: 0
+          readOnly: true
+          type: integer
+      required:
+        - results
+      type: object
     PaginatedTeamRoleView:
       properties:
         links:
@@ -20903,6 +22041,7 @@ components:
       type: object
     PemFileInfo:
       description: PEM file information for the identity provider's current certificates.
+      nullable: true
       properties:
         certificates:
           description: List of certificates in the file.
@@ -21425,6 +22564,8 @@ components:
       type: object
     PublicApiUsageDetailsLineItemView:
       properties:
+        additionalData:
+          $ref: "#/components/schemas/AdditionalData"
         billDate:
           description: Billing date of the line item. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           format: date-time
@@ -21624,15 +22765,18 @@ components:
           description: Human-readable label that identifies the namespace on the specified host. The resource expresses this parameter value as `<database>.<collection>`.
           type: string
         p50ExecMicros:
-          description: The 50th percentile value of execution time in microseconds.
+          deprecated: true
+          description: The 50th percentile value of execution time in microseconds. This field is deprecated as the values it reports may be inaccurate. It will be removed in a future release.
           format: double
           type: number
         p90ExecMicros:
-          description: The 90th percentile value of execution time in microseconds.
+          deprecated: true
+          description: The 90th percentile value of execution time in microseconds. This field is deprecated as the values it reports may be inaccurate. It will be removed in a future release.
           format: double
           type: number
         p99ExecMicros:
-          description: The 99th percentile value of execution time in microseconds.
+          deprecated: true
+          description: The 99th percentile value of execution time in microseconds. This field is deprecated as the values it reports may be inaccurate. It will be removed in a future release.
           format: double
           type: number
         queryShape:
@@ -21667,6 +22811,7 @@ components:
         defaultValue:
           description: The default request capacity of the endpoint set. Returned if there is a capacity override set for the requested entity.
           format: int64
+          nullable: true
           type: integer
         value:
           description: The applied request capacity of the endpoint set.
@@ -21695,6 +22840,7 @@ components:
         defaultValue:
           description: The default rate limit refill duration, in seconds, of the endpoint set. Returned if there is a rate limit refill duration override set for the requested entity.
           format: int64
+          nullable: true
           type: integer
         value:
           description: The applied rate limit refill duration of the endpoint set.
@@ -21707,6 +22853,7 @@ components:
         defaultValue:
           description: The default rate limit refill rate of the endpoint set. Returned if there is a rate limit refill rate override set for the requested entity.
           format: int64
+          nullable: true
           type: integer
         value:
           description: The applied rate limit refill rate of the endpoint set.
@@ -21951,6 +23098,7 @@ components:
       type: object
     SandboxClusterTemplateView:
       description: Cluster template configuration for sandbox clusters.
+      nullable: true
       properties:
         provider:
           description: The provider for a cluster.
@@ -21972,6 +23120,7 @@ components:
           $ref: "#/components/schemas/SandboxClusterTemplateView"
         enabled:
           description: Whether sandbox mode is enabled for the organization.
+          nullable: true
           type: boolean
       type: object
     SandboxConfigResponse:
@@ -21981,6 +23130,7 @@ components:
           $ref: "#/components/schemas/SandboxClusterTemplateView"
         enabled:
           description: Whether sandbox mode is enabled for the organization.
+          nullable: true
           type: boolean
         id:
           description: The ID of the sandbox configuration.
@@ -21996,6 +23146,7 @@ components:
           $ref: "#/components/schemas/SandboxClusterTemplateView"
         enabled:
           description: Whether sandbox mode is enabled for the organization.
+          nullable: true
           type: boolean
       type: object
     SchemaAdvisorItemRecommendation:
@@ -22966,6 +24117,7 @@ components:
         cidrBlock:
           description: Range of network addresses in the access list for the Service Account. This parameter requires the range to be expressed in Classless Inter-Domain Routing (CIDR) notation of Internet Protocol version 4 or version 6 addresses. You can set a value for this parameter or `ipAddress`, but not for both in the same request.
           example: 203.0.113.0/24
+          nullable: true
           pattern: ^((([0-9]{1,3}\.){3}[0-9]{1,3})|(:{0,2}([0-9a-f]{1,4}:){0,7}[0-9a-f]{1,4}[:]{0,2}))((%2[fF]|/)[0-9]{1,3})+$
           type: string
         createdAt:
@@ -22976,16 +24128,19 @@ components:
         ipAddress:
           description: Network address in the access list for the Service Account. This parameter requires the address to be expressed as one Internet Protocol version 4 or version 6 address. You can set a value for this parameter or `cidrBlock`, but not for both in the same request.
           example: 203.0.113.10
+          nullable: true
           pattern: ^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}|([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}$
           type: string
         lastUsedAddress:
           description: Network address that issued the most recent request to the API. This parameter requires the address to be expressed as one Internet Protocol version 4 or version 6 address. The resource returns this parameter after this IP address makes at least one request.
           example: 203.0.113.10
+          nullable: true
           readOnly: true
           type: string
         lastUsedAt:
           description: Date when MongoDB Cloud received the most recent request that originated from this Internet Protocol version 4 or version 6 address. The resource returns this parameter when at least one request originates from this IP address. MongoDB Cloud updates this parameter each time a client accesses the permitted resource, with a delay of up to 5 minutes. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           format: date-time
+          nullable: true
           readOnly: true
           type: string
         requestCount:
@@ -23015,6 +24170,7 @@ components:
         lastUsedAt:
           description: The last time the secret was used. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           format: date-time
+          nullable: true
           readOnly: true
           type: string
         maskedSecretValue:
@@ -23078,6 +24234,7 @@ components:
       writeOnly: true
     ShardingRequest:
       description: Document that configures sharding on the destination cluster when migrating from a replica set source to a sharded cluster destination on MongoDB 6.0 or higher. If you don't wish to shard any collections on the destination cluster, leave this empty.
+      nullable: true
       properties:
         createSupportingIndexes:
           description: Flag that lets the migration create supporting indexes for the shard keys, if none exists, as the destination cluster also needs compatible indexes for the specified shard keys.
@@ -23111,6 +24268,7 @@ components:
       properties:
         caCertificatePath:
           description: Path to the CA certificate that signed SSL certificates use to authenticate to the source cluster.
+          nullable: true
           type: string
         clusterName:
           description: Label that identifies the source cluster name.
@@ -23126,6 +24284,7 @@ components:
           type: boolean
         password:
           description: Password that authenticates the username to the source cluster.
+          nullable: true
           type: string
           writeOnly: true
         ssl:
@@ -23133,6 +24292,7 @@ components:
           type: boolean
         username:
           description: Label that identifies the SCRAM-SHA user that connects to the source cluster.
+          nullable: true
           type: string
           writeOnly: true
       required:
@@ -23332,6 +24492,7 @@ components:
           type: string
         clusterGroupId:
           description: Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.
+          nullable: true
           type: string
         clusterName:
           description: Name of the cluster configured for this connection.
@@ -23668,6 +24829,9 @@ components:
     StreamsModifyStreamProcessor:
       description: A request to modify an existing stream processor.
       properties:
+        failoverEnabled:
+          description: Flag that enables or disables failover for the stream processor.
+          type: boolean
         links:
           description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
           externalDocs:
@@ -23836,6 +25000,9 @@ components:
           pattern: ^([a-f0-9]{24})$
           readOnly: true
           type: string
+        failoverEnabled:
+          description: Flag that enables or disables failover for the stream processor.
+          type: boolean
         links:
           description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
           externalDocs:
@@ -23886,9 +25053,11 @@ components:
           enum:
             - GRACEFUL
             - FORCED
+          nullable: true
           type: string
         region:
           description: Name of the region against which to apply the status change. Required when `status` is `FAILED_OVER`; optional otherwise.
+          nullable: true
           type: string
         status:
           description: Represents the desired action to apply to stream processors within a workspace, such as starting all processors, stopping all processors, or performing a bulk regional failover.
@@ -23909,6 +25078,14 @@ components:
           pattern: ^([a-f0-9]{24})$
           readOnly: true
           type: string
+        eligibleForFailover:
+          description: Flag that indicates whether the stream processor is eligible for failover.
+          readOnly: true
+          type: boolean
+        failoverEnabled:
+          description: Flag that enables or disables failover for the stream processor.
+          readOnly: true
+          type: boolean
         links:
           description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
           externalDocs:
@@ -24045,6 +25222,8 @@ components:
     StreamsStartStreamProcessorWith:
       description: A request to start a stream processor.
       properties:
+        failover:
+          $ref: "#/components/schemas/StreamsStartProcessorFailover"
         links:
           description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
           externalDocs:
@@ -24091,6 +25270,12 @@ components:
           type: array
         dataProcessRegion:
           $ref: "#/components/schemas/StreamsDataProcessRegion"
+        failoverRegions:
+          description: List of failover regions configured for the stream workspace.
+          items:
+            $ref: "#/components/schemas/StreamsDataProcessRegion"
+          maxItems: 2
+          type: array
         groupId:
           description: Unique 24-hexadecimal character string that identifies the project.
           example: 32b6e34b3d91647abb20e7b8
@@ -24122,7 +25307,7 @@ components:
         streamConfig:
           $ref: "#/components/schemas/StreamConfig"
       type: object
-    StreamsTenantUpdatePreviewUpdateRequest:
+    StreamsTenantUpdateRequest:
       description: Details to update a stream tenant, optionally accompanied by a processor status change (for example, triggering bulk regional failover).
       properties:
         cloudProvider:
@@ -24134,6 +25319,12 @@ components:
             - TENANT
             - SERVERLESS
           type: string
+        failoverRegions:
+          description: Failover regions for the stream workspace.
+          items:
+            $ref: "#/components/schemas/StreamsDataProcessRegion"
+          maxItems: 2
+          type: array
         links:
           description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
           externalDocs:
@@ -24150,17 +25341,73 @@ components:
         streamConfig:
           $ref: "#/components/schemas/StreamConfig"
       type: object
-    StreamsTenantUpdateRequest:
-      description: Details to update a stream tenant.
+    StreamsTransitGatewayAttachmentRequest:
       properties:
         cloudProvider:
-          description: Human-readable label that identifies the cloud provider.
-          enum:
-            - AWS
-            - GCP
-            - AZURE
-            - TENANT
-            - SERVERLESS
+          description: Provider for the transit gateway resources.
+          type: string
+          writeOnly: true
+        regionName:
+          description: AWS region name.
+          type: string
+          writeOnly: true
+        tgwId:
+          description: AWS transit gateway ID.
+          pattern: ^(tgw-)[0-9a-zA-Z]+$
+          type: string
+        vpcId:
+          description: AWS VPC ID.
+          pattern: ^(vpc-)[0-9a-zA-Z]+$
+          type: string
+          writeOnly: true
+      type: object
+    StreamsTransitGatewayAttachmentResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        tgwAttachmentId:
+          description: The AWS Transit Gateway Attachment ID.
+          pattern: ^(tgw-attach-)[0-9a-zA-Z]+$
+          readOnly: true
+          type: string
+        tgwId:
+          description: AWS transit gateway ID.
+          pattern: ^(tgw-)[0-9a-zA-Z]+$
+          type: string
+      type: object
+    StreamsTransitGatewayInvitationsResponse:
+      properties:
+        links:
+          description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+          externalDocs:
+            description: Web Linking Specification (RFC 5988)
+            url: https://datatracker.ietf.org/doc/html/rfc5988
+          items:
+            $ref: "#/components/schemas/Link"
+          readOnly: true
+          type: array
+        tgwId:
+          description: AWS transit gateway ID.
+          pattern: ^(tgw-)[0-9a-zA-Z]+$
+          type: string
+        tgwResourceShareArn:
+          description: AWS Transit Gateway resource share ARN.
+          type: string
+        tgwResourceShareInvitationArn:
+          description: AWS Transit Gateway resource share invitation ARN.
+          type: string
+      type: object
+    StreamsTransitGatewayResourceShare:
+      properties:
+        cloudProvider:
+          description: Provider for the transit gateway resources.
           type: string
         links:
           description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
@@ -24171,10 +25418,52 @@ components:
             $ref: "#/components/schemas/Link"
           readOnly: true
           type: array
+        regionName:
+          description: AWS Region name.
+          type: string
+        tgwId:
+          description: AWS transit gateway ID.
+          pattern: ^(tgw-)[0-9a-zA-Z]+$
+          type: string
+        tgwResourceShareArn:
+          description: AWS Transit Gateway resource share ARN.
+          type: string
+        tgwResourceShareInvitationArn:
+          description: AWS Transit Gateway resource share invitation ARN.
+          readOnly: true
+          type: string
+      type: object
+    StreamsTransitGatewayRouteRequest:
+      description: Container for metadata needed to create a Transit Gateway route.
+      properties:
+        destinationCidr:
+          description: The route's destination CIDR.
+          type: string
         region:
-          $ref: "#/components/schemas/BaseStreamsRegion"
-        streamConfig:
-          $ref: "#/components/schemas/StreamConfig"
+          description: The region of the Atlas VPCs where this route should take effect.
+          type: string
+        tgwId:
+          description: The AWS ID of the Transit Gateway through which traffic will be routed.
+          type: string
+      type: object
+    StreamsTransitGatewayRouteResponse:
+      description: Container for metadata associated with a Transit Gateway route.
+      properties:
+        destinationCidr:
+          description: The route's destination CIDR.
+          type: string
+        region:
+          description: The region of the Atlas VPCs where this route should take effect.
+          type: string
+        tgwId:
+          description: The AWS ID of the Transit Gateway through which traffic will be routed.
+          type: string
+        tgwRouteId:
+          description: The ID of the Transit Gateway route.
+          example: 32b6e34b3d91647abb20e7b8
+          pattern: ^([a-f0-9]{24})$
+          readOnly: true
+          type: string
       type: object
     SynonymMappingStatusDetail:
       description: Contains the status of the index's synonym mappings on each search host. This field (and its subfields) only appear if the index has synonyms defined.
@@ -24465,6 +25754,16 @@ components:
           description: Routing key associated with your Splunk On-Call account.
           example: test routing
           type: string
+        bodyTemplate:
+          description: "HTTP body template for a webhook-based alert. The rendered output MUST be valid JSON — MongoDB Cloud sends the rendered body with `Content-Type: application/json`. If the template fails to render, exceeds the 16 KB limit, or renders non-JSON output, MongoDB Cloud sends the webhook with its default JSON payload instead."
+          example: '{"alert":"${id}","severity":"${severity}"}'
+          format: password
+          type: string
+        headersTemplate:
+          description: 'HTTP headers template for a webhook-based alert. The rendered output MUST be a JSON object mapping header name to header value (e.g. `{"X-Custom-Header": "static-value", "X-Alert-Id": "${id}"}`). Placeholders may reference any alert-view field plus `${eventType}`; the webhook secret and the signature header are NOT exposed to templates. If the template fails to render, exceeds the 4 KB limit, or renders output that is not a valid JSON name→value object, MongoDB Cloud sends the webhook with its default set of headers instead.'
+          example: '{"X-Alert-Id":"${id}","X-Event-Type":"${eventType}"}'
+          format: password
+          type: string
         secret:
           description: |-
             An optional field returned if your webhook is configured with a secret.
@@ -24577,6 +25876,8 @@ components:
               - apiKey
           WEBHOOK:
             properties:
+              - bodyTemplate
+              - headersTemplate
               - secret
               - url
             required:
@@ -24612,6 +25913,7 @@ components:
               - ORG_BILLING_READ_ONLY
               - ORG_STREAM_PROCESSING_ADMIN
               - ORG_READ_ONLY
+            nullable: true
             type: string
           type: array
       type: object
@@ -24752,7 +26054,7 @@ components:
               - Cloud Manager
               - Cloud Manager Standard/Premium
               - Legacy Backup
-              - AI Models
+              - AI Model APIs
               - Automated Embedding
               - Native Reranking
               - Flex Consulting
@@ -25221,6 +26523,7 @@ components:
         description:
           description: Description of the event.
           example: Alert Acknowledged
+          nullable: true
           type: string
         gn:
           description: Human-readable label that identifies the project.
@@ -25652,7 +26955,7 @@ info:
   termsOfService: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
   title: MongoDB Atlas Administration API
   version: "2.0"
-  x-xgen-sha: 51d1ffaea55034e002aeb6329745dd9d6773c97c
+  x-xgen-sha: 68e310a94321e8bb33f32ad0383c3938555face2
 openapi: 3.0.1
 paths:
   /api/atlas/v2:
@@ -27587,10 +28890,10 @@ paths:
         - Project Model Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/updateGroupAiModelApiKey
       x-xgen-operation-id-override: updateModelApiKey
-  /api/atlas/v2/groups/{groupId}/aiModelRateLimits:
+  /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits:
     get:
       description: Retrieve AI model rate limits for the given group.
-      operationId: listGroupAiModelRateLimits
+      operationId: listGroupAiModelApiRateLimits
       parameters:
         - $ref: "#/components/parameters/groupId"
         - $ref: "#/components/parameters/itemsPerPage"
@@ -27627,12 +28930,12 @@ paths:
         - AI Model Rate Limits
       x-rolesRequirements:
         - Project Read Only
-      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listGroupAiModelRateLimits
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listGroupAiModelApiRateLimits
       x-xgen-operation-id-override: listGroupModelLimits
-  /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:
+  /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits/{modelGroupName}:
     get:
       description: Retrieve a single AI model rate limit for the given group.
-      operationId: getGroupAiModelRateLimit
+      operationId: getGroupAiModelApiRateLimit
       parameters:
         - $ref: "#/components/parameters/groupId"
         - $ref: "#/components/parameters/envelope"
@@ -27673,11 +28976,11 @@ paths:
         - AI Model Rate Limits
       x-rolesRequirements:
         - Project Read Only
-      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getGroupAiModelRateLimit
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getGroupAiModelApiRateLimit
       x-xgen-operation-id-override: getGroupModelLimit
     patch:
       description: Update an AI model rate limit for the given model group.
-      operationId: updateGroupAiModelRateLimit
+      operationId: updateGroupAiModelApiRateLimit
       parameters:
         - $ref: "#/components/parameters/groupId"
         - $ref: "#/components/parameters/envelope"
@@ -27730,12 +29033,12 @@ paths:
         - AI Model Rate Limits
       x-rolesRequirements:
         - Project Model Owner
-      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/updateGroupAiModelRateLimit
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/updateGroupAiModelApiRateLimit
       x-xgen-operation-id-override: updateModelRateLimit
-  /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:reset:
+  /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits/{modelGroupName}:reset:
     post:
       description: Reset the AI model rate limit for the given model group to default values.
-      operationId: resetGroupAiModelRateLimit
+      operationId: resetGroupAiModelApiRateLimit
       parameters:
         - $ref: "#/components/parameters/groupId"
         - $ref: "#/components/parameters/envelope"
@@ -27778,12 +29081,12 @@ paths:
         - AI Model Rate Limits
       x-rolesRequirements:
         - Project Model Owner
-      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimit
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelApiRateLimit
       x-xgen-operation-id-override: resetModelRateLimit
-  /api/atlas/v2/groups/{groupId}/aiModelRateLimits:reset:
+  /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits:reset:
     post:
       description: Reset the AI Model rate limits for the given group to default values.
-      operationId: resetGroupAiModelRateLimits
+      operationId: resetGroupAiModelApiRateLimits
       parameters:
         - $ref: "#/components/parameters/groupId"
         - $ref: "#/components/parameters/envelope"
@@ -27818,7 +29121,7 @@ paths:
         - AI Model Rate Limits
       x-rolesRequirements:
         - Project Model Owner
-      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimits
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelApiRateLimits
       x-xgen-method-verb-override:
         customMethod: "True"
         verb: reset
@@ -29573,6 +30876,132 @@ paths:
         - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupBackupCompliancePolicy
       x-xgen-operation-id-override: updateCompliancePolicy
+  /api/atlas/v2/groups/{groupId}/chartsDashboards/{dashboardId}:export:
+    get:
+      description: Exports the specified Charts dashboard.
+      operationId: exportGroupChartsDashboard
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - description: ID of the dashboard to export.
+          in: path
+          name: dashboardId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                description: This resource returns an exported Charts dashboard. You can use this response to import to the Charts Dashboard Import endpoint.
+                type: string
+              x-xgen-preview:
+                name: charts-dashboards
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Export One Charts Dashboard
+      tags:
+        - Charts Dashboards
+      x-rolesRequirements:
+        - Project Data Access Admin
+        - Project Data Access Read Only
+        - Project Data Access Read Write
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Charts-Dashboards/operation/exportGroupChartsDashboard
+      x-xgen-operation-id-override: exportChartsDashboard
+  /api/atlas/v2/groups/{groupId}/chartsDashboards:import:
+    post:
+      description: Imports the Charts dashboard that the template specifies. Optionally, you can specify `overwrite=true` to import into an existing dashboard.
+      operationId: importGroupChartsDashboards
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/groupId"
+        - description: Setting this to true enables importing into an existing dashboard.
+          in: query
+          name: overwrite
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            examples:
+              Sample import response body:
+                description: Sample import response body
+                value:
+                  dashboards:
+                    dashboard-1:
+                      description: Dashboard description
+                      embedding:
+                        anonymousAuthEnabled: true
+                      filters: []
+                      layout: []
+                      title: Dashboard title
+                  dataSources:
+                    data-source-1:
+                      alias: "Sample Data: Movies"
+                      collection: movies
+                      database: sample_data
+                      deployment: sample-data-cluster
+                      sourceType: cluster
+                  exportVersion: 9
+                  items:
+                    item-1:
+                      calculatedFields: []
+                      query: null
+                      sample: false
+                  queries: {}
+            schema:
+              type: object
+            x-xgen-preview:
+              name: charts-dashboards
+              public: "false"
+            x-xgen-version: preview
+        description: Schema corresponding to the response fetched from an exported dashboard.
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiChartsDashboardImportResponseView"
+              x-xgen-preview:
+                name: charts-dashboards
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Import One Charts Dashboard
+      tags:
+        - Charts Dashboards
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Charts-Dashboards/operation/importGroupChartsDashboards
+      x-xgen-operation-id-override: importChartsDashboards
   /api/atlas/v2/groups/{groupId}/cloudProviderAccess:
     get:
       description: Returns all cloud provider access roles with access to the specified project.
@@ -30129,6 +31558,12 @@ paths:
             schema:
               $ref: "#/components/schemas/ClusterDescription20240805"
             x-xgen-version: 2024-10-23
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/ApiAtlasClusterDescriptionPreview"
+            x-xgen-preview:
+              public: "true"
+            x-xgen-version: preview
         description: Cluster to create in this project.
         required: true
       responses:
@@ -30153,6 +31588,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ClusterDescription20240805"
               x-xgen-version: 2024-10-23
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiAtlasClusterDescriptionPreview"
+              x-xgen-preview:
+                public: "true"
+              x-xgen-version: preview
           description: Created
           headers:
             RateLimit-Limit:
@@ -30295,6 +31736,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ClusterDescription20240805"
               x-xgen-version: 2024-08-05
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiAtlasClusterDescriptionPreview"
+              x-xgen-preview:
+                public: "true"
+              x-xgen-version: preview
           description: OK
           headers:
             RateLimit-Limit:
@@ -30362,6 +31809,12 @@ paths:
             schema:
               $ref: "#/components/schemas/ClusterDescription20240805"
             x-xgen-version: 2024-10-23
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/ApiAtlasClusterDescriptionPreview"
+            x-xgen-preview:
+              public: "true"
+            x-xgen-version: preview
         description: Cluster to update in the specified project.
         required: true
       responses:
@@ -30386,6 +31839,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ClusterDescription20240805"
               x-xgen-version: 2024-10-23
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/ApiAtlasClusterDescriptionPreview"
+              x-xgen-preview:
+                public: "true"
+              x-xgen-version: preview
           description: OK
           headers:
             RateLimit-Limit:
@@ -34352,11 +35811,11 @@ paths:
             maximum: 100
             minimum: 1
             type: integer
-        - description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series.
+        - description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series. The `P50_EXECUTION_TIME`, `P90_EXECUTION_TIME`, and `P99_EXECUTION_TIME` series are deprecated as the values they report may be inaccurate. They will be removed in a future release.
           in: query
           name: series
           schema:
-            description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series.
+            description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series. The `P50_EXECUTION_TIME`, `P90_EXECUTION_TIME`, and `P99_EXECUTION_TIME` series are deprecated as the values they report may be inaccurate. They will be removed in a future release.
             items:
               enum:
                 - TOTAL_EXECUTION_TIME
@@ -40323,7 +41782,7 @@ paths:
             | Limit Name | Description | Default | API Override Limit |
             | --- | --- | --- | --- |
             | `atlas.project.deployment.clusters` | Limit on the number of clusters in this project | 25 | 100 |
-            | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on the number of nodes per Private Link region in this project | 50 | 90 |
+            | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on AWS PrivateLink addressable target nodes per region in this project. For sharded clusters using optimized (load-balanced) connection strings, `currentUsage` doesn't grow with the number of `mongos` — the load balancer is counted as a single addressable target regardless of how many `mongos` sit behind it. | 50 | 90 |
             | `atlas.project.security.databaseAccess.customRoles` | Limit on the number of custom roles in this project | 100 | 1400 |
             | `atlas.project.security.databaseAccess.users` | Limit on the number of database users in this project | 100 | 100 |
             | `atlas.project.security.networkAccess.crossRegionEntries` | Limit on the number of cross-region network access entries in this project | 40 | 220 |
@@ -40397,7 +41856,7 @@ paths:
             | Limit Name | Description | Default | API Override Limit |
             | --- | --- | --- | --- |
             | `atlas.project.deployment.clusters` | Limit on the number of clusters in this project | 25 | 100 |
-            | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on the number of nodes per Private Link region in this project | 50 | 90 |
+            | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on AWS PrivateLink addressable target nodes per region in this project. For sharded clusters using optimized (load-balanced) connection strings, `currentUsage` doesn't grow with the number of `mongos` — the load balancer is counted as a single addressable target regardless of how many `mongos` sit behind it. | 50 | 90 |
             | `atlas.project.security.databaseAccess.customRoles` | Limit on the number of custom roles in this project | 100 | 1400 |
             | `atlas.project.security.databaseAccess.users` | Limit on the number of database users in this project | 100 | 100 |
             | `atlas.project.security.networkAccess.crossRegionEntries` | Limit on the number of cross-region network access entries in this project | 40 | 220 |
@@ -40476,7 +41935,7 @@ paths:
             | Limit Name | Description | Default | API Override Limit |
             | --- | --- | --- | --- |
             | `atlas.project.deployment.clusters` | Limit on the number of clusters in this project | 25 | 100 |
-            | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on the number of nodes per Private Link region in this project | 50 | 90 |
+            | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on AWS PrivateLink addressable target nodes per region in this project. For sharded clusters using optimized (load-balanced) connection strings, `currentUsage` doesn't grow with the number of `mongos` — the load balancer is counted as a single addressable target regardless of how many `mongos` sit behind it. | 50 | 90 |
             | `atlas.project.security.databaseAccess.customRoles` | Limit on the number of custom roles in this project | 100 | 1400 |
             | `atlas.project.security.databaseAccess.users` | Limit on the number of database users in this project | 100 | 100 |
             | `atlas.project.security.networkAccess.crossRegionEntries` | Limit on the number of cross-region network access entries in this project | 40 | 220 |
@@ -41198,7 +42657,10 @@ paths:
       x-xgen-operation-id-override: toggleMaintenanceAutoDefer
   /api/atlas/v2/groups/{groupId}/maintenanceWindow/defer:
     post:
-      description: Defers the maintenance window for the specified project. Urgent maintenance activities such as security patches can't wait for your chosen window. MongoDB Cloud starts those maintenance activities when needed. After you schedule maintenance for your cluster, you can't change your maintenance window until the current maintenance efforts complete. The maintenance procedure that MongoDB Cloud performs requires at least one replica set election during the maintenance window per replica set. Maintenance always begins as close to the scheduled hour as possible, but in-progress cluster updates or unexpected system issues could delay the start time.
+      description: Defers the maintenance window for the specified project. Urgent maintenance activities such as security patches can't wait for your chosen window. MongoDB Cloud starts those maintenance activities when needed. After you schedule maintenance for your cluster, you can't change your maintenance window until the current maintenance efforts complete. The maintenance procedure that MongoDB Cloud performs requires at least one replica set election during the maintenance window per replica set. Maintenance always begins as close to the scheduled hour as possible, but in-progress cluster updates or unexpected system issues could delay the start time. You can only defer maintenance within a limited time window before the scheduled maintenance starts; deferral requests made outside of this window return an error.
+      externalDocs:
+        description: Respond to Required Maintenance
+        url: https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/#respond-to-required-maintenance
       operationId: deferGroupMaintenanceWindow
       parameters:
         - $ref: "#/components/parameters/envelope"
@@ -41349,6 +42811,153 @@ paths:
       x-xgen-method-verb-override:
         customMethod: true
       x-xgen-operation-id-override: enableManagedSlowMs
+  /api/atlas/v2/groups/{groupId}/mcpConfigs:
+    get:
+      description: Returns all MCP configurations associated with the specified project.
+      operationId: listGroupMcpConfigs
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/includeCount"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedGroupMcpConfigView"
+              x-xgen-version: 2025-03-12
+          description: OK
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All MCP Configurations for One Project
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Project Read Only
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/listGroupMcpConfigs
+    post:
+      description: Creates an MCP configuration for the specified project. Returns the configuration ID and ingress credentials.
+      operationId: createGroupMcpConfig
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2025-03-12+json:
+            schema:
+              $ref: "#/components/schemas/CreateGroupMcpConfigRequest"
+            x-xgen-version: 2025-03-12
+        description: MCP configuration to create.
+        required: true
+      responses:
+        "201":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/GroupMcpConfigResponse"
+              x-xgen-version: 2025-03-12
+          description: Created
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Create One MCP Configuration for One Project
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/createGroupMcpConfig
+  /api/atlas/v2/groups/{groupId}/mcpConfigs/{mcpConfigId}:
+    delete:
+      description: Deletes the MCP configuration with the specified ID for the specified project.
+      operationId: deleteGroupMcpConfig
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - description: Unique identifier of the MCP configuration to delete.
+          in: path
+          name: mcpConfigId
+          required: true
+          schema:
+            type: string
+        - description: Flag that indicates whether to delete the MCP configuration even if it has active secrets. If false and active secrets exist, the request returns an error. Defaults to false.
+          in: query
+          name: cascading
+          schema:
+            default: false
+            type: boolean
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              x-xgen-version: 2025-03-12
+          description: No Content
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Delete One MCP Configuration for One Project
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Project Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/deleteGroupMcpConfig
+    get:
+      description: Returns the MCP configuration with the specified ID for the specified project.
+      operationId: getGroupMcpConfig
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/groupId"
+        - description: Unique identifier of the MCP configuration.
+          in: path
+          name: mcpConfigId
+          required: true
+          schema:
+            example: 32b6e34b3d91647adeabc012
+            pattern: ^[a-fA-F0-9]{24}$
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/GroupMcpConfigResponse"
+              x-xgen-version: 2025-03-12
+          description: OK
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One MCP Configuration for One Project
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Project Read Only
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/getGroupMcpConfig
   /api/atlas/v2/groups/{groupId}/metricIntegrations:
     get:
       description: Returns all metric integration configurations for the project. Optionally filter by integration type and provider type.
@@ -44967,6 +46576,47 @@ paths:
         - Project Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/createGroupPushBasedLogExport
       x-xgen-operation-id-override: createLogExport
+  /api/atlas/v2/groups/{groupId}/ratelimits:
+    get:
+      description: Retrieve rate limiting bucket state for the specified group.
+      operationId: getGroupRatelimits
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/AtlasRateLimitInspectionResponse"
+              x-xgen-preview:
+                name: rate-limit
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Rate Limit State for One Group
+      tags:
+        - Rate Limit
+      x-rolesRequirements:
+        - Project Read Only
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/getGroupRatelimits
   /api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}:
     post:
       description: Requests loading the MongoDB sample dataset into the specified cluster.
@@ -46898,7 +48548,7 @@ paths:
               $ref: "#/components/schemas/StreamsTenantUpdateRequest"
           application/vnd.atlas.preview+json:
             schema:
-              $ref: "#/components/schemas/StreamsTenantUpdatePreviewUpdateRequest"
+              $ref: "#/components/schemas/StreamsTenantUpdateRequest"
             x-xgen-preview:
               name: regional-failover
               public: "false"
@@ -47302,6 +48952,68 @@ paths:
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamConnection
       x-xgen-operation-id-override: updateStreamConnection
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}/failoverConnections:
+    get:
+      description: Returns all failover connections for the specified connection in a stream workspace.
+      operationId: listGroupStreamConnectionFailoverConnections
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+        - description: Label that identifies the stream workspace.
+          in: path
+          name: tenantName
+          required: true
+          schema:
+            type: string
+        - description: Label that identifies the stream connection.
+          in: path
+          name: connectionName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiStreamsFailoverConnection"
+              x-xgen-version: 2025-03-12
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiStreamsFailoverConnection"
+              x-sunset: 2026-07-20
+              x-xgen-preview:
+                name: regional-failover
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Stream Failover Connections
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamConnectionFailoverConnections
+      x-xgen-operation-id-override: listFailoverConnections
     post:
       description: Creates one failover connection for a stream workspace in the specified project.
       operationId: createGroupStreamConnectionFailoverConnection
@@ -47323,25 +49035,27 @@ paths:
             type: string
       requestBody:
         content:
-          application/vnd.atlas.preview+json:
+          application/vnd.atlas.2025-03-12+json:
             schema:
               $ref: "#/components/schemas/StreamsConnection"
-            x-xgen-preview:
-              name: regional-failover
-              public: "false"
-            x-xgen-version: preview
+            x-xgen-version: application/vnd.atlas.2025-03-12+json
         description: Details to create one failover connection for a streams workspace in the specified project.
         required: true
       responses:
         "201":
           content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/StreamsConnection"
+              x-xgen-version: 2025-03-12
             application/vnd.atlas.preview+json:
               schema:
                 $ref: "#/components/schemas/StreamsConnection"
+              x-sunset: 2026-07-20
               x-xgen-preview:
                 name: regional-failover
                 public: "false"
-              x-xgen-version: application/vnd.atlas.preview+json
+              x-xgen-version: preview
           description: OK
           headers:
             RateLimit-Limit:
@@ -47368,10 +49082,204 @@ paths:
       x-rolesRequirements:
         - Organization Stream Processing Admin
         - Project Stream Processing Owner
-      x-xgen-changelog:
-        2023-09-11: The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamConnectionFailoverConnection
       x-xgen-operation-id-override: createFailoverConnection
+  /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}/failoverConnections/{failoverConnectionId}:
+    delete:
+      description: Delete one failover connection of the specified stream workspace.
+      operationId: deleteGroupStreamConnectionFailoverConnection
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/groupId"
+        - description: Label that identifies the stream workspace.
+          in: path
+          name: tenantName
+          required: true
+          schema:
+            type: string
+        - description: Label that identifies the stream connection.
+          in: path
+          name: connectionName
+          required: true
+          schema:
+            type: string
+        - description: Label that identifies the stream failover connection id.
+          in: path
+          name: failoverConnectionId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              x-xgen-version: 2025-03-12
+            application/vnd.atlas.preview+json:
+              x-sunset: 2026-07-20
+              x-xgen-preview:
+                name: regional-failover
+                public: "false"
+              x-xgen-version: preview
+          description: No Content
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Delete One Stream Failover Connection
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamConnectionFailoverConnection
+      x-xgen-operation-id-override: deleteStreamFailoverConnection
+    get:
+      description: Get one failover connection of the specified stream workspace.
+      operationId: getGroupStreamConnectionFailoverConnection
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/groupId"
+        - description: Label that identifies the stream workspace.
+          in: path
+          name: tenantName
+          required: true
+          schema:
+            type: string
+        - description: Label that identifies the stream connection.
+          in: path
+          name: connectionName
+          required: true
+          schema:
+            type: string
+        - description: Label that identifies the stream failover connection id.
+          in: path
+          name: failoverConnectionId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/StreamsConnection"
+              x-xgen-version: 2025-03-12
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/StreamsConnection"
+              x-sunset: 2026-07-20
+              x-xgen-preview:
+                name: regional-failover
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Stream Failover Connection
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamConnectionFailoverConnection
+      x-xgen-operation-id-override: getStreamFailoverConnection
+    patch:
+      description: Update one failover connection of the specified stream workspace.
+      operationId: updateGroupStreamConnectionFailoverConnection
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/groupId"
+        - description: Label that identifies the stream workspace.
+          in: path
+          name: tenantName
+          required: true
+          schema:
+            type: string
+        - description: Label that identifies the stream connection.
+          in: path
+          name: connectionName
+          required: true
+          schema:
+            type: string
+        - description: Label that identifies the stream failover connection id.
+          in: path
+          name: failoverConnectionId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/vnd.atlas.2025-03-12+json:
+            schema:
+              $ref: "#/components/schemas/StreamsConnection"
+        description: Details to update one failover connection for a streams workspace in the specified project.
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/StreamsConnection"
+              x-xgen-version: 2025-03-12
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/StreamsConnection"
+              x-sunset: 2026-07-20
+              x-xgen-preview:
+                name: regional-failover
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Update One Stream Failover Connection
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamConnectionFailoverConnection
+      x-xgen-operation-id-override: updateStreamFailoverConnection
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor:
     post:
       description: Create one Stream Processor within the specified stream workspace.
@@ -47758,7 +49666,7 @@ paths:
       x-xgen-operation-id-override: stopStreamProcessor
   /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processors:
     get:
-      description: Returns all Stream Processors within the specified stream workspace.
+      description: Returns all Stream Processors within the specified stream workspace, including information on which processors are failover-eligible.
       operationId: getGroupStreamProcessors
       parameters:
         - $ref: "#/components/parameters/envelope"
@@ -48386,6 +50294,609 @@ paths:
         - Project Stream Processing Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/withGroupStreamSampleConnections
       x-xgen-operation-id-override: withStreamSampleConnections
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayAttachments:
+    get:
+      description: Returns the Transit Gateway Attachments for this group in the shared Atlas AWS Account.
+      operationId: listGroupStreamsTransitGatewayAttachments
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiStreamsTransitGatewayAttachmentResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Transit Gateway Attachments for One Group
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamsTransitGatewayAttachments
+      x-xgen-operation-id-override: listTransitGatewayAttachments
+    post:
+      description: Creates Transit Gateway Attachment with the provided VPC for a Transit Gateway that has been shared with an Atlas AWS Account. This Transit Gateway will be used in Atlas Streams private networking connections.
+      operationId: createGroupStreamsTransitGatewayAttachment
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/StreamsTransitGatewayAttachmentRequest"
+            x-xgen-preview:
+              name: aws-transit-gateway
+            x-xgen-version: preview
+        description: Metadata needed for creating a transit gateway attachment.
+        required: true
+      responses:
+        "201":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/StreamsTransitGatewayAttachmentResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: Created
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Create One Transit Gateway Attachment
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamsTransitGatewayAttachment
+      x-xgen-operation-id-override: createTransitGatewayAttachment
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayAttachments/{attachmentId}:
+    delete:
+      description: Deletes a transit gateway attachment.
+      operationId: deleteGroupStreamsTransitGatewayAttachment
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - description: Unique identifier that identifies the Transit Gateway Attachment.
+          in: path
+          name: attachmentId
+          required: true
+          schema:
+            example: tgw-attach-01f8100bc7EXAMPLE
+            pattern: ^tgw-attach-[0-9a-zA-Z]+$
+            type: string
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.preview+json:
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: No Content
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Delete One Transit Gateway Attachment
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamsTransitGatewayAttachment
+      x-xgen-operation-id-override: deleteTransitGatewayAttachment
+    get:
+      description: Returns one Transit Gateway Attachment for this group from the shared Atlas AWS Account.
+      operationId: getGroupStreamsTransitGatewayAttachment
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - description: Unique identifier that identifies the Transit Gateway Attachment.
+          in: path
+          name: attachmentId
+          required: true
+          schema:
+            example: tgw-attach-01f8100bc7EXAMPLE
+            pattern: ^tgw-attach-[0-9a-zA-Z]+$
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/StreamsTransitGatewayAttachmentResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Transit Gateway Attachment for One Group
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamsTransitGatewayAttachment
+      x-xgen-operation-id-override: getTransitGatewayAttachment
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations:
+    get:
+      description: Returns the AWS RAM Resource Shares and Transit Gateway IDs for a Transit Gateway that has been shared with an Atlas AWS Account. This only returns the resource shares cached for Atlas Streams Processing.
+      operationId: listGroupStreamsTransitGatewayInvitations
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedStreamsTransitGatewayInvitationsResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Streams Transit Gateway Invitations
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamsTransitGatewayInvitations
+      x-xgen-operation-id-override: listTransitGatewayInvitations
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations/{resourceShareArn}:
+    delete:
+      description: Deletes an AWS Resource Share Invitation for a Transit Gateway that has been shared with an Atlas AWS account. This does not delete the resource share invitation from the sender's AWS account. This only deletes the resource share invitation that's cached for Atlas Streams Processing.
+      operationId: deleteGroupStreamsTransitGatewayInvitation
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - description: AWS Transit Gateway resource share ARN.
+          in: path
+          name: resourceShareArn
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.preview+json:
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: No Content
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Delete One Transit Gateway Invitation
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamsTransitGatewayInvitation
+      x-xgen-operation-id-override: deleteTransitGatewayInvitation
+    get:
+      description: Returns the details of one AWS Resource Share Invitation for a Transit Gateway that has been shared with an Atlas AWS Account. This only returns the resource share invitation cached for Atlas Streams Processing.
+      operationId: getGroupStreamsTransitGatewayInvitation
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - description: AWS Transit Gateway resource share ARN.
+          in: path
+          name: resourceShareArn
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/StreamsTransitGatewayInvitationsResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Transit Gateway Invitation
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamsTransitGatewayInvitation
+      x-xgen-operation-id-override: getTransitGatewayInvitation
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations:accept:
+    post:
+      description: Accept AWS RAM Resource Share for a Transit Gateway that has been shared with an Atlas AWS account. This Transit Gateway will be used in Atlas Streams private networking connections.
+      operationId: acceptGroupStreamsTransitGatewayInvitations
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/StreamsTransitGatewayResourceShare"
+            x-xgen-preview:
+              name: aws-transit-gateway
+            x-xgen-version: preview
+        description: Detailed information on accepting a transit gateway resource share invitation.
+        required: true
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.preview+json:
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: No Content
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Accept Transit Gateway Resource Share Invitations
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/acceptGroupStreamsTransitGatewayInvitations
+      x-xgen-operation-id-override: acceptTransitGatewayInvitations
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations:reject:
+    post:
+      description: Rejects AWS RAM Resource Share for a Transit Gateway that has been shared with an Atlas AWS account.
+      operationId: rejectGroupStreamsTransitGatewayInvitations
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/StreamsTransitGatewayResourceShare"
+            x-xgen-preview:
+              name: aws-transit-gateway
+            x-xgen-version: preview
+        description: Detailed information on rejecting a transit gateway resource share invitation.
+        required: true
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.preview+json:
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: No Content
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Reject Transit Gateway Resource Share Invitations
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/rejectGroupStreamsTransitGatewayInvitations
+      x-xgen-operation-id-override: rejectTransitGatewayInvitations
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayRoutes:
+    get:
+      description: List Transit Gateway routes in the default route table associated with Atlas VPC.
+      operationId: listGroupStreamsTransitGatewayRoutes
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiStreamsTransitGatewayRouteResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Transit Gateway Routes in the Default Route Table for One Atlas VPC
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamsTransitGatewayRoutes
+      x-xgen-operation-id-override: listTransitGatewayRoutes
+    post:
+      description: Creates a route in the default route table associated with Atlas VPC to route all traffic destined for provided CIDR to the provided Transit Gateway.
+      operationId: createGroupStreamsTransitGatewayRoute
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/StreamsTransitGatewayRouteRequest"
+            x-xgen-preview:
+              name: aws-transit-gateway
+            x-xgen-version: preview
+        description: Metadata needed for creating a transit gateway route.
+        required: true
+      responses:
+        "201":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/StreamsTransitGatewayRouteResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: Created
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Create One Transit Gateway Route in the Default Route Table for One Atlas VPC
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamsTransitGatewayRoute
+      x-xgen-operation-id-override: createTransitGatewayRoute
+  /api/atlas/v2/groups/{groupId}/streamsTransitGatewayRoutes/{routeId}:
+    delete:
+      description: Deletes a transit gateway route in the default route table associated with Atlas VPC.
+      operationId: deleteGroupStreamsTransitGatewayRoute
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - $ref: "#/components/parameters/envelope"
+        - description: The Object ID that uniquely identifies a transit gateway route.
+          in: path
+          name: routeId
+          required: true
+          schema:
+            example: 32b6e34b3d91647abb20e7b8
+            pattern: ^([a-f0-9]{24})$
+            type: string
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.preview+json:
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: No Content
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Delete One Transit Gateway Route in the Default Route Table for One Atlas VPC
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamsTransitGatewayRoute
+      x-xgen-operation-id-override: deleteTransitGatewayRoute
+    get:
+      description: Retrieves a transit gateway route in the default route table associated with Atlas VPC.
+      operationId: getGroupStreamsTransitGatewayRoute
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+        - description: The Object ID that uniquely identifies a transit gateway route.
+          in: path
+          name: routeId
+          required: true
+          schema:
+            example: 32b6e34b3d91647abb20e7b8
+            pattern: ^([a-f0-9]{24})$
+            type: string
+        - $ref: "#/components/parameters/envelope"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/StreamsTransitGatewayRouteResponse"
+              x-xgen-preview:
+                name: aws-transit-gateway
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One Transit Gateway Route in the Default Route Table for One Atlas VPC
+      tags:
+        - Streams
+      x-rolesRequirements:
+        - Organization Stream Processing Admin
+        - Project Stream Processing Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamsTransitGatewayRoute
+      x-xgen-operation-id-override: getTransitGatewayRoute
   /api/atlas/v2/groups/{groupId}/teams:
     get:
       description: Returns all teams to which the authenticated user has access in the project specified using its unique 24-hexadecimal digit identifier. All members of the team share the same project access.
@@ -48992,6 +51503,7 @@ paths:
         - If the user has a pending invitation to join the project's organization, MongoDB Cloud modifies it and grants project access. 
         - If the user doesn't have an invitation to join the organization, MongoDB Cloud sends a new invitation that grants the user organization and project access. 
         - If the user is already active in the project's organization, MongoDB Cloud grants access to the project. 
+        - Replaces `INVITATION_EXPIRED` and `INVITATION_REJECTED` user with the same email. A conflict, if and only if, there is an existing `PENDING` or `ACTIVE` user. 
       operationId: addGroupUsers
       parameters:
         - $ref: "#/components/parameters/envelope"
@@ -49427,6 +51939,48 @@ paths:
       tags:
         - Projects
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupByName
+  /api/atlas/v2/openapi/info:
+    get:
+      description: This resource returns general information about the MongoDB Atlas Administration API OpenAPI Specification.
+      operationId: getOpenapiInfo
+      parameters:
+        - $ref: "#/components/parameters/pretty"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2024-05-30+json:
+              schema:
+                $ref: "#/components/schemas/OpenApiInfo"
+              x-sunset: 9999-12-30
+              x-xgen-version: 2024-05-30
+            application/vnd.atlas.2024-08-05+json:
+              schema:
+                $ref: "#/components/schemas/OpenApiInfo"
+              x-xgen-version: 2024-08-05
+            application/vnd.atlas.2025-09-22.upcoming+json:
+              schema:
+                $ref: "#/components/schemas/OpenApiInfo"
+              x-xgen-version: 2025-09-22.upcoming
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/OpenApiInfo"
+              x-sunset: 9999-12-30
+              x-xgen-preview:
+                public: "true"
+              x-xgen-version: preview
+          description: OK
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return General Information on MongoDB Atlas Administration API OpenAPI Specification
+      tags:
+        - OpenAPI
+      x-xgen-method-verb-override:
+        customMethod: "False"
+        verb: get
   /api/atlas/v2/orgs:
     get:
       description: Returns all organizations to which the requesting Service Account or API Key has access.
@@ -49810,10 +52364,10 @@ paths:
         - Organization Read Only
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/getOrgAiModelApiKey
       x-xgen-operation-id-override: getOrgModelKey
-  /api/atlas/v2/orgs/{orgId}/aiModelRateLimits:
+  /api/atlas/v2/orgs/{orgId}/aiModelApiRateLimits:
     get:
       description: Retrieve AI model rate limits for the given organization.
-      operationId: listOrgAiModelRateLimits
+      operationId: listOrgAiModelApiRateLimits
       parameters:
         - $ref: "#/components/parameters/orgId"
         - $ref: "#/components/parameters/itemsPerPage"
@@ -49850,12 +52404,12 @@ paths:
         - AI Model Rate Limits
       x-rolesRequirements:
         - Organization Read Only
-      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listOrgAiModelRateLimits
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listOrgAiModelApiRateLimits
       x-xgen-operation-id-override: listOrgModelLimits
-  /api/atlas/v2/orgs/{orgId}/aiModelRateLimits/{modelGroupName}:
+  /api/atlas/v2/orgs/{orgId}/aiModelApiRateLimits/{modelGroupName}:
     get:
       description: Retrieve a single AI model rate limit for the given organization.
-      operationId: getOrgAiModelRateLimit
+      operationId: getOrgAiModelApiRateLimit
       parameters:
         - $ref: "#/components/parameters/orgId"
         - $ref: "#/components/parameters/envelope"
@@ -49896,7 +52450,7 @@ paths:
         - AI Model Rate Limits
       x-rolesRequirements:
         - Organization Read Only
-      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getOrgAiModelRateLimit
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getOrgAiModelApiRateLimit
       x-xgen-operation-id-override: getOrgModelLimit
   /api/atlas/v2/orgs/{orgId}/apiKeys:
     get:
@@ -50535,6 +53089,89 @@ paths:
         - Organization Billing Viewer
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgBillingCostExplorerUsage
       x-xgen-operation-id-override: getCostExplorerUsage
+  /api/atlas/v2/orgs/{orgId}/delegationSettings:
+    get:
+      description: Returns the delegation settings for the specified organization.
+      operationId: getOrgDelegationSettings
+      parameters:
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/OrgDelegationSettingsResponse"
+              x-xgen-version: 2025-03-12
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Delegation Settings for One Organization
+      tags:
+        - Organizations
+      x-rolesRequirements:
+        - Organization Member
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgDelegationSettings
+    patch:
+      description: Updates the delegation settings for the specified organization. Only fields present in the request body are updated; omitted fields retain their current values.
+      operationId: updateOrgDelegationSettings
+      parameters:
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+      requestBody:
+        content:
+          application/vnd.atlas.2025-03-12+json:
+            schema:
+              $ref: "#/components/schemas/OrgDelegationSettingsUpdateRequest"
+            x-xgen-version: 2025-03-12
+        description: Delegation settings to update.
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/OrgDelegationSettingsResponse"
+              x-xgen-version: 2025-03-12
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Update Delegation Settings for One Organization
+      tags:
+        - Organizations
+      x-rolesRequirements:
+        - Organization Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgDelegationSettings
   /api/atlas/v2/orgs/{orgId}/events:
     get:
       description: |-
@@ -51577,6 +54214,289 @@ paths:
         - Organization Owner
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/createOrgLiveMigrationLinkToken
       x-xgen-operation-id-override: createLinkToken
+  /api/atlas/v2/orgs/{orgId}/maintenanceSettings:
+    get:
+      description: Returns maintenance settings for the specified organization.
+      operationId: getOrgMaintenanceSettings
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/pretty"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/OrganizationMaintenanceSettingsResponse"
+              x-xgen-preview:
+                name: organization-maintenance
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Maintenance Settings for One Organization
+      tags:
+        - Organizations
+      x-rolesRequirements:
+        - Organization Member
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgMaintenanceSettings
+    patch:
+      description: Updates maintenance settings for the specified organization. Omit optional fields from the request body to leave their current values unchanged. Specify null on an optional field to reset it to its default value.
+      operationId: updateOrgMaintenanceSettings
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/pretty"
+      requestBody:
+        content:
+          application/vnd.atlas.preview+json:
+            schema:
+              $ref: "#/components/schemas/OrganizationMaintenanceSettingsUpdateRequest"
+            x-xgen-preview:
+              name: organization-maintenance
+            x-xgen-version: preview
+        description: Maintenance settings to update for the specified organization.
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/OrganizationMaintenanceSettingsResponse"
+              x-xgen-preview:
+                name: organization-maintenance
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Update Maintenance Settings for One Organization
+      tags:
+        - Organizations
+      x-rolesRequirements:
+        - Organization Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgMaintenanceSettings
+  /api/atlas/v2/orgs/{orgId}/maintenanceSettings:reset:
+    post:
+      description: Resets maintenance settings for the specified organization to their default values. Restores the wave assignment mode to the default manual mode.
+      operationId: resetOrgMaintenanceSettings
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/pretty"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/OrganizationMaintenanceSettingsResponse"
+              x-xgen-preview:
+                name: organization-maintenance
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Reset Maintenance Settings for One Organization
+      tags:
+        - Organizations
+      x-rolesRequirements:
+        - Organization Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/resetOrgMaintenanceSettings
+      x-xgen-method-verb-override:
+        customMethod: "True"
+        verb: reset
+      x-xgen-operation-id-override: resetOrgMaintenanceSettings
+  /api/atlas/v2/orgs/{orgId}/mcpConfigs:
+    get:
+      description: Returns all MCP configurations associated with the specified organization.
+      operationId: listOrgMcpConfigs
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/includeCount"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/orgId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedOrgMcpConfigView"
+              x-xgen-version: 2025-03-12
+          description: OK
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All MCP Configurations for One Organization
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Organization Read Only
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/listOrgMcpConfigs
+    post:
+      description: Creates an MCP configuration for the specified organization. Returns the configuration ID and ingress credentials.
+      operationId: createOrgMcpConfig
+      parameters:
+        - $ref: "#/components/parameters/orgId"
+      requestBody:
+        content:
+          application/vnd.atlas.2025-03-12+json:
+            schema:
+              $ref: "#/components/schemas/CreateOrgMcpConfigRequest"
+            x-xgen-version: 2025-03-12
+        description: MCP configuration to create.
+        required: true
+      responses:
+        "201":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/OrgMcpConfigResponse"
+              x-xgen-version: 2025-03-12
+          description: Created
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Create One MCP Configuration for One Organization
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Organization Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/createOrgMcpConfig
+  /api/atlas/v2/orgs/{orgId}/mcpConfigs/{mcpConfigId}:
+    delete:
+      description: Deletes the MCP configuration with the specified ID for the specified organization.
+      operationId: deleteOrgMcpConfig
+      parameters:
+        - $ref: "#/components/parameters/orgId"
+        - description: Unique identifier of the MCP configuration to delete.
+          in: path
+          name: mcpConfigId
+          required: true
+          schema:
+            type: string
+        - description: Flag that indicates whether to delete the MCP configuration even if it has active secrets. If false and active secrets exist, the request returns an error. Defaults to false.
+          in: query
+          name: cascading
+          schema:
+            default: false
+            type: boolean
+      responses:
+        "204":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              x-xgen-version: 2025-03-12
+          description: No Content
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Delete One MCP Configuration for One Organization
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Organization Owner
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/deleteOrgMcpConfig
+    get:
+      description: Returns the MCP configuration with the specified ID for the specified organization.
+      operationId: getOrgMcpConfig
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/orgId"
+        - description: Unique identifier of the MCP configuration.
+          in: path
+          name: mcpConfigId
+          required: true
+          schema:
+            example: 32b6e34b3d91647adeabc012
+            pattern: ^[a-fA-F0-9]{24}$
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2025-03-12+json:
+              schema:
+                $ref: "#/components/schemas/OrgMcpConfigResponse"
+              x-xgen-version: 2025-03-12
+          description: OK
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return One MCP Configuration for One Organization
+      tags:
+        - Remote MCP Configurations
+      x-rolesRequirements:
+        - Organization Read Only
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/getOrgMcpConfig
   /api/atlas/v2/orgs/{orgId}/nonCompliantResources:
     get:
       description: Return all non-compliant resources for an organization.
@@ -51622,6 +54542,47 @@ paths:
         - Organization Member
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/getOrgNonCompliantResources
       x-xgen-operation-id-override: getNonCompliantResources
+  /api/atlas/v2/orgs/{orgId}/ratelimits:
+    get:
+      description: Retrieve rate limiting bucket state for the specified organization.
+      operationId: getOrgRatelimits
+      parameters:
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/envelope"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/AtlasRateLimitInspectionResponse"
+              x-xgen-preview:
+                name: rate-limit
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Rate Limit State for One Organization
+      tags:
+        - Rate Limit
+      x-rolesRequirements:
+        - Organization Read Only
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/getOrgRatelimits
   /api/atlas/v2/orgs/{orgId}/resourcePolicies:
     get:
       description: Return all Atlas Resource Policies for the organization.
@@ -53239,7 +56200,9 @@ paths:
       description: |-
         Adds one MongoDB Cloud user to one team. You can add an active user or a user that has not yet accepted the invitation to join the organization. 
 
-        **Note**: This resource cannot be used to add a user invited via the deprecated Invite One MongoDB Cloud User to Join One Project endpoint.
+        **Note**: This resource cannot be used to add a user invited via the deprecated Invite One MongoDB Cloud User to Join One Project endpoint. 
+
+        A user whose only organization invitation has `EXPIRED` or been `REJECTED` is treated as not belonging to the organization (`USER_NOT_IN_ORG`); re-invite them to the organization first (which creates a new pending invitation), then add them to the team.
       externalDocs:
         description: "Deprecated: Invite One MongoDB Cloud User to Join One Project endpoint"
         url: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateProjectInvitation
@@ -53486,7 +56449,9 @@ paths:
       description: |-
         Invites one new or existing MongoDB Cloud user to join the organization. The invitation to join the organization will be sent to the username provided and must be accepted within 30 days. 
 
-        **Note**: If the user does not have an existing MongoDB Cloud account, they will be prompted to finish setting up an account upon accepting the invitation. If the user already has an account, they will still receive an invitation to access the organization.
+        **Note**: If the user does not have an existing MongoDB Cloud account, they will be prompted to finish setting up an account upon accepting the invitation. If the user already has an account, they will still receive an invitation to access the organization. 
+
+        Replaces `INVITATION_EXPIRED` and `INVITATION_REJECTED` user with the same email. A conflict, if and only if, there is an existing `PENDING` or `ACTIVE` user.
       operationId: createOrgUser
       parameters:
         - $ref: "#/components/parameters/envelope"
@@ -54162,6 +57127,128 @@ paths:
         - Root
       x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Root/operation/listControlPlaneIpAddresses
       x-xgen-operation-id-override: listControlPlaneAddresses
+  /api/atlas/v2/unauth/openapi/versions:
+    get:
+      description: API that provides a list of available versions for a given environment.
+      operationId: listOpenapiVersions
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/pageNum"
+        - $ref: "#/components/parameters/pretty"
+        - description: The environment to get the versions from. If not provided, it returns the versions for the given MongoDB URL. (E.g. prod for cloud.mongodb.com).
+          in: query
+          name: env
+          schema:
+            enum:
+              - dev
+              - qa
+              - prod
+              - stage
+            type: string
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2024-08-05+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiVersions"
+              x-xgen-version: 2024-08-05
+            application/vnd.atlas.2024-08-05+yaml:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiVersions"
+              x-xgen-version: 2024-08-05
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiVersions"
+              x-xgen-preview:
+                name: version-resource
+              x-xgen-version: preview
+            application/vnd.atlas.preview+yaml:
+              schema:
+                $ref: "#/components/schemas/PaginatedApiVersions"
+              x-xgen-preview:
+                name: version-resource
+              x-xgen-version: preview
+          description: OK
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return All Versions for One Environment
+      tags:
+        - OpenAPI
+  /api/atlas/v2/unauth/ratelimits:
+    get:
+      description: Retrieve rate limiting bucket state for unauthenticated requests.
+      operationId: listRatelimits
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/AtlasRateLimitInspectionResponse"
+              x-xgen-preview:
+                name: rate-limit
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "404":
+          $ref: "#/components/responses/notFound"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Rate Limit State for Unauthenticated Requests
+      tags:
+        - Rate Limit
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/listRatelimits
+  /api/atlas/v2/userRateLimits:
+    get:
+      description: Retrieve rate limiting bucket state for the current user.
+      operationId: listUserRatelimits
+      parameters:
+        - $ref: "#/components/parameters/envelope"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.preview+json:
+              schema:
+                $ref: "#/components/schemas/AtlasRateLimitInspectionResponse"
+              x-xgen-preview:
+                name: rate-limit
+                public: "false"
+              x-xgen-version: preview
+          description: OK
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/HeaderRateLimitLimit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/HeaderRateLimitRemaining"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+      summary: Return Rate Limit State for One User
+      tags:
+        - Rate Limit
+      x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/listUserRatelimits
   /api/atlas/v2/users:
     post:
       deprecated: true
@@ -54324,6 +57411,8 @@ tags:
     name: Auditing
   - description: Returns and edits custom DNS configurations for MongoDB Cloud database deployments on AWS. The resource requires your Project ID. If you use the VPC peering on AWS and you use your own DNS servers instead of Amazon Route 53, enable custom DNS. Before 31 March 2020, applications deployed within AWS using custom DNS services and VPC-peered with MongoDB Cloud couldn't connect over private IP addresses. Custom DNS resolved to public IP addresses. AWS internal DNS resolved to private IP addresses. Applications deployed with custom DNS services in AWS should use Private IP for Peering connection strings.
     name: AWS Clusters DNS
+  - description: Returns, adds, and edits Charts Dashboard instances. This resource applies only to projects with a Charts tenant, and requires your Project ID.
+    name: Charts Dashboards
   - description: Manages Cloud Backup snapshots, snapshot export buckets, restore jobs, and schedules. This resource applies only to clusters that use Cloud Backups.
     name: Cloud Backups
   - description: Manages the Cloud Migration Service. Source organizations, projects, and MongoDB clusters reside on Cloud Manager or Ops Manager. Destination organizations, projects, and MongoDB clusters reside on MongoDB Cloud. Source databases can't use any authentication except SCRAM-SHA.
@@ -54385,6 +57474,8 @@ tags:
     name: Network Peering
   - description: Returns, adds, edits, or removes an online archive.
     name: Online Archive
+  - description: Returns information about the MongoDB Atlas Specification.
+    name: OpenAPI
   - description: Returns, adds, and edits organizational units in MongoDB Cloud.
     name: Organizations
   - description: Returns suggested indexes and slow query data for a database deployment. Also enables or disables MongoDB Cloud-managed slow operation thresholds. To view field values in a sample query, you must have the Project Data Access Read Only role or higher. Otherwise, MongoDB Cloud returns redacted data rather than the field values.
@@ -54404,6 +57495,8 @@ tags:
       description: Atlas API Rate Limits documentation
       url: http://dochub.mongodb.org/core/atlas-api-rate-limit
     name: Rate Limiting
+  - description: Returns and manages Remote MCP configurations for organizations and projects.
+    name: Remote MCP Configurations
   - description: Configure and manage Atlas Resource Policies within your organization.
     name: Resource Policies
   - description: Creates one index to a database deployment in a rolling manner. Rolling indexes build indexes on the applicable nodes sequentially and may reduce the performance impact of an index build if your deployment's average CPU utilization exceeds (N-1)/N-10% where N is the number of CPU threads available to mongod of if the WiredTiger cache fill ratio regularly exceeds 90%. If your deployment does not meet this criteria, use the default index build. You can't create a rolling index on an `M0` free cluster or `M2/M5` shared cluster.

--- a/tools/codegen/atlasapispec/raw-multi-version-api-spec.yml
+++ b/tools/codegen/atlasapispec/raw-multi-version-api-spec.yml
@@ -1255,11 +1255,13 @@ components:
             properties:
                 cidrBlock:
                     description: Range of IP addresses in Classless Inter-Domain Routing (CIDR) notation that found in this project's access list.
+                    nullable: true
                     pattern: ^((([0-9]{1,3}\.){3}[0-9]{1,3})|(:{0,2}([0-9a-f]{1,4}:){0,7}[0-9a-f]{1,4}[:]{0,2}))((%2[fF]|/)[0-9]{1,3})+$
                     readOnly: true
                     type: string
                 ipAddress:
                     description: IP address included in the API access list.
+                    nullable: true
                     pattern: ^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}|([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}$
                     readOnly: true
                     type: string
@@ -1375,6 +1377,21 @@ components:
             required:
                 - id
             type: object
+        AdditionalData:
+            description: Additional metadata associated with the line item.
+            properties:
+                processorId:
+                    description: Identifier of the stream processor associated with the line item.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                processorName:
+                    description: Name of the stream processor associated with the line item.
+                    type: string
+                workspace:
+                    description: Workspace associated with the line item.
+                    type: string
+            type: object
         AdvancedAutoScalingSettings:
             description: Options that determine how this cluster handles resource scaling.
             properties:
@@ -1448,6 +1465,7 @@ components:
                     enum:
                         - FULLY_WARMED
                         - VISIBLE_EARLIER
+                        - ENHANCED_FULLY_WARMED
                     externalDocs:
                         description: Reduce Secondary Disk Warming Impact
                         url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -1685,6 +1703,7 @@ components:
                 lastUsedAt:
                     description: UTC date when the API key was last used. This parameter is formatted as an ISO 8601 timestamp.
                     example: "2026-01-15T16:47:49.855000+00:00"
+                    nullable: true
                     readOnly: true
                     type: string
                 maskedSecret:
@@ -1702,6 +1721,7 @@ components:
                     description: 'The full API key secret used for interacting with the embedding / reranking service. Note: this will only be fully populated in the response to a create API key request. Responses to get, list, and update requests will not include the secret.'
                     example: al-jZsluhPMzPM9CFXepRWwMwvpZDDra6tZMgoAZKdodu2
                     format: password
+                    nullable: true
                     readOnly: true
                     type: string
                 status:
@@ -2294,6 +2314,273 @@ components:
                         - DEFAULT
                     type: string
             type: object
+        ApiAtlasClusterDescriptionPreview:
+            properties:
+                acceptDataRisksAndForceReplicaSetReconfig:
+                    description: If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set `acceptDataRisksAndForceReplicaSetReconfig` to the current date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+                    externalDocs:
+                        description: Reconfiguring a Replica Set during a regional outage
+                        url: https://dochub.mongodb.org/core/regional-outage-reconfigure-replica-set
+                    format: date-time
+                    type: string
+                adaptiveCapacity:
+                    description: Governs adaptive capacity behavior of Azure nodes in single-cloud Azure clusters or multi-cloud clusters that include Azure nodes. Adaptive capacity enables fallback hardware selection when the primary instance family is unavailable. ``ENABLED`` means the cluster explicitly opts in to adaptive capacity. ``DISABLED`` means the cluster explicitly opts out; the cluster receives capacity errors instead of being placed on fallback hardware. ``null`` means the field is unset; Azure clusters use adaptive capacity by default when the feature is enabled at the group level. Setting this field for single-cloud AWS or GCP clusters is a no-op.
+                    enum:
+                        - ENABLED
+                        - DISABLED
+                    nullable: true
+                    type: string
+                advancedConfiguration:
+                    $ref: '#/components/schemas/ApiAtlasClusterAdvancedConfigurationView'
+                backupEnabled:
+                    default: false
+                    description: Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses Cloud Backups for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.
+                    externalDocs:
+                        description: Cloud Backups
+                        url: https://docs.atlas.mongodb.com/backup/cloud-backup/overview/
+                    type: boolean
+                biConnector:
+                    $ref: '#/components/schemas/BiConnector'
+                clusterType:
+                    description: Configuration of nodes that comprise the cluster.
+                    enum:
+                        - REPLICASET
+                        - SHARDED
+                        - GEOSHARDED
+                    type: string
+                configServerManagementMode:
+                    default: ATLAS_MANAGED
+                    description: Config Server Management Mode for creating or updating a sharded cluster. When configured as `ATLAS_MANAGED`, Atlas may automatically switch the cluster's config server type for optimal performance and savings. When configured as `FIXED_TO_DEDICATED`, the cluster will always use a dedicated config server.
+                    enum:
+                        - ATLAS_MANAGED
+                        - FIXED_TO_DEDICATED
+                    externalDocs:
+                        description: MongoDB Sharded Cluster Config Servers
+                        url: https://dochub.mongodb.org/docs/manual/core/sharded-cluster-config-servers
+                    type: string
+                configServerType:
+                    description: Describes a sharded cluster's config server type.
+                    enum:
+                        - DEDICATED
+                        - EMBEDDED
+                    externalDocs:
+                        description: MongoDB Sharded Cluster Config Servers
+                        url: https://dochub.mongodb.org/docs/manual/core/sharded-cluster-config-servers
+                    readOnly: true
+                    type: string
+                connectionStrings:
+                    $ref: '#/components/schemas/ClusterConnectionStrings'
+                createDate:
+                    description: Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.
+                    format: date-time
+                    readOnly: true
+                    type: string
+                diskWarmingMode:
+                    default: FULLY_WARMED
+                    description: Disk warming mode selection.
+                    enum:
+                        - FULLY_WARMED
+                        - VISIBLE_EARLIER
+                        - ENHANCED_FULLY_WARMED
+                    externalDocs:
+                        description: Reduce Secondary Disk Warming Impact
+                        url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
+                    type: string
+                effectiveReplicationSpecs:
+                    description: List of settings that represent the actual cluster state. This is read-only and always returned in the response. It reflects the current cluster configuration, which may differ from `replicationSpecs` due to system-managed changes.
+                    items:
+                        $ref: '#/components/schemas/ReplicationSpec20240805'
+                    readOnly: true
+                    type: array
+                encryptionAtRestProvider:
+                    description: 'Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster `replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize` setting must be `M10` or higher and `"backupEnabled" : false` or omitted entirely.'
+                    enum:
+                        - NONE
+                        - AWS
+                        - AZURE
+                        - GCP
+                    externalDocs:
+                        description: Encryption at Rest using Customer Key Management
+                        url: https://www.mongodb.com/docs/atlas/security-kms-encryption/
+                    type: string
+                featureCompatibilityVersion:
+                    description: Feature compatibility version of the cluster. This will always appear regardless of whether FCV is pinned.
+                    readOnly: true
+                    type: string
+                featureCompatibilityVersionExpirationDate:
+                    description: Feature compatibility version expiration date. Will only appear if FCV is pinned. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+                    format: date-time
+                    readOnly: true
+                    type: string
+                globalClusterSelfManagedSharding:
+                    description: |-
+                        Set this field to configure the Sharding Management Mode when creating a new Global Cluster.
+
+                        When set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.
+
+                        When set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.
+
+                        This setting cannot be changed once the cluster is deployed.
+                    externalDocs:
+                        description: Creating a Global Cluster
+                        url: https://dochub.mongodb.org/core/global-cluster-management
+                    type: boolean
+                groupId:
+                    description: Unique 24-hexadecimal character string that identifies the project.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    readOnly: true
+                    type: string
+                id:
+                    description: Unique 24-hexadecimal digit string that identifies the cluster.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    readOnly: true
+                    type: string
+                internalClusterRole:
+                    description: 'Internal classification of the cluster''s role. Possible values: `NONE` (regular user cluster), `SYSTEM_CLUSTER` (system cluster for backup), `INTERNAL_SHADOW_CLUSTER` (internal use shadow cluster for testing).'
+                    enum:
+                        - NONE
+                        - SYSTEM_CLUSTER
+                        - INTERNAL_SHADOW_CLUSTER
+                    readOnly: true
+                    type: string
+                labels:
+                    deprecated: true
+                    description: |-
+                        Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.
+
+                        Cluster labels are deprecated and will be removed in a future release. We strongly recommend that you use Resource Tags instead.
+                    externalDocs:
+                        description: Resource Tags
+                        url: https://dochub.mongodb.org/core/add-cluster-tag-atlas
+                    items:
+                        $ref: '#/components/schemas/ComponentLabel'
+                    type: array
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                mongoDBEmployeeAccessGrant:
+                    $ref: '#/components/schemas/EmployeeAccessGrantView'
+                mongoDBMajorVersion:
+                    description: "MongoDB major version of the cluster. Set to the binary major version. \n\nOn creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLtsVersions).\n\n On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+                    externalDocs:
+                        description: Available MongoDB Versions in Atlas
+                        url: https://www.mongodb.com/docs/atlas/reference/faq/database/#which-versions-of-mongodb-do-service-clusters-use-
+                    type: string
+                mongoDBVersion:
+                    description: Version of MongoDB that the cluster runs.
+                    pattern: ([\d]+\.[\d]+\.[\d]+)
+                    readOnly: true
+                    type: string
+                mongosTopology:
+                    $ref: '#/components/schemas/MongosTopology'
+                name:
+                    description: Human-readable label that identifies the cluster.
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                paused:
+                    description: Flag that indicates whether the cluster is paused.
+                    type: boolean
+                pitEnabled:
+                    description: Flag that indicates whether the cluster uses continuous cloud backups.
+                    externalDocs:
+                        description: Continuous Cloud Backups
+                        url: https://docs.atlas.mongodb.com/backup/cloud-backup/overview/
+                    type: boolean
+                redactClientLogData:
+                    description: |-
+                        Enable or disable log redaction.
+
+                        This setting configures the ``mongod`` or ``mongos`` to redact any document field contents from a message accompanying a given log event before logging. This prevents the program from writing potentially sensitive data stored on the database to the diagnostic log. Metadata such as error or operation codes, line numbers, and source file names are still visible in the logs.
+
+                        Use ``redactClientLogData`` in conjunction with Encryption at Rest and TLS/SSL (Transport Encryption) to assist compliance with regulatory requirements.
+
+                        *Note*: changing this setting on a cluster will trigger a rolling restart as soon as the cluster is updated.
+                    externalDocs:
+                        description: Log Redaction
+                        url: https://www.mongodb.com/docs/manual/administration/monitoring/#log-redaction
+                    type: boolean
+                replicaSetScalingStrategy:
+                    default: WORKLOAD_TYPE
+                    description: |-
+                        Set this field to configure the replica set scaling mode for your cluster.
+
+                        By default, Atlas scales under `WORKLOAD_TYPE`. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.
+
+                        When configured as `SEQUENTIAL`, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.
+
+                        When configured as `NODE_TYPE`, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.
+                    enum:
+                        - SEQUENTIAL
+                        - WORKLOAD_TYPE
+                        - NODE_TYPE
+                    externalDocs:
+                        description: Modify the Replica Set Scaling Mode
+                        url: https://dochub.mongodb.org/core/scale-nodes
+                    type: string
+                replicationSpecs:
+                    description: List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations.
+                    items:
+                        $ref: '#/components/schemas/ReplicationSpec20240805'
+                    type: array
+                retainBackups:
+                    default: false
+                    description: Flag that indicates whether the cluster retains backups.
+                    type: boolean
+                rootCertType:
+                    default: ISRGROOTX1
+                    description: Root Certificate Authority that MongoDB Atlas cluster uses. MongoDB Cloud supports Internet Security Research Group.
+                    enum:
+                        - ISRGROOTX1
+                    type: string
+                stateName:
+                    description: |-
+                        Human-readable label that indicates any current activity being taken on this cluster by the Atlas control plane. With the exception of CREATING and DELETING states, clusters should always be available and have a Primary node even when in states indicating ongoing activity.
+
+                         - `IDLE`: Atlas is making no changes to this cluster and all changes requested via the UI or API can be assumed to have been applied.
+                         - `CREATING`: A cluster being provisioned for the very first time returns state CREATING until it is ready for connections. Ensure IP Access List and DB Users are configured before attempting to connect.
+                         - `UPDATING`: A change requested via the UI, API, AutoScaling, or other scheduled activity is taking place.
+                         - `DELETING`: The cluster is in the process of deletion and will soon be deleted.
+                         - `REPAIRING`: One or more nodes in the cluster are being returned to service by the Atlas control plane. Other nodes should continue to provide service as normal.
+                    enum:
+                        - IDLE
+                        - CREATING
+                        - UPDATING
+                        - DELETING
+                        - REPAIRING
+                    readOnly: true
+                    type: string
+                tags:
+                    description: List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.
+                    externalDocs:
+                        description: Resource Tags
+                        url: https://dochub.mongodb.org/core/add-cluster-tag-atlas
+                    items:
+                        $ref: '#/components/schemas/ResourceTag'
+                    type: array
+                terminationProtectionEnabled:
+                    default: false
+                    description: Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.
+                    type: boolean
+                useAwsTimeBasedSnapshotCopyForFastInitialSync:
+                    default: false
+                    description: Flag that indicates whether AWS time-based snapshot copies will be used instead of slower standard snapshot copies during fast Atlas cross-region initial syncs. This flag is only relevant for clusters containing AWS nodes.
+                    type: boolean
+                versionReleaseSystem:
+                    default: LTS
+                    description: Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify `mongoDBMajorVersion`.
+                    enum:
+                        - LTS
+                        - CONTINUOUS
+                    type: string
+            type: object
         ApiAtlasCollectionRestoreCollectionStateResponse:
             description: Collection-level state within a collection restore job.
             properties:
@@ -2383,9 +2670,11 @@ components:
             type: object
         ApiAtlasCollectionRestoreJobRequest:
             description: Request body for creating a collection restore job.
+            nullable: true
             properties:
                 collectionSuffix:
                     description: Optional suffix applied to restored collection names.
+                    nullable: true
                     type: string
                 collections:
                     description: List of collections to restore (up to 100 items).
@@ -2395,6 +2684,7 @@ components:
                     type: array
                 databaseSuffix:
                     description: Optional suffix applied to restored database names.
+                    nullable: true
                     type: string
                 databases:
                     description: List of databases to restore (up to 100 items).
@@ -2412,10 +2702,12 @@ components:
                 oplogInc:
                     description: Oplog increment for point-in-time restore.
                     format: int32
+                    nullable: true
                     type: integer
                 oplogTs:
                     description: Oplog timestamp (seconds part) for point-in-time restore.
                     format: int32
+                    nullable: true
                     type: integer
                 overwriteStrategy:
                     description: Strategy for overwriting existing data (new if exists or overwrite if exists).
@@ -2426,6 +2718,7 @@ components:
                 pointInTimeUtcSeconds:
                     description: Point-in-time restore time in seconds since UNIX epoch.
                     format: int32
+                    nullable: true
                     type: integer
                 snapshotId:
                     description: ID of the snapshot to restore.
@@ -2818,6 +3111,7 @@ components:
             properties:
                 description:
                     description: Description of the atlas resource policy.
+                    nullable: true
                     type: string
                 name:
                     description: Human-readable label that describes the atlas resource policy.
@@ -2835,9 +3129,11 @@ components:
             properties:
                 description:
                     description: Description of the atlas resource policy.
+                    nullable: true
                     type: string
                 name:
                     description: Human-readable label that describes the atlas resource policy.
+                    nullable: true
                     type: string
                 policies:
                     description: List of policies that make up the atlas resource policy.
@@ -3079,6 +3375,19 @@ components:
             readOnly: true
             title: BSON Timestamp
             type: object
+        ApiChartsDashboardImportResponseView:
+            description: Imported dashboard and associated imported items.
+            properties:
+                dashboard:
+                    $ref: '#/components/schemas/ImportedDashboard'
+                items:
+                    description: Imported items.
+                    items:
+                        $ref: '#/components/schemas/ImportedItem'
+                    type: array
+            required:
+                - items
+            type: object
         ApiCheckpointPartView:
             description: Metadata contained in one document that describes the complete snapshot taken for this node.
             properties:
@@ -3112,6 +3421,7 @@ components:
                     $ref: '#/components/schemas/BadRequestDetail'
                 detail:
                     description: Describes the specific conditions or reasons that cause each type of error.
+                    nullable: true
                     type: string
                 error:
                     description: HTTP status code returned with this error.
@@ -3132,6 +3442,7 @@ components:
                     type: array
                 reason:
                     description: Application error message returned with this error.
+                    nullable: true
                     readOnly: true
                     type: string
             required:
@@ -3382,11 +3693,75 @@ components:
                         - DESCENDING
                     type: string
             type: object
-        ApiSearchDeploymentRequestSpecView:
+        ApiSearchDeploymentEffectiveSpecView:
             properties:
+                cloudProvider:
+                    description: Cloud service provider on which Search Nodes are provisioned.
+                    enum:
+                        - AWS
+                        - AZURE
+                        - GCP
+                    readOnly: true
+                    type: string
                 instanceSize:
                     description: Hardware specification for the Search Node instance sizes.
                     enum:
+                        - S10_HIGHCPU
+                        - S20_HIGHCPU_NVME
+                        - S30_HIGHCPU_NVME
+                        - S40_HIGHCPU_NVME
+                        - S50_HIGHCPU_NVME
+                        - S60_HIGHCPU_NVME
+                        - S70_HIGHCPU_NVME
+                        - S80_HIGHCPU_NVME
+                        - S30_LOWCPU_NVME
+                        - S40_LOWCPU_NVME
+                        - S50_LOWCPU_NVME
+                        - S60_LOWCPU_NVME
+                        - S70_LOWCPU_NVME
+                        - S80_LOWCPU_NVME
+                        - S90_LOWCPU_NVME
+                        - S100_LOWCPU_NVME
+                        - S110_LOWCPU_NVME
+                        - S120_LOWCPU_NVME
+                        - S130_LOWCPU_NVME
+                        - S135_LOWCPU_NVME
+                        - S140_LOWCPU_NVME
+                        - S40_STORAGE_NVME
+                        - S50_STORAGE_NVME
+                        - S60_STORAGE_NVME
+                        - S80_STORAGE_NVME
+                        - S90_STORAGE_NVME
+                    readOnly: true
+                    type: string
+                nodeCount:
+                    description: Number of Search Nodes in this region.
+                    example: 2
+                    format: int32
+                    maximum: 32
+                    minimum: 2
+                    readOnly: true
+                    type: integer
+                regionName:
+                    description: Cloud provider region where Search Nodes are provisioned.
+                    example: US_EAST_1
+                    readOnly: true
+                    type: string
+            type: object
+        ApiSearchDeploymentRequestSpecView:
+            properties:
+                cloudProvider:
+                    description: Cloud service provider that hosts the Search Nodes in this region. Required when a region is specified.
+                    enum:
+                        - AWS
+                        - AZURE
+                        - GCP
+                    nullable: true
+                    type: string
+                instanceSize:
+                    description: Hardware specification for the Search Node instance sizes.
+                    enum:
+                        - S10_HIGHCPU
                         - S20_HIGHCPU_NVME
                         - S30_HIGHCPU_NVME
                         - S40_HIGHCPU_NVME
@@ -3419,12 +3794,26 @@ components:
                     format: int32
                     maximum: 32
                     minimum: 2
+                    nullable: true
                     type: integer
+                regionName:
+                    description: Cloud provider region where Search Nodes are provisioned. Required when the request configures more than one region; optional for single-region requests.
+                    example: US_EAST_1
+                    nullable: true
+                    type: string
             required:
                 - instanceSize
             type: object
         ApiSearchDeploymentRequestView:
             properties:
+                defaultNodeCount:
+                    description: Default number of Search Nodes per region. Applied to a region without an explicit override.
+                    example: 2
+                    format: int32
+                    maximum: 32
+                    minimum: 2
+                    nullable: true
+                    type: integer
                 specs:
                     description: List of settings that configure the Search Nodes for your cluster. Provide one element per region when configuring asymmetric deployments; a single element applies to all regions.
                     items:
@@ -3436,6 +3825,12 @@ components:
             type: object
         ApiSearchDeploymentResponseView:
             properties:
+                effectiveSpecs:
+                    description: List of settings that configure the Search Nodes for your cluster, with per-region detail including the region name and cloud provider.
+                    items:
+                        $ref: '#/components/schemas/ApiSearchDeploymentEffectiveSpecView'
+                    readOnly: true
+                    type: array
                 encryptionAtRestProvider:
                     description: Cloud service provider that manages your customer keys to provide an additional layer of Encryption At Rest for the cluster.
                     enum:
@@ -3446,6 +3841,7 @@ components:
                     externalDocs:
                         description: Encryption at Rest using Customer Key Management
                         url: https://www.mongodb.com/docs/atlas/security-kms-encryption/
+                    nullable: true
                     readOnly: true
                     type: string
                 groupId:
@@ -3461,7 +3857,8 @@ components:
                     readOnly: true
                     type: string
                 specs:
-                    description: List of settings that configure the Search Nodes for your cluster. The configuration will be returned for each region and shard.
+                    deprecated: true
+                    description: Deprecated. `specs` will be removed in a future release. We strongly recommend that you use `effectiveSpecs` instead.
                     items:
                         $ref: '#/components/schemas/ApiSearchDeploymentSpecView'
                     readOnly: true
@@ -3481,6 +3878,7 @@ components:
                 instanceSize:
                     description: Hardware specification for the Search Node instance sizes.
                     enum:
+                        - S10_HIGHCPU
                         - S20_HIGHCPU_NVME
                         - S30_HIGHCPU_NVME
                         - S40_HIGHCPU_NVME
@@ -3684,6 +4082,7 @@ components:
                 - TOKYO_JPN
                 - SINGAPORE_SGP
                 - PARIS_FRA
+                - SEOUL_KOR
             type: string
         ApiStreamsAzureRegionView:
             description: Atlas Streams Azure Regions.
@@ -3804,6 +4203,7 @@ components:
                 targetPublicKey:
                     description: Public part of the API key that this event targets.
                     example: zmmrboas
+                    nullable: true
                     readOnly: true
                     type: string
                 userId:
@@ -3820,6 +4220,7 @@ components:
                 whitelistEntry:
                     description: Entry in the list of source host addresses that the API key accepts and this event targets.
                     example: 0.0.0.0
+                    nullable: true
                     readOnly: true
                     type: string
             required:
@@ -3898,6 +4299,7 @@ components:
                 targetPublicKey:
                     description: Public part of the API key that this event targets.
                     example: zmmrboas
+                    nullable: true
                     readOnly: true
                     type: string
                 userId:
@@ -3914,6 +4316,7 @@ components:
                 whitelistEntry:
                     description: Entry in the list of source host addresses that the API key accepts and this event targets.
                     example: 0.0.0.0
+                    nullable: true
                     readOnly: true
                     type: string
             required:
@@ -3921,6 +4324,12 @@ components:
                 - eventTypeName
                 - id
             title: API User Events
+            type: object
+        ApiVersion:
+            properties:
+                version:
+                    description: Object representing a version of the Atlas Admin API.
+                    type: string
             type: object
         AppServiceAlertConfigViewForNdsGroup:
             description: App Services metric alert configuration allows to select which app service conditions and events trigger alerts and how users are notified.
@@ -4590,6 +4999,48 @@ components:
             required:
                 - name
             type: object
+        AtlasRateLimitBucketState:
+            description: Configuration and current state of a single rate limit token bucket.
+            properties:
+                capacity:
+                    description: The capacity of the bucket.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                name:
+                    description: The name of the bucket.
+                    readOnly: true
+                    type: string
+                remaining:
+                    description: The remaining tokens of the bucket.
+                    format: int64
+                    readOnly: true
+                    type: integer
+            type: object
+        AtlasRateLimitInspectionResponse:
+            description: Rate limit inspection response containing bucket states for debugging and monitoring.
+            properties:
+                limits:
+                    description: List of bucket states.
+                    items:
+                        $ref: '#/components/schemas/AtlasRateLimitBucketState'
+                    readOnly: true
+                    type: array
+                scope:
+                    description: The scope type of the rate limit.
+                    enum:
+                        - GROUP
+                        - ORGANIZATION
+                        - USER
+                        - IP
+                    readOnly: true
+                    type: string
+                scopeId:
+                    description: The scope id associated to the bucket.
+                    nullable: true
+                    readOnly: true
+                    type: string
+            type: object
         AtlasResourcePolicyAuditForNdsGroup:
             description: Atlas resource policy audits indicate organization level changes to resource policies.
             properties:
@@ -4895,6 +5346,7 @@ components:
                     enum:
                         - FULLY_WARMED
                         - VISIBLE_EARLIER
+                        - ENHANCED_FULLY_WARMED
                     externalDocs:
                         description: Reduce Secondary Disk Warming Impact
                         url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -6979,6 +7431,7 @@ components:
                     type: string
                 clusterName:
                     description: Human-readable label that identifies the cluster.
+                    nullable: true
                     readOnly: true
                     type: string
                 complete:
@@ -7141,6 +7594,7 @@ components:
             type: object
         BadRequestDetail:
             description: Bad request detail.
+            nullable: true
             properties:
                 fields:
                     description: Describes all violations in a client request.
@@ -10115,6 +10569,7 @@ components:
                     enum:
                         - FULLY_WARMED
                         - VISIBLE_EARLIER
+                        - ENHANCED_FULLY_WARMED
                     externalDocs:
                         description: Reduce Secondary Disk Warming Impact
                         url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -11079,12 +11534,14 @@ components:
                         - TOTAL_OPS_P95_VALUE
                         - TOTAL_OPS_P99_VALUE
                     example: READS_OPS
+                    nullable: true
                     readOnly: true
                     type: string
                 units:
                     description: Unit of measurement that applies to this metric.
                     enum:
                         - MILLISECONDS
+                    nullable: true
                     readOnly: true
                     type: string
             readOnly: true
@@ -11412,6 +11869,7 @@ components:
                     type: boolean
                 identityProviderId:
                     description: Legacy 20-hexadecimal digit string that identifies the UI access identity provider that this connected organization configuration is associated with. This id can be found within the Federation Management Console > Identity Providers tab by clicking the info icon in the IdP ID row of a configured identity provider.
+                    nullable: true
                     pattern: ^([a-f0-9]{20})$
                     type: string
                 orgId:
@@ -11431,6 +11889,7 @@ components:
                             - ORG_BILLING_READ_ONLY
                             - ORG_STREAM_PROCESSING_ADMIN
                             - ORG_READ_ONLY
+                        nullable: true
                         type: string
                     type: array
                     uniqueItems: true
@@ -11612,7 +12071,7 @@ components:
                             - Cloud Manager
                             - Cloud Manager Standard/Premium
                             - Legacy Backup
-                            - AI Models
+                            - AI Model APIs
                             - Automated Embedding
                             - Native Reranking
                             - Flex Consulting
@@ -11754,6 +12213,7 @@ components:
                             - ORG_BILLING_READ_ONLY
                             - ORG_STREAM_PROCESSING_ADMIN
                             - ORG_READ_ONLY
+                        nullable: true
                         type: string
                     minItems: 1
                     type: array
@@ -11886,6 +12346,64 @@ components:
                     type: string
                     writeOnly: true
             title: GCP Forwarding Rules
+            type: object
+        CreateGroupMcpConfigRequest:
+            properties:
+                ipAccessList:
+                    description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+                    items:
+                        $ref: '#/components/schemas/ServiceAccountIPAccessListEntry'
+                    maxItems: 200
+                    type: array
+                mcpConfigName:
+                    description: Human-readable name that identifies this MCP configuration.
+                    minLength: 1
+                    type: string
+                roles:
+                    description: List of project roles to assign to this MCP configuration.
+                    externalDocs:
+                        description: Project-level Roles for Service Accounts
+                        url: https://www.mongodb.com/docs/atlas/reference/user-roles/
+                    items:
+                        type: string
+                    maxItems: 100
+                    minItems: 1
+                    type: array
+            required:
+                - mcpConfigName
+                - roles
+            type: object
+        CreateOrgMcpConfigRequest:
+            properties:
+                ipAccessList:
+                    description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+                    items:
+                        $ref: '#/components/schemas/ServiceAccountIPAccessListEntry'
+                    maxItems: 200
+                    type: array
+                mcpConfigName:
+                    description: Human-readable name that identifies this MCP configuration.
+                    minLength: 1
+                    type: string
+                roles:
+                    description: List of organization roles to assign to this MCP configuration.
+                    items:
+                        description: Organization roles available for Service Accounts.
+                        enum:
+                            - ORG_MEMBER
+                            - ORG_READ_ONLY
+                            - ORG_BILLING_ADMIN
+                            - ORG_BILLING_READ_ONLY
+                            - ORG_STREAM_PROCESSING_ADMIN
+                            - ORG_GROUP_CREATOR
+                            - ORG_OWNER
+                        type: string
+                    maxItems: 100
+                    minItems: 1
+                    type: array
+            required:
+                - mcpConfigName
+                - roles
             type: object
         CreateOrganizationRequest:
             properties:
@@ -12098,6 +12616,7 @@ components:
             externalDocs:
                 description: Built-in Roles
                 url: https://www.mongodb.com/docs/atlas/mongodb-users-roles-and-privileges/#mongodb-atlasrole-atlasAdmin
+            nullable: true
             properties:
                 links:
                     description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
@@ -13943,6 +14462,10 @@ components:
                         - LIST_STREAM_PROCESSORS
                         - LIST_CONNECTIONS
                         - STREAM_PROCESSOR_STATS
+                        - CREATE_SEARCH_INDEX
+                        - DROP_SEARCH_INDEX
+                        - LIST_SEARCH_INDEXES
+                        - UPDATE_SEARCH_INDEX
                     type: string
                 resources:
                     description: List of resources on which you grant the action.
@@ -15224,6 +15747,7 @@ components:
                           type: string
                         - enum:
                             - STREAM_PROCESSOR_STATE_IS_FAILED
+                            - STREAM_PROCESSOR_STARTED
                             - INSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
                             - OUTSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
                           title: Stream Processor Event Types
@@ -15279,12 +15803,13 @@ components:
                           title: Mongotune Event Types
                           type: string
                         - enum:
-                            - AI_MODELS_API_KEY_CREATED
-                            - AI_MODELS_API_KEY_DELETED
-                            - AI_MODELS_API_KEY_UPDATED
-                            - AI_MODELS_RATE_LIMIT_UPDATED
-                            - AI_MODELS_RATE_LIMIT_RESET
-                          title: Ai Models Event Types
+                            - AI_MODELS_APIS_API_KEY_CREATED
+                            - AI_MODELS_APIS_API_KEY_DELETED
+                            - AI_MODELS_APIS_API_KEY_UPDATED
+                            - AI_MODELS_APIS_RATE_LIMIT_UPDATED
+                            - AI_MODELS_APIS_RATE_LIMIT_RESET
+                            - AI_MODELS_APIS_RATE_LIMIT_ADMIN_OVERRIDE
+                          title: AI Models APIs Event Types
                           type: string
                     type: object
                 groupId:
@@ -15454,8 +15979,23 @@ components:
                           title: Support Event Types
                           type: string
                         - enum:
-                            - AI_MODELS_USAGE_TIER_UPDATED
-                          title: Ai Models Event Types
+                            - AI_MODELS_APIS_USAGE_TIER_UPDATED
+                            - AI_MODELS_APIS_FREE_TOKENS_ADMIN_ADJUSTED
+                          title: AI Models APIs Event Types
+                          type: string
+                        - enum:
+                            - OAUTH_CLIENT_CREATED
+                            - OAUTH_CLIENT_UPDATED
+                            - OAUTH_CLIENT_DELETED
+                            - OAUTH_CLIENT_SECRET_CREATED
+                            - OAUTH_CLIENT_SECRET_DELETED
+                            - OAUTH_AUTHORIZATION_GRANTED
+                            - OAUTH_AUTHORIZATION_DENIED
+                            - OAUTH_TOKEN_ISSUED
+                            - OAUTH_TOKEN_REVOKED
+                            - OAUTH_USER_CONSENT_GRANTED
+                            - OAUTH_USER_CONSENT_REVOKED
+                          title: OAuth Audit Types
                           type: string
                     type: object
                 groupId:
@@ -15526,6 +16066,7 @@ components:
                 defaultLimit:
                     description: Default limit value. Returns null if no default exists.
                     format: int32
+                    nullable: true
                     readOnly: true
                     type: integer
                 description:
@@ -15535,6 +16076,7 @@ components:
                 maximumLimit:
                     description: Maximum limit value. Returns null if no maximum exists.
                     format: int32
+                    nullable: true
                     readOnly: true
                     type: integer
                 name:
@@ -15669,6 +16211,7 @@ components:
                     type: string
                 privateLinkId:
                     description: Represents the endpoint to use when the host schema type is `PRIVATE_LINK`.
+                    nullable: true
                     type: string
             required:
                 - clusterName
@@ -16012,6 +16555,7 @@ components:
                 - exportBucketId
             type: object
         DiskBackupExportJobRequest:
+            nullable: true
             properties:
                 customData:
                     description: Collection of key-value pairs that represent custom data to add to the metadata file that MongoDB Cloud uploads to the bucket when the export job finishes.
@@ -16591,6 +17135,7 @@ components:
                     AZURE: '#/components/schemas/DiskBackupSnapshotAzureExportBucketRequest'
                     GCP: '#/components/schemas/DiskBackupSnapshotGCPExportBucketRequest'
                 propertyName: cloudProvider
+            nullable: true
             properties:
                 cloudProvider:
                     description: Human-readable label that identifies the cloud provider.
@@ -18418,6 +18963,7 @@ components:
                     - PROJECT_SCHEDULED_MAINTENANCE
                     - PROJECT_LIMIT_UPDATED
                     - PROJECT_ENABLE_EXTENDED_STORAGE_SIZES_UPDATED
+                    - PROJECT_ENABLE_DATA_VALIDATION_UPDATED
                     - PROJECT_COLLECT_DATABASE_STATISTICS_UPDATED
                     - OS_MAINTENANCE
                     - OS_MAINTENANCE_RESTART
@@ -18509,6 +19055,7 @@ components:
                     - SERVERLESS_UPGRADE_TO_DEDICATED_SUCCESSFUL
                     - SERVERLESS_UPGRADE_TO_DEDICATED_FAILED
                     - CLUSTER_FORCE_RECONFIG_REQUESTED
+                    - AGENT_FORCE_RESTART_REQUESTED
                     - CLUSTER_RESET_FORCE_RECONFIG_REQUESTED
                     - PROJECT_BYPASSED_MAINTENANCE
                     - FEATURE_FLAG_MAINTENANCE
@@ -18611,6 +19158,7 @@ components:
                     - MAINTENANCE_WAVE_ASSIGNMENT_REMOVED
                     - CLUSTER_MONGUARD_ENABLED
                     - CLUSTER_MONGUARD_DISABLED
+                    - CLUSTER_MONGODB_VERSION_UPDATED
                   title: Atlas Audit Types
                   type: string
                 - enum:
@@ -18783,6 +19331,7 @@ components:
                   type: string
                 - enum:
                     - STREAM_PROCESSOR_STATE_IS_FAILED
+                    - STREAM_PROCESSOR_STARTED
                     - INSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
                     - OUTSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
                   title: Stream Processor Event Types
@@ -18869,12 +19418,13 @@ components:
                   title: Shard Key Advisor Event Types
                   type: string
                 - enum:
-                    - AI_MODELS_API_KEY_CREATED
-                    - AI_MODELS_API_KEY_DELETED
-                    - AI_MODELS_API_KEY_UPDATED
-                    - AI_MODELS_RATE_LIMIT_UPDATED
-                    - AI_MODELS_RATE_LIMIT_RESET
-                  title: Ai Models Event Types
+                    - AI_MODELS_APIS_API_KEY_CREATED
+                    - AI_MODELS_APIS_API_KEY_DELETED
+                    - AI_MODELS_APIS_API_KEY_UPDATED
+                    - AI_MODELS_APIS_RATE_LIMIT_UPDATED
+                    - AI_MODELS_APIS_RATE_LIMIT_RESET
+                    - AI_MODELS_APIS_RATE_LIMIT_ADMIN_OVERRIDE
+                  title: AI Models APIs Event Types
                   type: string
             type: object
         EventTypeForOrg:
@@ -19059,6 +19609,7 @@ components:
                     - ORG_LIMIT_UPDATED
                     - SHADOW_CLUSTER_ORG_OPT_IN
                     - SHADOW_CLUSTER_ORG_OPT_OUT
+                    - ATLAS_MAINTENANCE_FLEET_ACTIVE_WAVE_CLOSED_BY_ADMIN
                   title: Atlas Audit Types
                   type: string
                 - enum:
@@ -19136,6 +19687,7 @@ components:
                     - SANDBOX_DISABLED_FOR_ORG
                     - SANDBOX_CONFIG_DELETED
                     - SANDBOX_TEMPLATE_UPDATED
+                    - ORG_DELEGATION_SETTINGS_UPDATED
                     - ORGANIZATION_VOYAGE_SETTINGS_CREATED
                     - ORGANIZATION_VOYAGE_SETTINGS_DELETED
                     - ORG_WAVE_ASSIGNMENT_MODE_MANUAL
@@ -19208,8 +19760,23 @@ components:
                   title: Atlas Resource Policy Audit Types
                   type: string
                 - enum:
-                    - AI_MODELS_USAGE_TIER_UPDATED
-                  title: Ai Models Event Types
+                    - AI_MODELS_APIS_USAGE_TIER_UPDATED
+                    - AI_MODELS_APIS_FREE_TOKENS_ADMIN_ADJUSTED
+                  title: AI Models APIs Event Types
+                  type: string
+                - enum:
+                    - OAUTH_CLIENT_CREATED
+                    - OAUTH_CLIENT_UPDATED
+                    - OAUTH_CLIENT_DELETED
+                    - OAUTH_CLIENT_SECRET_CREATED
+                    - OAUTH_CLIENT_SECRET_DELETED
+                    - OAUTH_AUTHORIZATION_GRANTED
+                    - OAUTH_AUTHORIZATION_DENIED
+                    - OAUTH_TOKEN_ISSUED
+                    - OAUTH_TOKEN_REVOKED
+                    - OAUTH_USER_CONSENT_GRANTED
+                    - OAUTH_USER_CONSENT_REVOKED
+                  title: OAuth Audit Types
                   type: string
             type: object
         EventViewForNdsGroup:
@@ -19442,6 +20009,7 @@ components:
                         - JVM_CURRENT_MEMORY
                         - JVM_MAX_MEMORY
                         - PAGE_FAULTS
+                    nullable: true
                     readOnly: true
                     type: string
                 units:
@@ -19460,6 +20028,7 @@ components:
                         - SCALAR
                         - SCALAR_PER_SECOND
                         - SECONDS
+                    nullable: true
                     readOnly: true
                     type: string
             readOnly: true
@@ -19517,6 +20086,7 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
@@ -19538,6 +20108,7 @@ components:
                     type: string
                 oktaIdpId:
                     description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+                    nullable: true
                     pattern: ^([a-f0-9]{20})$
                     type: string
                 protocol:
@@ -19549,6 +20120,7 @@ components:
                 updatedAt:
                     description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
+                    nullable: true
                     readOnly: true
                     type: string
             required:
@@ -19563,6 +20135,7 @@ components:
             properties:
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
@@ -19599,6 +20172,7 @@ components:
                     uniqueItems: true
                 audience:
                     description: Identifier of the intended recipient of the token.
+                    nullable: true
                     type: string
                 authorizationType:
                     description: Indicates whether authorization is granted based on group membership or user ID.
@@ -19613,12 +20187,14 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
                     type: string
                 groupsClaim:
                     description: Identifier of the claim which contains IdP Group IDs in the token.
+                    nullable: true
                     type: string
                 id:
                     description: Unique 24-hexadecimal digit string that identifies the identity provider.
@@ -19637,6 +20213,7 @@ components:
                     type: string
                 oktaIdpId:
                     description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+                    nullable: true
                     pattern: ^([a-f0-9]{20})$
                     type: string
                 protocol:
@@ -19648,6 +20225,7 @@ components:
                 updatedAt:
                     description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
+                    nullable: true
                     readOnly: true
                     type: string
                 userClaim:
@@ -19673,6 +20251,7 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
@@ -19718,6 +20297,7 @@ components:
                     uniqueItems: true
                 audience:
                     description: Identifier of the intended recipient of the token.
+                    nullable: true
                     type: string
                 authorizationType:
                     description: Indicates whether authorization is granted based on group membership or user ID.
@@ -19727,6 +20307,7 @@ components:
                     type: string
                 clientId:
                     description: Client identifier that is assigned to an application by the Identity Provider.
+                    nullable: true
                     type: string
                 createdAt:
                     description: Date that the identity provider was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
@@ -19735,12 +20316,14 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
                     type: string
                 groupsClaim:
                     description: Identifier of the claim which contains IdP Group IDs in the token.
+                    nullable: true
                     type: string
                 id:
                     description: Unique 24-hexadecimal digit string that identifies the identity provider.
@@ -19759,6 +20342,7 @@ components:
                     type: string
                 oktaIdpId:
                     description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+                    nullable: true
                     pattern: ^([a-f0-9]{20})$
                     type: string
                 protocol:
@@ -19775,6 +20359,7 @@ components:
                 updatedAt:
                     description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
+                    nullable: true
                     readOnly: true
                     type: string
                 userClaim:
@@ -19807,6 +20392,7 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
@@ -19852,6 +20438,7 @@ components:
                     uniqueItems: true
                 audience:
                     description: Identifier of the intended recipient of the token.
+                    nullable: true
                     type: string
                 authorizationType:
                     description: Indicates whether authorization is granted based on group membership or user ID.
@@ -19866,12 +20453,14 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
                     type: string
                 groupsClaim:
                     description: Identifier of the claim which contains IdP Group IDs in the token.
+                    nullable: true
                     type: string
                 id:
                     description: Unique 24-hexadecimal digit string that identifies the identity provider.
@@ -19890,6 +20479,7 @@ components:
                     type: string
                 oktaIdpId:
                     description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+                    nullable: true
                     pattern: ^([a-f0-9]{20})$
                     type: string
                 protocol:
@@ -19901,6 +20491,7 @@ components:
                 updatedAt:
                     description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
+                    nullable: true
                     readOnly: true
                     type: string
                 userClaim:
@@ -19924,6 +20515,7 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
@@ -19958,6 +20550,7 @@ components:
             properties:
                 acsUrl:
                     description: URL that points to where to send the SAML response.
+                    nullable: true
                     type: string
                 associatedDomains:
                     description: List that contains the domains associated with the identity provider.
@@ -19973,6 +20566,7 @@ components:
                     uniqueItems: true
                 audienceUri:
                     description: Unique string that identifies the intended audience of the SAML assertion.
+                    nullable: true
                     type: string
                 createdAt:
                     description: Date that the identity provider was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
@@ -19981,6 +20575,7 @@ components:
                     type: string
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
@@ -20002,6 +20597,7 @@ components:
                     type: string
                 oktaIdpId:
                     description: Legacy 20-hexadecimal digit string that identifies the identity provider.
+                    nullable: true
                     pattern: ^([a-f0-9]{20})$
                     type: string
                 pemFileInfo:
@@ -20026,6 +20622,7 @@ components:
                     type: string
                 slug:
                     description: Custom SSO URL for the identity provider.
+                    nullable: true
                     type: string
                 ssoDebugEnabled:
                     description: Flag that indicates whether the identity provider has SSO debug enabled.
@@ -20042,6 +20639,7 @@ components:
                 updatedAt:
                     description: Date that the identity provider was last updated on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
+                    nullable: true
                     readOnly: true
                     type: string
             required:
@@ -20059,6 +20657,7 @@ components:
                     uniqueItems: true
                 description:
                     description: The description of the identity provider.
+                    nullable: true
                     type: string
                 displayName:
                     description: Human-readable label that identifies the identity provider.
@@ -20110,6 +20709,7 @@ components:
                     enum:
                         - ACTIVE
                         - INACTIVE
+                    nullable: true
                     type: string
             required:
                 - ssoDebugEnabled
@@ -22692,6 +23292,46 @@ components:
             required:
                 - dayOfWeek
             type: object
+        GroupMcpConfigResponse:
+            properties:
+                clientId:
+                    description: Unique identifier for the Service Account client associated with this MCP configuration. Use this Service Account to connect to the Atlas Remote MCP.
+                    example: mdb_sa_id_1234567890abcdef12345678
+                    pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+                    readOnly: true
+                    type: string
+                egressClientId:
+                    description: Unique identifier for the egress Service Account client associated with this MCP configuration. This Service Account is managed by MongoDB Atlas.
+                    example: mdb_sa_id_1234567890abcdef12345678
+                    pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+                    readOnly: true
+                    type: string
+                ipAccessList:
+                    description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+                    items:
+                        $ref: '#/components/schemas/ServiceAccountIPAccessListEntry'
+                    maxItems: 200
+                    type: array
+                mcpConfigId:
+                    description: Unique 24-hexadecimal digit string that identifies this MCP configuration.
+                    example: 32b6e34b3d91647adeabc012
+                    pattern: ^[a-fA-F0-9]{24}$
+                    readOnly: true
+                    type: string
+                mcpConfigName:
+                    description: Human-readable name that identifies this MCP configuration.
+                    nullable: true
+                    type: string
+                roles:
+                    description: List of project roles associated with this MCP configuration.
+                    externalDocs:
+                        description: Project-level Roles for Service Accounts
+                        url: https://www.mongodb.com/docs/atlas/reference/user-roles/
+                    items:
+                        type: string
+                    maxItems: 100
+                    type: array
+            type: object
         GroupMigrationRequest:
             properties:
                 destinationOrgId:
@@ -22927,7 +23567,9 @@ components:
                 secretExpiresAfterHours:
                     description: The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.
                     example: 8
+                    exclusiveMinimum: true
                     format: int32
+                    minimum: 0
                     type: integer
             required:
                 - description
@@ -22956,12 +23598,14 @@ components:
                     description: Human readable description for the Service Account.
                     maxLength: 250
                     minLength: 1
+                    nullable: true
                     pattern: ^[\p{L}\p{N}\-_.,' ]*$
                     type: string
                 name:
                     description: Human-readable name for the Service Account. The name is modifiable and does not have to be unique.
                     maxLength: 64
                     minLength: 1
+                    nullable: true
                     pattern: ^[\p{L}\p{N}\-_.,' ]*$
                     type: string
                 roles:
@@ -22991,6 +23635,9 @@ components:
                 isDataExplorerGenAISampleDocumentPassingEnabled:
                     default: false
                     description: Flag that indicates whether to enable the passing of sample field values with the use of generative AI features in the Data Explorer for the specified project.
+                    type: boolean
+                isDataValidationEnabled:
+                    description: Flag that indicates whether data validation is enabled for all clusters in the specified project.
                     type: boolean
                 isExtendedStorageSizesEnabled:
                     description: Flag that indicates whether to enable extended storage sizes for the specified project.
@@ -24712,6 +25359,38 @@ components:
                     type: string
             readOnly: true
             type: object
+        ImportedDashboard:
+            description: Imported dashboard.
+            properties:
+                embeddingId:
+                    description: Embedding ID of the item. This field only returns if embedding is enabled for the entity.
+                    type: string
+                id:
+                    description: ID of the dashboard.
+                    type: string
+                title:
+                    description: Title of the dashboard.
+                    type: string
+            required:
+                - id
+                - title
+            type: object
+        ImportedItem:
+            description: Imported Item.
+            properties:
+                embeddingId:
+                    description: Embedding ID of the item. This will only be returned if embedding is enabled for the entity.
+                    type: string
+                id:
+                    description: ID of the item.
+                    type: string
+                title:
+                    description: Title of the item.
+                    type: string
+            required:
+                - id
+                - title
+            type: object
         InboundControlPlaneCloudProviderIPAddresses:
             description: List of inbound IP addresses to the Atlas control plane, categorized by cloud provider. If your application allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your API requests can reach the Atlas control plane.
             properties:
@@ -24977,6 +25656,28 @@ components:
                     type: object
             type: object
             writeOnly: true
+        Info:
+            description: Information about the MongoDB Atlas Administration API OpenAPI Specification.
+            properties:
+                description:
+                    description: Description of the MongoDB Atlas Administration API.
+                    example: The MongoDB Atlas Administration API allows developers to manage all components in MongoDB Atlas.
+                    type: string
+                license:
+                    $ref: '#/components/schemas/License'
+                termsOfService:
+                    description: Terms of Service URL.
+                    example: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
+                    type: string
+                title:
+                    description: Title of the MongoDB Atlas Administration API.
+                    example: MongoDB Atlas Administration API.
+                    type: string
+                version:
+                    description: Version of the MongoDB Atlas Administration API.
+                    example: "2.0"
+                    type: string
+            type: object
         IngestionPipelineRun:
             description: Run details of a Data Lake Pipeline.
             properties:
@@ -25552,6 +26253,7 @@ components:
                     enum:
                         - FULLY_WARMED
                         - VISIBLE_EARLIER
+                        - ENHANCED_FULLY_WARMED
                     externalDocs:
                         description: Reduce Secondary Disk Warming Impact
                         url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -25872,6 +26574,7 @@ components:
                     enum:
                         - FULLY_WARMED
                         - VISIBLE_EARLIER
+                        - ENHANCED_FULLY_WARMED
                     externalDocs:
                         description: Reduce Secondary Disk Warming Impact
                         url: https://docs.atlas.mongodb.com/reference/replica-set-tags/#reduce-secondary-disk-warming-impact
@@ -26233,6 +26936,18 @@ components:
                 - eventTypeName
                 - notifications
             type: object
+        License:
+            description: License information of the MongoDB Atlas Administration API.
+            properties:
+                name:
+                    description: Name of the license.
+                    example: CC BY-NC-SA 3.0 US
+                    type: string
+                url:
+                    description: URL of the license.
+                    example: https://creativecommons.org/licenses/by-nc-sa/3.0/us/
+                    type: string
+            type: object
         Link:
             properties:
                 href:
@@ -26445,6 +27160,7 @@ components:
                         - FAILED
                         - COMPLETE
                         - EXPIRED
+                    nullable: true
                     readOnly: true
                     type: string
             type: object
@@ -27555,6 +28271,7 @@ components:
                     description: List that contains the Atlas Search index identifiers.
                     items:
                         description: Unique 24-hexadecimal digit string that identifies the index.
+                        nullable: true
                         type: string
                     readOnly: true
                     type: array
@@ -28090,6 +28807,48 @@ components:
                     readOnly: true
                     type: array
             type: object
+        MongosRegionConfig:
+            description: Dedicated mongos placement in one region.
+            properties:
+                nodeCount:
+                    description: Number of dedicated mongos to run in this region.
+                    format: int32
+                    type: integer
+                providerName:
+                    description: Cloud provider on which the dedicated mongos run.
+                    enum:
+                        - AWS
+                        - AZURE
+                        - GCP
+                    type: string
+                regionName:
+                    description: Region in which the dedicated mongos run.
+                    type: string
+            type: object
+        MongosTier:
+            description: Hardware spec for the dedicated mongos tier.
+            properties:
+                instanceSize:
+                    description: Instance size of the dedicated mongos hosts (for example, `M30`).
+                    type: string
+                regionConfigs:
+                    description: Per-region placement of the dedicated mongos hosts.
+                    items:
+                        $ref: '#/components/schemas/MongosRegionConfig'
+                    type: array
+            type: object
+        MongosTopology:
+            description: 'Configuration of the mongos routers for a sharded cluster: colocated on the shard nodes or running on a dedicated tier.'
+            properties:
+                state:
+                    description: Desired mongos topology. `COLOCATED` runs mongos on the shard nodes; `DEDICATED` runs mongos on a dedicated tier described by `tier`.
+                    enum:
+                        - COLOCATED
+                        - DEDICATED
+                    type: string
+                tier:
+                    $ref: '#/components/schemas/MongosTier'
+            type: object
         MongotuneAlertConfigViewForNdsGroup:
             description: Intelligent Workload Management alert configuration allows to select which Intelligent Workload Management events trigger alerts and how users are notified.
             properties:
@@ -28476,6 +29235,7 @@ components:
                 - PROJECT_SCHEDULED_MAINTENANCE
                 - PROJECT_LIMIT_UPDATED
                 - PROJECT_ENABLE_EXTENDED_STORAGE_SIZES_UPDATED
+                - PROJECT_ENABLE_DATA_VALIDATION_UPDATED
                 - PROJECT_COLLECT_DATABASE_STATISTICS_UPDATED
                 - OS_MAINTENANCE
                 - OS_MAINTENANCE_RESTART
@@ -28567,6 +29327,7 @@ components:
                 - SERVERLESS_UPGRADE_TO_DEDICATED_SUCCESSFUL
                 - SERVERLESS_UPGRADE_TO_DEDICATED_FAILED
                 - CLUSTER_FORCE_RECONFIG_REQUESTED
+                - AGENT_FORCE_RESTART_REQUESTED
                 - CLUSTER_RESET_FORCE_RECONFIG_REQUESTED
                 - PROJECT_BYPASSED_MAINTENANCE
                 - FEATURE_FLAG_MAINTENANCE
@@ -28669,6 +29430,7 @@ components:
                 - MAINTENANCE_WAVE_ASSIGNMENT_REMOVED
                 - CLUSTER_MONGUARD_ENABLED
                 - CLUSTER_MONGUARD_DISABLED
+                - CLUSTER_MONGODB_VERSION_UPDATED
             example: CLUSTER_CREATED
             title: Atlas Audit Types
             type: string
@@ -28678,6 +29440,7 @@ components:
                 - ORG_LIMIT_UPDATED
                 - SHADOW_CLUSTER_ORG_OPT_IN
                 - SHADOW_CLUSTER_ORG_OPT_OUT
+                - ATLAS_MAINTENANCE_FLEET_ACTIVE_WAVE_CLOSED_BY_ADMIN
             example: ORG_LIMIT_UPDATED
             title: Atlas Audit Types
             type: string
@@ -30020,7 +30783,44 @@ components:
                         - AWS
                     type: string
                 regionName:
-                    description: Cloud provider region in which the Object Storage private endpoint is located.
+                    description: Cloud provider region of the S3 bucket that the Object Storage private endpoint accesses. For same-region endpoints, this is also the region where the VPC interface endpoint is deployed.
+                    oneOf:
+                        - description: |-
+                            Physical location where MongoDB Cloud deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases.
+                            When MongoDB Cloud deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Cloud creates them as part of the deployment. MongoDB Cloud assigns the VPC a CIDR block.
+                            To limit a new VPC peering connection to one CIDR block and region, create the connection first. Deploy the cluster after the connection starts.
+                          enum:
+                            - US_GOV_WEST_1
+                            - US_GOV_EAST_1
+                            - US_EAST_1
+                            - US_EAST_2
+                            - US_WEST_1
+                            - US_WEST_2
+                            - CA_CENTRAL_1
+                            - EU_NORTH_1
+                            - EU_WEST_1
+                            - EU_WEST_2
+                            - EU_WEST_3
+                            - EU_CENTRAL_1
+                            - AP_EAST_1
+                            - AP_NORTHEAST_1
+                            - AP_NORTHEAST_2
+                            - AP_NORTHEAST_3
+                            - AP_SOUTHEAST_1
+                            - AP_SOUTHEAST_2
+                            - AP_SOUTHEAST_3
+                            - AP_SOUTH_1
+                            - SA_EAST_1
+                            - CN_NORTH_1
+                            - CN_NORTHWEST_1
+                            - ME_SOUTH_1
+                            - AF_SOUTH_1
+                            - EU_SOUTH_1
+                            - GLOBAL
+                          type: string
+                    type: object
+                vpcRegionName:
+                    description: Cloud provider region in which the VPC interface endpoint is deployed. Omit to deploy the interface endpoint in the same region as the S3 bucket (same-region endpoint). Set to a region different from `regionName` to create a cross-region endpoint.
                     oneOf:
                         - description: |-
                             Physical location where MongoDB Cloud deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases.
@@ -30079,7 +30879,7 @@ components:
                     readOnly: true
                     type: string
                 regionName:
-                    description: Cloud provider region in which the Object Storage private endpoint is located.
+                    description: Cloud provider region in which the Object Storage bucket is located. For cross-region endpoints, this differs from `vpcRegionName`, which is the region in which the VPC interface endpoint is deployed.
                     oneOf:
                         - description: |-
                             Physical location where MongoDB Cloud deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases.
@@ -30126,6 +30926,43 @@ components:
                         - DELETING
                     readOnly: true
                     type: string
+                vpcRegionName:
+                    description: Cloud provider region in which the VPC interface endpoint is deployed. Echoes `regionName` for same-region endpoints.
+                    oneOf:
+                        - description: |-
+                            Physical location where MongoDB Cloud deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases.
+                            When MongoDB Cloud deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Cloud creates them as part of the deployment. MongoDB Cloud assigns the VPC a CIDR block.
+                            To limit a new VPC peering connection to one CIDR block and region, create the connection first. Deploy the cluster after the connection starts.
+                          enum:
+                            - US_GOV_WEST_1
+                            - US_GOV_EAST_1
+                            - US_EAST_1
+                            - US_EAST_2
+                            - US_WEST_1
+                            - US_WEST_2
+                            - CA_CENTRAL_1
+                            - EU_NORTH_1
+                            - EU_WEST_1
+                            - EU_WEST_2
+                            - EU_WEST_3
+                            - EU_CENTRAL_1
+                            - AP_EAST_1
+                            - AP_NORTHEAST_1
+                            - AP_NORTHEAST_2
+                            - AP_NORTHEAST_3
+                            - AP_SOUTHEAST_1
+                            - AP_SOUTHEAST_2
+                            - AP_SOUTHEAST_3
+                            - AP_SOUTH_1
+                            - SA_EAST_1
+                            - CN_NORTH_1
+                            - CN_NORTHWEST_1
+                            - ME_SOUTH_1
+                            - AF_SOUTH_1
+                            - EU_SOUTH_1
+                            - GLOBAL
+                          type: string
+                    type: object
             type: object
         OnDemandCpsSnapshotSource:
             allOf:
@@ -30451,6 +31288,11 @@ components:
                     $ref: '#/components/schemas/RawMetricUnits'
             required:
                 - metricName
+            type: object
+        OpenApiInfo:
+            properties:
+                info:
+                    $ref: '#/components/schemas/Info'
             type: object
         OperationThrottlingRejectedOperationsRawMetricThresholdView:
             properties:
@@ -30805,6 +31647,70 @@ components:
                     example: "2024"
                     type: string
             type: object
+        OrgDelegationSettingsResponse:
+            properties:
+                delegatedMcpAccess:
+                    description: Policy that controls how MCP (Model Context Protocol) delegated access is permitted within this organization. Possible values are `DISALLOWED`, `READ_ONLY`, and `READ_WRITE`. Defaults to `DISALLOWED`.
+                    enum:
+                        - DISALLOWED
+                        - READ_ONLY
+                        - READ_WRITE
+                    nullable: true
+                    type: string
+                delegatedPartnerAccess:
+                    description: Policy that controls whether partner delegated access is permitted within this organization. Possible values are `DISALLOWED` and `READ_WRITE`. Defaults to `DISALLOWED`.
+                    enum:
+                        - DISALLOWED
+                        - READ_WRITE
+                    nullable: true
+                    type: string
+                idleRefreshTokenLifetime:
+                    description: Maximum number of seconds a refresh token may be idle before it expires. When not set, the system default applies.
+                    format: int64
+                    maximum: 3.1536e+07
+                    minimum: 1
+                    nullable: true
+                    type: integer
+                maximumRefreshTokenLifetime:
+                    description: Maximum lifetime of a refresh token in seconds, regardless of activity. When not set, the system default applies.
+                    format: int64
+                    maximum: 3.1536e+07
+                    minimum: 1
+                    nullable: true
+                    type: integer
+            type: object
+        OrgDelegationSettingsUpdateRequest:
+            properties:
+                delegatedMcpAccess:
+                    description: Policy that controls how MCP (Model Context Protocol) delegated access is permitted within this organization. Possible values are `DISALLOWED`, `READ_ONLY`, and `READ_WRITE`. Defaults to `DISALLOWED`.
+                    enum:
+                        - DISALLOWED
+                        - READ_ONLY
+                        - READ_WRITE
+                    nullable: true
+                    type: string
+                delegatedPartnerAccess:
+                    description: Policy that controls whether partner delegated access is permitted within this organization. Possible values are `DISALLOWED` and `READ_WRITE`. Defaults to `DISALLOWED`.
+                    enum:
+                        - DISALLOWED
+                        - READ_WRITE
+                    nullable: true
+                    type: string
+                idleRefreshTokenLifetime:
+                    description: Maximum number of seconds a refresh token may be idle before it expires. Omit to leave unchanged; set to null to reset to the system default. Must be between 1 and 31536000 (1 year) when provided.
+                    format: int64
+                    maximum: 3.1536e+07
+                    minimum: 1
+                    nullable: true
+                    type: integer
+                maximumRefreshTokenLifetime:
+                    description: Maximum lifetime of a refresh token in seconds, regardless of activity. Omit to leave unchanged; set to null to reset to the system default. Must be between 1 and 31536000 (1 year) when provided.
+                    format: int64
+                    maximum: 3.1536e+07
+                    minimum: 1
+                    nullable: true
+                    type: integer
+            type: object
         OrgEventTypeViewForOrg:
             description: Unique identifier of event type.
             enum:
@@ -30882,6 +31788,7 @@ components:
                 - SANDBOX_DISABLED_FOR_ORG
                 - SANDBOX_CONFIG_DELETED
                 - SANDBOX_TEMPLATE_UPDATED
+                - ORG_DELEGATION_SETTINGS_UPDATED
                 - ORGANIZATION_VOYAGE_SETTINGS_CREATED
                 - ORGANIZATION_VOYAGE_SETTINGS_DELETED
                 - ORG_WAVE_ASSIGNMENT_MODE_MANUAL
@@ -31049,6 +31956,52 @@ components:
                     readOnly: true
                     type: array
             type: object
+        OrgMcpConfigResponse:
+            properties:
+                clientId:
+                    description: Unique identifier for the Service Account client associated with this MCP configuration. Use this Service Account to connect to the Atlas Remote MCP.
+                    example: mdb_sa_id_1234567890abcdef12345678
+                    pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+                    readOnly: true
+                    type: string
+                egressClientId:
+                    description: Unique identifier for the egress Service Account client associated with this MCP configuration. This Service Account is managed by MongoDB Atlas.
+                    example: mdb_sa_id_1234567890abcdef12345678
+                    pattern: ^mdb_sa_id_[a-fA-F\d]{24}$
+                    readOnly: true
+                    type: string
+                ipAccessList:
+                    description: List of IP access list entries that define allowed source addresses for this MCP configuration.
+                    items:
+                        $ref: '#/components/schemas/ServiceAccountIPAccessListEntry'
+                    maxItems: 200
+                    type: array
+                mcpConfigId:
+                    description: Unique 24-hexadecimal digit string that identifies this MCP configuration.
+                    example: 32b6e34b3d91647adeabc012
+                    pattern: ^[a-fA-F0-9]{24}$
+                    readOnly: true
+                    type: string
+                mcpConfigName:
+                    description: Human-readable name that identifies this MCP configuration.
+                    nullable: true
+                    type: string
+                roles:
+                    description: List of organization roles associated with this MCP configuration.
+                    items:
+                        description: Organization roles available for Service Accounts.
+                        enum:
+                            - ORG_MEMBER
+                            - ORG_READ_ONLY
+                            - ORG_BILLING_ADMIN
+                            - ORG_BILLING_READ_ONLY
+                            - ORG_STREAM_PROCESSING_ADMIN
+                            - ORG_GROUP_CREATOR
+                            - ORG_OWNER
+                        type: string
+                    maxItems: 100
+                    type: array
+            type: object
         OrgNotification:
             description: Organization notification configuration for MongoDB Cloud to send information when an event triggers an alert condition.
             properties:
@@ -31208,6 +32161,7 @@ components:
             type: object
         OrgServiceAccountRequest:
             description: Organization Service Account that Atlas creates for this organization. If omitted, Atlas doesn't create an organization Service Account for this organization. If specified, this object requires all body parameters. Note that API Keys cannot be specified in the same request.
+            nullable: true
             properties:
                 description:
                     description: Human readable description for the Service Account.
@@ -31239,7 +32193,9 @@ components:
                 secretExpiresAfterHours:
                     description: The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.
                     example: 8
+                    exclusiveMinimum: true
                     format: int32
+                    minimum: 0
                     type: integer
             required:
                 - description
@@ -31253,12 +32209,14 @@ components:
                     description: Human readable description for the Service Account.
                     maxLength: 250
                     minLength: 1
+                    nullable: true
                     pattern: ^[\p{L}\p{N}\-_.,' ]*$
                     type: string
                 name:
                     description: Human-readable name for the Service Account. The name is modifiable and does not have to be unique.
                     maxLength: 64
                     minLength: 1
+                    nullable: true
                     pattern: ^[\p{L}\p{N}\-_.,' ]*$
                     type: string
                 roles:
@@ -31567,6 +32525,33 @@ components:
                         type: string
                     type: array
                     uniqueItems: true
+            type: object
+        OrganizationMaintenanceSettingsResponse:
+            description: Maintenance configuration settings for an organization.
+            properties:
+                effectiveWaveAssignmentMode:
+                    description: Wave assignment mode that Atlas uses when scheduling maintenance for projects in this organization. This read-only field takes precedence over `waveAssignmentMode` for scheduling. It matches `waveAssignmentMode` except when cross-organization maintenance sequencing is enabled and this organization is a linked non-paying organization, in which case it reflects the paying organization's `waveAssignmentMode`. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when no mode is configured. Omitted from GET responses when maintenance sequencing is disabled for this organization.
+                    enum:
+                        - MANUAL
+                        - ENV_TAG_MAPPING
+                    readOnly: true
+                    type: string
+                waveAssignmentMode:
+                    description: Mode explicitly configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Omitted from the response when no explicit preference has been set; in that case `effectiveWaveAssignmentMode` reflects the value the system uses (`MANUAL` by default). Atlas uses read-only `effectiveWaveAssignmentMode` (not this field) for scheduling. In a cross-organization billing hierarchy, a linked non-paying organization cannot update its `effectiveWaveAssignmentMode` field, which inherits from the paying organization's `waveAssignmentMode`. In this case, a linked non-paying organization's `effectiveWaveAssignmentMode` and `waveAssignmentMode` might differ.
+                    enum:
+                        - MANUAL
+                        - ENV_TAG_MAPPING
+                    nullable: true
+                    type: string
+            type: object
+        OrganizationMaintenanceSettingsUpdateRequest:
+            properties:
+                waveAssignmentMode:
+                    description: Mode configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when unset. Only this field can be updated; Atlas derives read-only `effectiveWaveAssignmentMode` on GET responses and uses that value for scheduling when it differs from `waveAssignmentMode`. Omit this field to leave the current value unchanged. Specify null to reset to the default value (`MANUAL`).
+                    enum:
+                        - MANUAL
+                        - ENV_TAG_MAPPING
+                    type: string
             type: object
         OrganizationSettings:
             description: Collection of settings that configures the organization.
@@ -32438,6 +33423,32 @@ components:
             required:
                 - results
             type: object
+        PaginatedApiStreamsFailoverConnection:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/StreamsConnection'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
         PaginatedApiStreamsPrivateLinkView:
             properties:
                 links:
@@ -32516,6 +33527,58 @@ components:
             required:
                 - results
             type: object
+        PaginatedApiStreamsTransitGatewayAttachmentResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/StreamsTransitGatewayAttachmentResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
+        PaginatedApiStreamsTransitGatewayRouteResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/StreamsTransitGatewayRouteResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
         PaginatedApiStreamsVPCPeeringConnectionView:
             properties:
                 links:
@@ -32557,6 +33620,32 @@ components:
                     description: List of returned documents that MongoDB Cloud provides when completing this request.
                     items:
                         $ref: '#/components/schemas/UserAccessListResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
+        PaginatedApiVersions:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/ApiVersion'
                     readOnly: true
                     type: array
                 totalCount:
@@ -33120,6 +34209,32 @@ components:
             required:
                 - results
             type: object
+        PaginatedGroupMcpConfigView:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/GroupMcpConfigResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
         PaginatedGroupServiceAccounts:
             description: A list of Project Service Accounts.
             properties:
@@ -33370,6 +34485,32 @@ components:
                     description: List of returned documents that MongoDB Cloud provides when completing this request.
                     items:
                         $ref: '#/components/schemas/OrgGroup'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
+        PaginatedOrgMcpConfigView:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/OrgMcpConfigResponse'
                     readOnly: true
                     type: array
                 totalCount:
@@ -33776,6 +34917,32 @@ components:
             required:
                 - results
             type: object
+        PaginatedStreamsTransitGatewayInvitationsResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                results:
+                    description: List of returned documents that MongoDB Cloud provides when completing this request.
+                    items:
+                        $ref: '#/components/schemas/StreamsTransitGatewayInvitationsResponse'
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description: Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
+                    format: int32
+                    minimum: 0
+                    readOnly: true
+                    type: integer
+            required:
+                - results
+            type: object
         PaginatedTeamRoleView:
             properties:
                 links:
@@ -33887,6 +35054,7 @@ components:
             type: object
         PemFileInfo:
             description: PEM file information for the identity provider's current certificates.
+            nullable: true
             properties:
                 certificates:
                     description: List of certificates in the file.
@@ -34457,6 +35625,8 @@ components:
             type: object
         PublicApiUsageDetailsLineItemView:
             properties:
+                additionalData:
+                    $ref: '#/components/schemas/AdditionalData'
                 billDate:
                     description: Billing date of the line item. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
@@ -34731,15 +35901,18 @@ components:
                     description: Human-readable label that identifies the namespace on the specified host. The resource expresses this parameter value as `<database>.<collection>`.
                     type: string
                 p50ExecMicros:
-                    description: The 50th percentile value of execution time in microseconds.
+                    deprecated: true
+                    description: The 50th percentile value of execution time in microseconds. This field is deprecated as the values it reports may be inaccurate. It will be removed in a future release.
                     format: double
                     type: number
                 p90ExecMicros:
-                    description: The 90th percentile value of execution time in microseconds.
+                    deprecated: true
+                    description: The 90th percentile value of execution time in microseconds. This field is deprecated as the values it reports may be inaccurate. It will be removed in a future release.
                     format: double
                     type: number
                 p99ExecMicros:
-                    description: The 99th percentile value of execution time in microseconds.
+                    deprecated: true
+                    description: The 99th percentile value of execution time in microseconds. This field is deprecated as the values it reports may be inaccurate. It will be removed in a future release.
                     format: double
                     type: number
                 queryShape:
@@ -34849,6 +36022,7 @@ components:
                 defaultValue:
                     description: The default request capacity of the endpoint set. Returned if there is a capacity override set for the requested entity.
                     format: int64
+                    nullable: true
                     type: integer
                 value:
                     description: The applied request capacity of the endpoint set.
@@ -34877,6 +36051,7 @@ components:
                 defaultValue:
                     description: The default rate limit refill duration, in seconds, of the endpoint set. Returned if there is a rate limit refill duration override set for the requested entity.
                     format: int64
+                    nullable: true
                     type: integer
                 value:
                     description: The applied rate limit refill duration of the endpoint set.
@@ -34889,6 +36064,7 @@ components:
                 defaultValue:
                     description: The default rate limit refill rate of the endpoint set. Returned if there is a rate limit refill rate override set for the requested entity.
                     format: int64
+                    nullable: true
                     type: integer
                 value:
                     description: The applied rate limit refill rate of the endpoint set.
@@ -36134,6 +37310,7 @@ components:
             type: object
         SandboxClusterTemplateView:
             description: Cluster template configuration for sandbox clusters.
+            nullable: true
             properties:
                 provider:
                     description: The provider for a cluster.
@@ -36155,6 +37332,7 @@ components:
                     $ref: '#/components/schemas/SandboxClusterTemplateView'
                 enabled:
                     description: Whether sandbox mode is enabled for the organization.
+                    nullable: true
                     type: boolean
             type: object
         SandboxConfigResponse:
@@ -36164,6 +37342,7 @@ components:
                     $ref: '#/components/schemas/SandboxClusterTemplateView'
                 enabled:
                     description: Whether sandbox mode is enabled for the organization.
+                    nullable: true
                     type: boolean
                 id:
                     description: The ID of the sandbox configuration.
@@ -36179,6 +37358,7 @@ components:
                     $ref: '#/components/schemas/SandboxClusterTemplateView'
                 enabled:
                     description: Whether sandbox mode is enabled for the organization.
+                    nullable: true
                     type: boolean
             type: object
         SchemaAdvisorItemRecommendation:
@@ -38371,6 +39551,7 @@ components:
                 cidrBlock:
                     description: Range of network addresses in the access list for the Service Account. This parameter requires the range to be expressed in Classless Inter-Domain Routing (CIDR) notation of Internet Protocol version 4 or version 6 addresses. You can set a value for this parameter or `ipAddress`, but not for both in the same request.
                     example: 203.0.113.0/24
+                    nullable: true
                     pattern: ^((([0-9]{1,3}\.){3}[0-9]{1,3})|(:{0,2}([0-9a-f]{1,4}:){0,7}[0-9a-f]{1,4}[:]{0,2}))((%2[fF]|/)[0-9]{1,3})+$
                     type: string
                 createdAt:
@@ -38381,16 +39562,19 @@ components:
                 ipAddress:
                     description: Network address in the access list for the Service Account. This parameter requires the address to be expressed as one Internet Protocol version 4 or version 6 address. You can set a value for this parameter or `cidrBlock`, but not for both in the same request.
                     example: 203.0.113.10
+                    nullable: true
                     pattern: ^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}|([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}$
                     type: string
                 lastUsedAddress:
                     description: Network address that issued the most recent request to the API. This parameter requires the address to be expressed as one Internet Protocol version 4 or version 6 address. The resource returns this parameter after this IP address makes at least one request.
                     example: 203.0.113.10
+                    nullable: true
                     readOnly: true
                     type: string
                 lastUsedAt:
                     description: Date when MongoDB Cloud received the most recent request that originated from this Internet Protocol version 4 or version 6 address. The resource returns this parameter when at least one request originates from this IP address. MongoDB Cloud updates this parameter each time a client accesses the permitted resource, with a delay of up to 5 minutes. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
+                    nullable: true
                     readOnly: true
                     type: string
                 requestCount:
@@ -38504,6 +39688,7 @@ components:
                 lastUsedAt:
                     description: The last time the secret was used. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
                     format: date-time
+                    nullable: true
                     readOnly: true
                     type: string
                 maskedSecretValue:
@@ -38567,6 +39752,7 @@ components:
             writeOnly: true
         ShardingRequest:
             description: Document that configures sharding on the destination cluster when migrating from a replica set source to a sharded cluster destination on MongoDB 6.0 or higher. If you don't wish to shard any collections on the destination cluster, leave this empty.
+            nullable: true
             properties:
                 createSupportingIndexes:
                     description: Flag that lets the migration create supporting indexes for the shard keys, if none exists, as the destination cluster also needs compatible indexes for the specified shard keys.
@@ -38682,6 +39868,7 @@ components:
             properties:
                 caCertificatePath:
                     description: Path to the CA certificate that signed SSL certificates use to authenticate to the source cluster.
+                    nullable: true
                     type: string
                 clusterName:
                     description: Label that identifies the source cluster name.
@@ -38697,6 +39884,7 @@ components:
                     type: boolean
                 password:
                     description: Password that authenticates the username to the source cluster.
+                    nullable: true
                     type: string
                     writeOnly: true
                 ssl:
@@ -38704,6 +39892,7 @@ components:
                     type: boolean
                 username:
                     description: Label that identifies the SCRAM-SHA user that connects to the source cluster.
+                    nullable: true
                     type: string
                     writeOnly: true
             required:
@@ -39067,6 +40256,7 @@ components:
             description: Unique identifier of event type.
             enum:
                 - STREAM_PROCESSOR_STATE_IS_FAILED
+                - STREAM_PROCESSOR_STARTED
                 - INSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
                 - OUTSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD
             example: STREAM_PROCESSOR_STATE_IS_FAILED
@@ -39342,6 +40532,7 @@ components:
                 - properties:
                     clusterGroupId:
                         description: Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting.
+                        nullable: true
                         type: string
                     clusterName:
                         description: Name of the cluster configured for this connection.
@@ -39758,6 +40949,9 @@ components:
         StreamsModifyStreamProcessor:
             description: A request to modify an existing stream processor.
             properties:
+                failoverEnabled:
+                    description: Flag that enables or disables failover for the stream processor.
+                    type: boolean
                 links:
                     description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
                     externalDocs:
@@ -39926,6 +41120,9 @@ components:
                     pattern: ^([a-f0-9]{24})$
                     readOnly: true
                     type: string
+                failoverEnabled:
+                    description: Flag that enables or disables failover for the stream processor.
+                    type: boolean
                 links:
                     description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
                     externalDocs:
@@ -39976,9 +41173,11 @@ components:
                     enum:
                         - GRACEFUL
                         - FORCED
+                    nullable: true
                     type: string
                 region:
                     description: Name of the region against which to apply the status change. Required when `status` is `FAILED_OVER`; optional otherwise.
+                    nullable: true
                     type: string
                 status:
                     description: Represents the desired action to apply to stream processors within a workspace, such as starting all processors, stopping all processors, or performing a bulk regional failover.
@@ -39999,6 +41198,14 @@ components:
                     pattern: ^([a-f0-9]{24})$
                     readOnly: true
                     type: string
+                eligibleForFailover:
+                    description: Flag that indicates whether the stream processor is eligible for failover.
+                    readOnly: true
+                    type: boolean
+                failoverEnabled:
+                    description: Flag that enables or disables failover for the stream processor.
+                    readOnly: true
+                    type: boolean
                 links:
                     description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
                     externalDocs:
@@ -40177,6 +41384,8 @@ components:
         StreamsStartStreamProcessorWith:
             description: A request to start a stream processor.
             properties:
+                failover:
+                    $ref: '#/components/schemas/StreamsStartProcessorFailover'
                 links:
                     description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
                     externalDocs:
@@ -40223,6 +41432,12 @@ components:
                     type: array
                 dataProcessRegion:
                     $ref: '#/components/schemas/StreamsDataProcessRegion'
+                failoverRegions:
+                    description: List of failover regions configured for the stream workspace.
+                    items:
+                        $ref: '#/components/schemas/StreamsDataProcessRegion'
+                    maxItems: 2
+                    type: array
                 groupId:
                     description: Unique 24-hexadecimal character string that identifies the project.
                     example: 32b6e34b3d91647abb20e7b8
@@ -40254,7 +41469,7 @@ components:
                 streamConfig:
                     $ref: '#/components/schemas/StreamConfig'
             type: object
-        StreamsTenantUpdatePreviewUpdateRequest:
+        StreamsTenantUpdateRequest:
             description: Details to update a stream tenant, optionally accompanied by a processor status change (for example, triggering bulk regional failover).
             properties:
                 cloudProvider:
@@ -40266,6 +41481,12 @@ components:
                         - TENANT
                         - SERVERLESS
                     type: string
+                failoverRegions:
+                    description: Failover regions for the stream workspace.
+                    items:
+                        $ref: '#/components/schemas/StreamsDataProcessRegion'
+                    maxItems: 2
+                    type: array
                 links:
                     description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
                     externalDocs:
@@ -40282,17 +41503,73 @@ components:
                 streamConfig:
                     $ref: '#/components/schemas/StreamConfig'
             type: object
-        StreamsTenantUpdateRequest:
-            description: Details to update a stream tenant.
+        StreamsTransitGatewayAttachmentRequest:
             properties:
                 cloudProvider:
-                    description: Human-readable label that identifies the cloud provider.
-                    enum:
-                        - AWS
-                        - GCP
-                        - AZURE
-                        - TENANT
-                        - SERVERLESS
+                    description: Provider for the transit gateway resources.
+                    type: string
+                    writeOnly: true
+                regionName:
+                    description: AWS region name.
+                    type: string
+                    writeOnly: true
+                tgwId:
+                    description: AWS transit gateway ID.
+                    pattern: ^(tgw-)[0-9a-zA-Z]+$
+                    type: string
+                vpcId:
+                    description: AWS VPC ID.
+                    pattern: ^(vpc-)[0-9a-zA-Z]+$
+                    type: string
+                    writeOnly: true
+            type: object
+        StreamsTransitGatewayAttachmentResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                tgwAttachmentId:
+                    description: The AWS Transit Gateway Attachment ID.
+                    pattern: ^(tgw-attach-)[0-9a-zA-Z]+$
+                    readOnly: true
+                    type: string
+                tgwId:
+                    description: AWS transit gateway ID.
+                    pattern: ^(tgw-)[0-9a-zA-Z]+$
+                    type: string
+            type: object
+        StreamsTransitGatewayInvitationsResponse:
+            properties:
+                links:
+                    description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
+                    externalDocs:
+                        description: Web Linking Specification (RFC 5988)
+                        url: https://datatracker.ietf.org/doc/html/rfc5988
+                    items:
+                        $ref: '#/components/schemas/Link'
+                    readOnly: true
+                    type: array
+                tgwId:
+                    description: AWS transit gateway ID.
+                    pattern: ^(tgw-)[0-9a-zA-Z]+$
+                    type: string
+                tgwResourceShareArn:
+                    description: AWS Transit Gateway resource share ARN.
+                    type: string
+                tgwResourceShareInvitationArn:
+                    description: AWS Transit Gateway resource share invitation ARN.
+                    type: string
+            type: object
+        StreamsTransitGatewayResourceShare:
+            properties:
+                cloudProvider:
+                    description: Provider for the transit gateway resources.
                     type: string
                 links:
                     description: List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
@@ -40303,10 +41580,52 @@ components:
                         $ref: '#/components/schemas/Link'
                     readOnly: true
                     type: array
+                regionName:
+                    description: AWS Region name.
+                    type: string
+                tgwId:
+                    description: AWS transit gateway ID.
+                    pattern: ^(tgw-)[0-9a-zA-Z]+$
+                    type: string
+                tgwResourceShareArn:
+                    description: AWS Transit Gateway resource share ARN.
+                    type: string
+                tgwResourceShareInvitationArn:
+                    description: AWS Transit Gateway resource share invitation ARN.
+                    readOnly: true
+                    type: string
+            type: object
+        StreamsTransitGatewayRouteRequest:
+            description: Container for metadata needed to create a Transit Gateway route.
+            properties:
+                destinationCidr:
+                    description: The route's destination CIDR.
+                    type: string
                 region:
-                    $ref: '#/components/schemas/BaseStreamsRegion'
-                streamConfig:
-                    $ref: '#/components/schemas/StreamConfig'
+                    description: The region of the Atlas VPCs where this route should take effect.
+                    type: string
+                tgwId:
+                    description: The AWS ID of the Transit Gateway through which traffic will be routed.
+                    type: string
+            type: object
+        StreamsTransitGatewayRouteResponse:
+            description: Container for metadata associated with a Transit Gateway route.
+            properties:
+                destinationCidr:
+                    description: The route's destination CIDR.
+                    type: string
+                region:
+                    description: The region of the Atlas VPCs where this route should take effect.
+                    type: string
+                tgwId:
+                    description: The AWS ID of the Transit Gateway through which traffic will be routed.
+                    type: string
+                tgwRouteId:
+                    description: The ID of the Transit Gateway route.
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    readOnly: true
+                    type: string
             type: object
         SwapUsageFreeDataMetricThresholdView:
             properties:
@@ -41869,6 +43188,7 @@ components:
                             - ORG_BILLING_READ_ONLY
                             - ORG_STREAM_PROCESSING_ADMIN
                             - ORG_READ_ONLY
+                        nullable: true
                         type: string
                     type: array
             type: object
@@ -42009,7 +43329,7 @@ components:
                             - Cloud Manager
                             - Cloud Manager Standard/Premium
                             - Legacy Backup
-                            - AI Models
+                            - AI Model APIs
                             - Automated Embedding
                             - Native Reranking
                             - Flex Consulting
@@ -42269,6 +43589,7 @@ components:
                     description: 'Email address for the console user that this event targets. The resource returns this parameter when `"eventTypeName" : "USER"`.'
                     example: test.user@mongodb.com
                     format: email
+                    nullable: true
                     readOnly: true
                     type: string
                 userId:
@@ -42359,6 +43680,7 @@ components:
                     description: 'Email address for the console user that this event targets. The resource returns this parameter when `"eventTypeName" : "USER"`.'
                     example: test.user@mongodb.com
                     format: email
+                    nullable: true
                     readOnly: true
                     type: string
                 userId:
@@ -42800,6 +44122,16 @@ components:
         Webhook:
             description: Details to integrate one webhook with one MongoDB Cloud project.
             properties:
+                bodyTemplate:
+                    description: 'HTTP body template for a webhook-based alert. The rendered output MUST be valid JSON — MongoDB Cloud sends the rendered body with `Content-Type: application/json`. If the template fails to render, exceeds the 16 KB limit, or renders non-JSON output, MongoDB Cloud sends the webhook with its default JSON payload instead.'
+                    example: '{"alert":"${id}","severity":"${severity}"}'
+                    format: password
+                    type: string
+                headersTemplate:
+                    description: 'HTTP headers template for a webhook-based alert. The rendered output MUST be a JSON object mapping header name to header value (e.g. `{"X-Custom-Header": "static-value", "X-Alert-Id": "${id}"}`). Placeholders may reference any alert-view field plus `${eventType}`; the webhook secret and the signature header are NOT exposed to templates. If the template fails to render, exceeds the 4 KB limit, or renders output that is not a valid JSON name→value object, MongoDB Cloud sends the webhook with its default set of headers instead.'
+                    example: '{"X-Alert-Id":"${id}","X-Event-Type":"${eventType}"}'
+                    format: password
+                    type: string
                 id:
                     description: Integration id.
                     nullable: true
@@ -42855,6 +44187,14 @@ components:
                     description: Human-readable label that displays the alert notification type.
                     enum:
                         - WEBHOOK
+                    type: string
+                webhookBodyTemplate:
+                    description: Template, using ${field} interpolation, that renders the HTTP body MongoDB Cloud sends with each webhook notification. Must render valid JSON. When unset, MongoDB Cloud sends its default JSON payload.
+                    format: password
+                    type: string
+                webhookHeadersTemplate:
+                    description: Template, using ${field} interpolation, that renders the HTTP headers MongoDB Cloud sends with each webhook notification. Must render a JSON object mapping header name to header value. The webhook secret and the signature header are NOT exposed to templates.
+                    format: password
                     type: string
                 webhookSecret:
                     description: |-
@@ -43063,6 +44403,7 @@ components:
                 description:
                     description: Description of the event.
                     example: Alert Acknowledged
+                    nullable: true
                     type: string
                 gn:
                     description: Human-readable label that identifies the project.
@@ -43607,7 +44948,7 @@ info:
     termsOfService: https://www.mongodb.com/mongodb-management-service-terms-and-conditions
     title: MongoDB Atlas Administration API
     version: "2.0"
-    x-xgen-sha: 51d1ffaea55034e002aeb6329745dd9d6773c97c
+    x-xgen-sha: 68e310a94321e8bb33f32ad0383c3938555face2
 openapi: 3.0.1
 paths:
     /api/atlas/v2:
@@ -45527,10 +46868,10 @@ paths:
                 - Project Model Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/updateGroupAiModelApiKey
             x-xgen-operation-id-override: updateModelApiKey
-    /api/atlas/v2/groups/{groupId}/aiModelRateLimits:
+    /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits:
         get:
             description: Retrieve AI model rate limits for the given group.
-            operationId: listGroupAiModelRateLimits
+            operationId: listGroupAiModelApiRateLimits
             parameters:
                 - $ref: '#/components/parameters/groupId'
                 - $ref: '#/components/parameters/itemsPerPage'
@@ -45567,12 +46908,12 @@ paths:
                 - AI Model Rate Limits
             x-rolesRequirements:
                 - Project Read Only
-            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listGroupAiModelRateLimits
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listGroupAiModelApiRateLimits
             x-xgen-operation-id-override: listGroupModelLimits
-    /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:
+    /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits/{modelGroupName}:
         get:
             description: Retrieve a single AI model rate limit for the given group.
-            operationId: getGroupAiModelRateLimit
+            operationId: getGroupAiModelApiRateLimit
             parameters:
                 - $ref: '#/components/parameters/groupId'
                 - $ref: '#/components/parameters/envelope'
@@ -45613,11 +46954,11 @@ paths:
                 - AI Model Rate Limits
             x-rolesRequirements:
                 - Project Read Only
-            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getGroupAiModelRateLimit
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getGroupAiModelApiRateLimit
             x-xgen-operation-id-override: getGroupModelLimit
         patch:
             description: Update an AI model rate limit for the given model group.
-            operationId: updateGroupAiModelRateLimit
+            operationId: updateGroupAiModelApiRateLimit
             parameters:
                 - $ref: '#/components/parameters/groupId'
                 - $ref: '#/components/parameters/envelope'
@@ -45670,12 +47011,12 @@ paths:
                 - AI Model Rate Limits
             x-rolesRequirements:
                 - Project Model Owner
-            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/updateGroupAiModelRateLimit
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/updateGroupAiModelApiRateLimit
             x-xgen-operation-id-override: updateModelRateLimit
-    /api/atlas/v2/groups/{groupId}/aiModelRateLimits/{modelGroupName}:reset:
+    /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits/{modelGroupName}:reset:
         post:
             description: Reset the AI model rate limit for the given model group to default values.
-            operationId: resetGroupAiModelRateLimit
+            operationId: resetGroupAiModelApiRateLimit
             parameters:
                 - $ref: '#/components/parameters/groupId'
                 - $ref: '#/components/parameters/envelope'
@@ -45718,12 +47059,12 @@ paths:
                 - AI Model Rate Limits
             x-rolesRequirements:
                 - Project Model Owner
-            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimit
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelApiRateLimit
             x-xgen-operation-id-override: resetModelRateLimit
-    /api/atlas/v2/groups/{groupId}/aiModelRateLimits:reset:
+    /api/atlas/v2/groups/{groupId}/aiModelApiRateLimits:reset:
         post:
             description: Reset the AI Model rate limits for the given group to default values.
-            operationId: resetGroupAiModelRateLimits
+            operationId: resetGroupAiModelApiRateLimits
             parameters:
                 - $ref: '#/components/parameters/groupId'
                 - $ref: '#/components/parameters/envelope'
@@ -45758,7 +47099,7 @@ paths:
                 - AI Model Rate Limits
             x-rolesRequirements:
                 - Project Model Owner
-            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelRateLimits
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/resetGroupAiModelApiRateLimits
             x-xgen-method-verb-override:
                 customMethod: "True"
                 verb: reset
@@ -47502,6 +48843,132 @@ paths:
                 - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateGroupBackupCompliancePolicy
             x-xgen-operation-id-override: updateCompliancePolicy
+    /api/atlas/v2/groups/{groupId}/chartsDashboards/{dashboardId}:export:
+        get:
+            description: Exports the specified Charts dashboard.
+            operationId: exportGroupChartsDashboard
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - description: ID of the dashboard to export.
+                  in: path
+                  name: dashboardId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                description: This resource returns an exported Charts dashboard. You can use this response to import to the Charts Dashboard Import endpoint.
+                                type: string
+                            x-xgen-preview:
+                                name: charts-dashboards
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Export One Charts Dashboard
+            tags:
+                - Charts Dashboards
+            x-rolesRequirements:
+                - Project Data Access Admin
+                - Project Data Access Read Only
+                - Project Data Access Read Write
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Charts-Dashboards/operation/exportGroupChartsDashboard
+            x-xgen-operation-id-override: exportChartsDashboard
+    /api/atlas/v2/groups/{groupId}/chartsDashboards:import:
+        post:
+            description: Imports the Charts dashboard that the template specifies. Optionally, you can specify `overwrite=true` to import into an existing dashboard.
+            operationId: importGroupChartsDashboards
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/groupId'
+                - description: Setting this to true enables importing into an existing dashboard.
+                  in: query
+                  name: overwrite
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        examples:
+                            Sample import response body:
+                                description: Sample import response body
+                                value:
+                                    dashboards:
+                                        dashboard-1:
+                                            description: Dashboard description
+                                            embedding:
+                                                anonymousAuthEnabled: true
+                                            filters: []
+                                            layout: []
+                                            title: Dashboard title
+                                    dataSources:
+                                        data-source-1:
+                                            alias: 'Sample Data: Movies'
+                                            collection: movies
+                                            database: sample_data
+                                            deployment: sample-data-cluster
+                                            sourceType: cluster
+                                    exportVersion: 9
+                                    items:
+                                        item-1:
+                                            calculatedFields: []
+                                            query: null
+                                            sample: false
+                                    queries: {}
+                        schema:
+                            type: object
+                        x-xgen-preview:
+                            name: charts-dashboards
+                            public: "false"
+                        x-xgen-version: preview
+                description: Schema corresponding to the response fetched from an exported dashboard.
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiChartsDashboardImportResponseView'
+                            x-xgen-preview:
+                                name: charts-dashboards
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Import One Charts Dashboard
+            tags:
+                - Charts Dashboards
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Charts-Dashboards/operation/importGroupChartsDashboards
+            x-xgen-operation-id-override: importChartsDashboards
     /api/atlas/v2/groups/{groupId}/cloudProviderAccess:
         get:
             description: Returns all cloud provider access roles with access to the specified project.
@@ -48058,6 +49525,12 @@ paths:
                         schema:
                             $ref: '#/components/schemas/ClusterDescription20240805'
                         x-xgen-version: "2024-10-23"
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/ApiAtlasClusterDescriptionPreview'
+                        x-xgen-preview:
+                            public: "true"
+                        x-xgen-version: preview
                 description: Cluster to create in this project.
                 required: true
             responses:
@@ -48082,6 +49555,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/ClusterDescription20240805'
                             x-xgen-version: "2024-10-23"
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiAtlasClusterDescriptionPreview'
+                            x-xgen-preview:
+                                public: "true"
+                            x-xgen-version: preview
                     description: Created
                     headers:
                         RateLimit-Limit:
@@ -48224,6 +49703,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/ClusterDescription20240805'
                             x-xgen-version: "2024-08-05"
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiAtlasClusterDescriptionPreview'
+                            x-xgen-preview:
+                                public: "true"
+                            x-xgen-version: preview
                     description: OK
                     headers:
                         RateLimit-Limit:
@@ -48291,6 +49776,12 @@ paths:
                         schema:
                             $ref: '#/components/schemas/ClusterDescription20240805'
                         x-xgen-version: "2024-10-23"
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/ApiAtlasClusterDescriptionPreview'
+                        x-xgen-preview:
+                            public: "true"
+                        x-xgen-version: preview
                 description: Cluster to update in the specified project.
                 required: true
             responses:
@@ -48315,6 +49806,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/ClusterDescription20240805'
                             x-xgen-version: "2024-10-23"
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/ApiAtlasClusterDescriptionPreview'
+                            x-xgen-preview:
+                                public: "true"
+                            x-xgen-version: preview
                     description: OK
                     headers:
                         RateLimit-Limit:
@@ -52281,11 +53778,11 @@ paths:
                     maximum: 100
                     minimum: 1
                     type: integer
-                - description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series.
+                - description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series. The `P50_EXECUTION_TIME`, `P90_EXECUTION_TIME`, and `P99_EXECUTION_TIME` series are deprecated as the values they report may be inaccurate. They will be removed in a future release.
                   in: query
                   name: series
                   schema:
-                    description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series.
+                    description: Query shape statistics data series to retrieve. A series represents a specific metric about query execution. To include multiple series, pass the parameter multiple times delimited with an ampersand (`&`) between each series. Omit this parameter to return results for all available series. The `P50_EXECUTION_TIME`, `P90_EXECUTION_TIME`, and `P99_EXECUTION_TIME` series are deprecated as the values they report may be inaccurate. They will be removed in a future release.
                     items:
                         enum:
                             - TOTAL_EXECUTION_TIME
@@ -58249,7 +59746,7 @@ paths:
                     | Limit Name | Description | Default | API Override Limit |
                     | --- | --- | --- | --- |
                     | `atlas.project.deployment.clusters` | Limit on the number of clusters in this project | 25 | 100 |
-                    | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on the number of nodes per Private Link region in this project | 50 | 90 |
+                    | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on AWS PrivateLink addressable target nodes per region in this project. For sharded clusters using optimized (load-balanced) connection strings, `currentUsage` doesn't grow with the number of `mongos` — the load balancer is counted as a single addressable target regardless of how many `mongos` sit behind it. | 50 | 90 |
                     | `atlas.project.security.databaseAccess.customRoles` | Limit on the number of custom roles in this project | 100 | 1400 |
                     | `atlas.project.security.databaseAccess.users` | Limit on the number of database users in this project | 100 | 100 |
                     | `atlas.project.security.networkAccess.crossRegionEntries` | Limit on the number of cross-region network access entries in this project | 40 | 220 |
@@ -58323,7 +59820,7 @@ paths:
                     | Limit Name | Description | Default | API Override Limit |
                     | --- | --- | --- | --- |
                     | `atlas.project.deployment.clusters` | Limit on the number of clusters in this project | 25 | 100 |
-                    | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on the number of nodes per Private Link region in this project | 50 | 90 |
+                    | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on AWS PrivateLink addressable target nodes per region in this project. For sharded clusters using optimized (load-balanced) connection strings, `currentUsage` doesn't grow with the number of `mongos` — the load balancer is counted as a single addressable target regardless of how many `mongos` sit behind it. | 50 | 90 |
                     | `atlas.project.security.databaseAccess.customRoles` | Limit on the number of custom roles in this project | 100 | 1400 |
                     | `atlas.project.security.databaseAccess.users` | Limit on the number of database users in this project | 100 | 100 |
                     | `atlas.project.security.networkAccess.crossRegionEntries` | Limit on the number of cross-region network access entries in this project | 40 | 220 |
@@ -58399,7 +59896,7 @@ paths:
                     | Limit Name | Description | Default | API Override Limit |
                     | --- | --- | --- | --- |
                     | `atlas.project.deployment.clusters` | Limit on the number of clusters in this project | 25 | 100 |
-                    | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on the number of nodes per Private Link region in this project | 50 | 90 |
+                    | `atlas.project.deployment.nodesPerPrivateLinkRegion` | Limit on AWS PrivateLink addressable target nodes per region in this project. For sharded clusters using optimized (load-balanced) connection strings, `currentUsage` doesn't grow with the number of `mongos` — the load balancer is counted as a single addressable target regardless of how many `mongos` sit behind it. | 50 | 90 |
                     | `atlas.project.security.databaseAccess.customRoles` | Limit on the number of custom roles in this project | 100 | 1400 |
                     | `atlas.project.security.databaseAccess.users` | Limit on the number of database users in this project | 100 | 100 |
                     | `atlas.project.security.networkAccess.crossRegionEntries` | Limit on the number of cross-region network access entries in this project | 40 | 220 |
@@ -59121,7 +60618,10 @@ paths:
             x-xgen-operation-id-override: toggleMaintenanceAutoDefer
     /api/atlas/v2/groups/{groupId}/maintenanceWindow/defer:
         post:
-            description: Defers the maintenance window for the specified project. Urgent maintenance activities such as security patches can't wait for your chosen window. MongoDB Cloud starts those maintenance activities when needed. After you schedule maintenance for your cluster, you can't change your maintenance window until the current maintenance efforts complete. The maintenance procedure that MongoDB Cloud performs requires at least one replica set election during the maintenance window per replica set. Maintenance always begins as close to the scheduled hour as possible, but in-progress cluster updates or unexpected system issues could delay the start time.
+            description: Defers the maintenance window for the specified project. Urgent maintenance activities such as security patches can't wait for your chosen window. MongoDB Cloud starts those maintenance activities when needed. After you schedule maintenance for your cluster, you can't change your maintenance window until the current maintenance efforts complete. The maintenance procedure that MongoDB Cloud performs requires at least one replica set election during the maintenance window per replica set. Maintenance always begins as close to the scheduled hour as possible, but in-progress cluster updates or unexpected system issues could delay the start time. You can only defer maintenance within a limited time window before the scheduled maintenance starts; deferral requests made outside of this window return an error.
+            externalDocs:
+                description: Respond to Required Maintenance
+                url: https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/#respond-to-required-maintenance
             operationId: deferGroupMaintenanceWindow
             parameters:
                 - $ref: '#/components/parameters/envelope'
@@ -59272,6 +60772,153 @@ paths:
             x-xgen-method-verb-override:
                 customMethod: true
             x-xgen-operation-id-override: enableManagedSlowMs
+    /api/atlas/v2/groups/{groupId}/mcpConfigs:
+        get:
+            description: Returns all MCP configurations associated with the specified project.
+            operationId: listGroupMcpConfigs
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/includeCount'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/groupId'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedGroupMcpConfigView'
+                            x-xgen-version: "2025-03-12"
+                    description: OK
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All MCP Configurations for One Project
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Project Read Only
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/listGroupMcpConfigs
+        post:
+            description: Creates an MCP configuration for the specified project. Returns the configuration ID and ingress credentials.
+            operationId: createGroupMcpConfig
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+            requestBody:
+                content:
+                    application/vnd.atlas.2025-03-12+json:
+                        schema:
+                            $ref: '#/components/schemas/CreateGroupMcpConfigRequest'
+                        x-xgen-version: "2025-03-12"
+                description: MCP configuration to create.
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/GroupMcpConfigResponse'
+                            x-xgen-version: "2025-03-12"
+                    description: Created
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Create One MCP Configuration for One Project
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/createGroupMcpConfig
+    /api/atlas/v2/groups/{groupId}/mcpConfigs/{mcpConfigId}:
+        delete:
+            description: Deletes the MCP configuration with the specified ID for the specified project.
+            operationId: deleteGroupMcpConfig
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - description: Unique identifier of the MCP configuration to delete.
+                  in: path
+                  name: mcpConfigId
+                  required: true
+                  schema:
+                    type: string
+                - description: Flag that indicates whether to delete the MCP configuration even if it has active secrets. If false and active secrets exist, the request returns an error. Defaults to false.
+                  in: query
+                  name: cascading
+                  schema:
+                    default: false
+                    type: boolean
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            x-xgen-version: "2025-03-12"
+                    description: No Content
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Delete One MCP Configuration for One Project
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Project Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/deleteGroupMcpConfig
+        get:
+            description: Returns the MCP configuration with the specified ID for the specified project.
+            operationId: getGroupMcpConfig
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/groupId'
+                - description: Unique identifier of the MCP configuration.
+                  in: path
+                  name: mcpConfigId
+                  required: true
+                  schema:
+                    example: 32b6e34b3d91647adeabc012
+                    pattern: ^[a-fA-F0-9]{24}$
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/GroupMcpConfigResponse'
+                            x-xgen-version: "2025-03-12"
+                    description: OK
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One MCP Configuration for One Project
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Project Read Only
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/getGroupMcpConfig
     /api/atlas/v2/groups/{groupId}/metricIntegrations:
         get:
             description: Returns all metric integration configurations for the project. Optionally filter by integration type and provider type.
@@ -62879,6 +64526,47 @@ paths:
                 - Project Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Push-Based-Log-Export/operation/createGroupPushBasedLogExport
             x-xgen-operation-id-override: createLogExport
+    /api/atlas/v2/groups/{groupId}/ratelimits:
+        get:
+            description: Retrieve rate limiting bucket state for the specified group.
+            operationId: getGroupRatelimits
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/AtlasRateLimitInspectionResponse'
+                            x-xgen-preview:
+                                name: rate-limit
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Rate Limit State for One Group
+            tags:
+                - Rate Limit
+            x-rolesRequirements:
+                - Project Read Only
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/getGroupRatelimits
     /api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}:
         post:
             description: Requests loading the MongoDB sample dataset into the specified cluster.
@@ -64810,7 +66498,7 @@ paths:
                             $ref: '#/components/schemas/StreamsTenantUpdateRequest'
                     application/vnd.atlas.preview+json:
                         schema:
-                            $ref: '#/components/schemas/StreamsTenantUpdatePreviewUpdateRequest'
+                            $ref: '#/components/schemas/StreamsTenantUpdateRequest'
                         x-xgen-preview:
                             name: regional-failover
                             public: "false"
@@ -65214,6 +66902,68 @@ paths:
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamConnection
             x-xgen-operation-id-override: updateStreamConnection
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}/failoverConnections:
+        get:
+            description: Returns all failover connections for the specified connection in a stream workspace.
+            operationId: listGroupStreamConnectionFailoverConnections
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+                - description: Label that identifies the stream workspace.
+                  in: path
+                  name: tenantName
+                  required: true
+                  schema:
+                    type: string
+                - description: Label that identifies the stream connection.
+                  in: path
+                  name: connectionName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiStreamsFailoverConnection'
+                            x-xgen-version: "2025-03-12"
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiStreamsFailoverConnection'
+                            x-sunset: "2026-07-20"
+                            x-xgen-preview:
+                                name: regional-failover
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Stream Failover Connections
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamConnectionFailoverConnections
+            x-xgen-operation-id-override: listFailoverConnections
         post:
             description: Creates one failover connection for a stream workspace in the specified project.
             operationId: createGroupStreamConnectionFailoverConnection
@@ -65235,25 +66985,27 @@ paths:
                     type: string
             requestBody:
                 content:
-                    application/vnd.atlas.preview+json:
+                    application/vnd.atlas.2025-03-12+json:
                         schema:
                             $ref: '#/components/schemas/StreamsConnection'
-                        x-xgen-preview:
-                            name: regional-failover
-                            public: "false"
-                        x-xgen-version: preview
+                        x-xgen-version: application/vnd.atlas.2025-03-12+json
                 description: Details to create one failover connection for a streams workspace in the specified project.
                 required: true
             responses:
                 "201":
                     content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsConnection'
+                            x-xgen-version: "2025-03-12"
                         application/vnd.atlas.preview+json:
                             schema:
                                 $ref: '#/components/schemas/StreamsConnection'
+                            x-sunset: "2026-07-20"
                             x-xgen-preview:
                                 name: regional-failover
                                 public: "false"
-                            x-xgen-version: application/vnd.atlas.preview+json
+                            x-xgen-version: preview
                     description: OK
                     headers:
                         RateLimit-Limit:
@@ -65280,10 +67032,204 @@ paths:
             x-rolesRequirements:
                 - Organization Stream Processing Admin
                 - Project Stream Processing Owner
-            x-xgen-changelog:
-                "2023-09-11": The MongoDB Atlas Streams Processing API is now exposed as part of private preview, but is subject to change until GA.
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamConnectionFailoverConnection
             x-xgen-operation-id-override: createFailoverConnection
+    /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}/failoverConnections/{failoverConnectionId}:
+        delete:
+            description: Delete one failover connection of the specified stream workspace.
+            operationId: deleteGroupStreamConnectionFailoverConnection
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/groupId'
+                - description: Label that identifies the stream workspace.
+                  in: path
+                  name: tenantName
+                  required: true
+                  schema:
+                    type: string
+                - description: Label that identifies the stream connection.
+                  in: path
+                  name: connectionName
+                  required: true
+                  schema:
+                    type: string
+                - description: Label that identifies the stream failover connection id.
+                  in: path
+                  name: failoverConnectionId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            x-xgen-version: "2025-03-12"
+                        application/vnd.atlas.preview+json:
+                            x-sunset: "2026-07-20"
+                            x-xgen-preview:
+                                name: regional-failover
+                                public: "false"
+                            x-xgen-version: preview
+                    description: No Content
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Delete One Stream Failover Connection
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamConnectionFailoverConnection
+            x-xgen-operation-id-override: deleteStreamFailoverConnection
+        get:
+            description: Get one failover connection of the specified stream workspace.
+            operationId: getGroupStreamConnectionFailoverConnection
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/groupId'
+                - description: Label that identifies the stream workspace.
+                  in: path
+                  name: tenantName
+                  required: true
+                  schema:
+                    type: string
+                - description: Label that identifies the stream connection.
+                  in: path
+                  name: connectionName
+                  required: true
+                  schema:
+                    type: string
+                - description: Label that identifies the stream failover connection id.
+                  in: path
+                  name: failoverConnectionId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsConnection'
+                            x-xgen-version: "2025-03-12"
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsConnection'
+                            x-sunset: "2026-07-20"
+                            x-xgen-preview:
+                                name: regional-failover
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Stream Failover Connection
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamConnectionFailoverConnection
+            x-xgen-operation-id-override: getStreamFailoverConnection
+        patch:
+            description: Update one failover connection of the specified stream workspace.
+            operationId: updateGroupStreamConnectionFailoverConnection
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/groupId'
+                - description: Label that identifies the stream workspace.
+                  in: path
+                  name: tenantName
+                  required: true
+                  schema:
+                    type: string
+                - description: Label that identifies the stream connection.
+                  in: path
+                  name: connectionName
+                  required: true
+                  schema:
+                    type: string
+                - description: Label that identifies the stream failover connection id.
+                  in: path
+                  name: failoverConnectionId
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/vnd.atlas.2025-03-12+json:
+                        schema:
+                            $ref: '#/components/schemas/StreamsConnection'
+                description: Details to update one failover connection for a streams workspace in the specified project.
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsConnection'
+                            x-xgen-version: "2025-03-12"
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsConnection'
+                            x-sunset: "2026-07-20"
+                            x-xgen-preview:
+                                name: regional-failover
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Update One Stream Failover Connection
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateGroupStreamConnectionFailoverConnection
+            x-xgen-operation-id-override: updateStreamFailoverConnection
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor:
         post:
             description: Create one Stream Processor within the specified stream workspace.
@@ -65670,7 +67616,7 @@ paths:
             x-xgen-operation-id-override: stopStreamProcessor
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processors:
         get:
-            description: Returns all Stream Processors within the specified stream workspace.
+            description: Returns all Stream Processors within the specified stream workspace, including information on which processors are failover-eligible.
             operationId: getGroupStreamProcessors
             parameters:
                 - $ref: '#/components/parameters/envelope'
@@ -66298,6 +68244,609 @@ paths:
                 - Project Stream Processing Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/withGroupStreamSampleConnections
             x-xgen-operation-id-override: withStreamSampleConnections
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayAttachments:
+        get:
+            description: Returns the Transit Gateway Attachments for this group in the shared Atlas AWS Account.
+            operationId: listGroupStreamsTransitGatewayAttachments
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiStreamsTransitGatewayAttachmentResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Transit Gateway Attachments for One Group
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamsTransitGatewayAttachments
+            x-xgen-operation-id-override: listTransitGatewayAttachments
+        post:
+            description: Creates Transit Gateway Attachment with the provided VPC for a Transit Gateway that has been shared with an Atlas AWS Account. This Transit Gateway will be used in Atlas Streams private networking connections.
+            operationId: createGroupStreamsTransitGatewayAttachment
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/StreamsTransitGatewayAttachmentRequest'
+                        x-xgen-preview:
+                            name: aws-transit-gateway
+                        x-xgen-version: preview
+                description: Metadata needed for creating a transit gateway attachment.
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsTransitGatewayAttachmentResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: Created
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Create One Transit Gateway Attachment
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamsTransitGatewayAttachment
+            x-xgen-operation-id-override: createTransitGatewayAttachment
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayAttachments/{attachmentId}:
+        delete:
+            description: Deletes a transit gateway attachment.
+            operationId: deleteGroupStreamsTransitGatewayAttachment
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - description: Unique identifier that identifies the Transit Gateway Attachment.
+                  in: path
+                  name: attachmentId
+                  required: true
+                  schema:
+                    example: tgw-attach-01f8100bc7EXAMPLE
+                    pattern: ^tgw-attach-[0-9a-zA-Z]+$
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: No Content
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Delete One Transit Gateway Attachment
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamsTransitGatewayAttachment
+            x-xgen-operation-id-override: deleteTransitGatewayAttachment
+        get:
+            description: Returns one Transit Gateway Attachment for this group from the shared Atlas AWS Account.
+            operationId: getGroupStreamsTransitGatewayAttachment
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - description: Unique identifier that identifies the Transit Gateway Attachment.
+                  in: path
+                  name: attachmentId
+                  required: true
+                  schema:
+                    example: tgw-attach-01f8100bc7EXAMPLE
+                    pattern: ^tgw-attach-[0-9a-zA-Z]+$
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsTransitGatewayAttachmentResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Transit Gateway Attachment for One Group
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamsTransitGatewayAttachment
+            x-xgen-operation-id-override: getTransitGatewayAttachment
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations:
+        get:
+            description: Returns the AWS RAM Resource Shares and Transit Gateway IDs for a Transit Gateway that has been shared with an Atlas AWS Account. This only returns the resource shares cached for Atlas Streams Processing.
+            operationId: listGroupStreamsTransitGatewayInvitations
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedStreamsTransitGatewayInvitationsResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Streams Transit Gateway Invitations
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamsTransitGatewayInvitations
+            x-xgen-operation-id-override: listTransitGatewayInvitations
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations/{resourceShareArn}:
+        delete:
+            description: Deletes an AWS Resource Share Invitation for a Transit Gateway that has been shared with an Atlas AWS account. This does not delete the resource share invitation from the sender's AWS account. This only deletes the resource share invitation that's cached for Atlas Streams Processing.
+            operationId: deleteGroupStreamsTransitGatewayInvitation
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - description: AWS Transit Gateway resource share ARN.
+                  in: path
+                  name: resourceShareArn
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: No Content
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Delete One Transit Gateway Invitation
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamsTransitGatewayInvitation
+            x-xgen-operation-id-override: deleteTransitGatewayInvitation
+        get:
+            description: Returns the details of one AWS Resource Share Invitation for a Transit Gateway that has been shared with an Atlas AWS Account. This only returns the resource share invitation cached for Atlas Streams Processing.
+            operationId: getGroupStreamsTransitGatewayInvitation
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - description: AWS Transit Gateway resource share ARN.
+                  in: path
+                  name: resourceShareArn
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsTransitGatewayInvitationsResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Transit Gateway Invitation
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamsTransitGatewayInvitation
+            x-xgen-operation-id-override: getTransitGatewayInvitation
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations:accept:
+        post:
+            description: Accept AWS RAM Resource Share for a Transit Gateway that has been shared with an Atlas AWS account. This Transit Gateway will be used in Atlas Streams private networking connections.
+            operationId: acceptGroupStreamsTransitGatewayInvitations
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/StreamsTransitGatewayResourceShare'
+                        x-xgen-preview:
+                            name: aws-transit-gateway
+                        x-xgen-version: preview
+                description: Detailed information on accepting a transit gateway resource share invitation.
+                required: true
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: No Content
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Accept Transit Gateway Resource Share Invitations
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/acceptGroupStreamsTransitGatewayInvitations
+            x-xgen-operation-id-override: acceptTransitGatewayInvitations
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayInvitations:reject:
+        post:
+            description: Rejects AWS RAM Resource Share for a Transit Gateway that has been shared with an Atlas AWS account.
+            operationId: rejectGroupStreamsTransitGatewayInvitations
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/StreamsTransitGatewayResourceShare'
+                        x-xgen-preview:
+                            name: aws-transit-gateway
+                        x-xgen-version: preview
+                description: Detailed information on rejecting a transit gateway resource share invitation.
+                required: true
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: No Content
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Reject Transit Gateway Resource Share Invitations
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/rejectGroupStreamsTransitGatewayInvitations
+            x-xgen-operation-id-override: rejectTransitGatewayInvitations
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayRoutes:
+        get:
+            description: List Transit Gateway routes in the default route table associated with Atlas VPC.
+            operationId: listGroupStreamsTransitGatewayRoutes
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiStreamsTransitGatewayRouteResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Transit Gateway Routes in the Default Route Table for One Atlas VPC
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/listGroupStreamsTransitGatewayRoutes
+            x-xgen-operation-id-override: listTransitGatewayRoutes
+        post:
+            description: Creates a route in the default route table associated with Atlas VPC to route all traffic destined for provided CIDR to the provided Transit Gateway.
+            operationId: createGroupStreamsTransitGatewayRoute
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/StreamsTransitGatewayRouteRequest'
+                        x-xgen-preview:
+                            name: aws-transit-gateway
+                        x-xgen-version: preview
+                description: Metadata needed for creating a transit gateway route.
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsTransitGatewayRouteResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: Created
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Create One Transit Gateway Route in the Default Route Table for One Atlas VPC
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createGroupStreamsTransitGatewayRoute
+            x-xgen-operation-id-override: createTransitGatewayRoute
+    /api/atlas/v2/groups/{groupId}/streamsTransitGatewayRoutes/{routeId}:
+        delete:
+            description: Deletes a transit gateway route in the default route table associated with Atlas VPC.
+            operationId: deleteGroupStreamsTransitGatewayRoute
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - $ref: '#/components/parameters/envelope'
+                - description: The Object ID that uniquely identifies a transit gateway route.
+                  in: path
+                  name: routeId
+                  required: true
+                  schema:
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: No Content
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Delete One Transit Gateway Route in the Default Route Table for One Atlas VPC
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/deleteGroupStreamsTransitGatewayRoute
+            x-xgen-operation-id-override: deleteTransitGatewayRoute
+        get:
+            description: Retrieves a transit gateway route in the default route table associated with Atlas VPC.
+            operationId: getGroupStreamsTransitGatewayRoute
+            parameters:
+                - $ref: '#/components/parameters/groupId'
+                - description: The Object ID that uniquely identifies a transit gateway route.
+                  in: path
+                  name: routeId
+                  required: true
+                  schema:
+                    example: 32b6e34b3d91647abb20e7b8
+                    pattern: ^([a-f0-9]{24})$
+                    type: string
+                - $ref: '#/components/parameters/envelope'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/StreamsTransitGatewayRouteResponse'
+                            x-xgen-preview:
+                                name: aws-transit-gateway
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One Transit Gateway Route in the Default Route Table for One Atlas VPC
+            tags:
+                - Streams
+            x-rolesRequirements:
+                - Organization Stream Processing Admin
+                - Project Stream Processing Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/getGroupStreamsTransitGatewayRoute
+            x-xgen-operation-id-override: getTransitGatewayRoute
     /api/atlas/v2/groups/{groupId}/teams:
         get:
             description: Returns all teams to which the authenticated user has access in the project specified using its unique 24-hexadecimal digit identifier. All members of the team share the same project access.
@@ -66894,7 +69443,7 @@ paths:
                 - Project Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listGroupUsers
         post:
-            description: "Adds one MongoDB Cloud user to one project. \n- If the user has a pending invitation to join the project's organization, MongoDB Cloud modifies it and grants project access. \n- If the user doesn't have an invitation to join the organization, MongoDB Cloud sends a new invitation that grants the user organization and project access. \n- If the user is already active in the project's organization, MongoDB Cloud grants access to the project. \n"
+            description: "Adds one MongoDB Cloud user to one project. \n- If the user has a pending invitation to join the project's organization, MongoDB Cloud modifies it and grants project access. \n- If the user doesn't have an invitation to join the organization, MongoDB Cloud sends a new invitation that grants the user organization and project access. \n- If the user is already active in the project's organization, MongoDB Cloud grants access to the project. \n- Replaces `INVITATION_EXPIRED` and `INVITATION_REJECTED` user with the same email. A conflict, if and only if, there is an existing `PENDING` or `ACTIVE` user. \n"
             operationId: addGroupUsers
             parameters:
                 - $ref: '#/components/parameters/envelope'
@@ -67319,6 +69868,48 @@ paths:
             tags:
                 - Projects
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getGroupByName
+    /api/atlas/v2/openapi/info:
+        get:
+            description: This resource returns general information about the MongoDB Atlas Administration API OpenAPI Specification.
+            operationId: getOpenapiInfo
+            parameters:
+                - $ref: '#/components/parameters/pretty'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2024-05-30+json:
+                            schema:
+                                $ref: '#/components/schemas/OpenApiInfo'
+                            x-sunset: "9999-12-30"
+                            x-xgen-version: "2024-05-30"
+                        application/vnd.atlas.2024-08-05+json:
+                            schema:
+                                $ref: '#/components/schemas/OpenApiInfo'
+                            x-xgen-version: "2024-08-05"
+                        application/vnd.atlas.2025-09-22.upcoming+json:
+                            schema:
+                                $ref: '#/components/schemas/OpenApiInfo'
+                            x-xgen-version: 2025-09-22.upcoming
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/OpenApiInfo'
+                            x-sunset: "9999-12-30"
+                            x-xgen-preview:
+                                public: "true"
+                            x-xgen-version: preview
+                    description: OK
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return General Information on MongoDB Atlas Administration API OpenAPI Specification
+            tags:
+                - OpenAPI
+            x-xgen-method-verb-override:
+                customMethod: "False"
+                verb: get
     /api/atlas/v2/orgs:
         get:
             description: Returns all organizations to which the requesting Service Account or API Key has access.
@@ -67702,10 +70293,10 @@ paths:
                 - Organization Read Only
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-API-Keys/operation/getOrgAiModelApiKey
             x-xgen-operation-id-override: getOrgModelKey
-    /api/atlas/v2/orgs/{orgId}/aiModelRateLimits:
+    /api/atlas/v2/orgs/{orgId}/aiModelApiRateLimits:
         get:
             description: Retrieve AI model rate limits for the given organization.
-            operationId: listOrgAiModelRateLimits
+            operationId: listOrgAiModelApiRateLimits
             parameters:
                 - $ref: '#/components/parameters/orgId'
                 - $ref: '#/components/parameters/itemsPerPage'
@@ -67742,12 +70333,12 @@ paths:
                 - AI Model Rate Limits
             x-rolesRequirements:
                 - Organization Read Only
-            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listOrgAiModelRateLimits
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/listOrgAiModelApiRateLimits
             x-xgen-operation-id-override: listOrgModelLimits
-    /api/atlas/v2/orgs/{orgId}/aiModelRateLimits/{modelGroupName}:
+    /api/atlas/v2/orgs/{orgId}/aiModelApiRateLimits/{modelGroupName}:
         get:
             description: Retrieve a single AI model rate limit for the given organization.
-            operationId: getOrgAiModelRateLimit
+            operationId: getOrgAiModelApiRateLimit
             parameters:
                 - $ref: '#/components/parameters/orgId'
                 - $ref: '#/components/parameters/envelope'
@@ -67788,7 +70379,7 @@ paths:
                 - AI Model Rate Limits
             x-rolesRequirements:
                 - Organization Read Only
-            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getOrgAiModelRateLimit
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/AI-Model-Rate-Limits/operation/getOrgAiModelApiRateLimit
             x-xgen-operation-id-override: getOrgModelLimit
     /api/atlas/v2/orgs/{orgId}/apiKeys:
         get:
@@ -68427,6 +71018,89 @@ paths:
                 - Organization Billing Viewer
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Invoices/operation/getOrgBillingCostExplorerUsage
             x-xgen-operation-id-override: getCostExplorerUsage
+    /api/atlas/v2/orgs/{orgId}/delegationSettings:
+        get:
+            description: Returns the delegation settings for the specified organization.
+            operationId: getOrgDelegationSettings
+            parameters:
+                - $ref: '#/components/parameters/orgId'
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/OrgDelegationSettingsResponse'
+                            x-xgen-version: "2025-03-12"
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Delegation Settings for One Organization
+            tags:
+                - Organizations
+            x-rolesRequirements:
+                - Organization Member
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgDelegationSettings
+        patch:
+            description: Updates the delegation settings for the specified organization. Only fields present in the request body are updated; omitted fields retain their current values.
+            operationId: updateOrgDelegationSettings
+            parameters:
+                - $ref: '#/components/parameters/orgId'
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+            requestBody:
+                content:
+                    application/vnd.atlas.2025-03-12+json:
+                        schema:
+                            $ref: '#/components/schemas/OrgDelegationSettingsUpdateRequest'
+                        x-xgen-version: "2025-03-12"
+                description: Delegation settings to update.
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/OrgDelegationSettingsResponse'
+                            x-xgen-version: "2025-03-12"
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Update Delegation Settings for One Organization
+            tags:
+                - Organizations
+            x-rolesRequirements:
+                - Organization Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgDelegationSettings
     /api/atlas/v2/orgs/{orgId}/events:
         get:
             description: "Returns events for the specified organization. Events identify significant database, billing, or security activities or status changes. \n\nThis resource remains under revision and may change."
@@ -69457,6 +72131,289 @@ paths:
                 - Organization Owner
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Migration-Service/operation/createOrgLiveMigrationLinkToken
             x-xgen-operation-id-override: createLinkToken
+    /api/atlas/v2/orgs/{orgId}/maintenanceSettings:
+        get:
+            description: Returns maintenance settings for the specified organization.
+            operationId: getOrgMaintenanceSettings
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/orgId'
+                - $ref: '#/components/parameters/pretty'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/OrganizationMaintenanceSettingsResponse'
+                            x-xgen-preview:
+                                name: organization-maintenance
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Maintenance Settings for One Organization
+            tags:
+                - Organizations
+            x-rolesRequirements:
+                - Organization Member
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/getOrgMaintenanceSettings
+        patch:
+            description: Updates maintenance settings for the specified organization. Omit optional fields from the request body to leave their current values unchanged. Specify null on an optional field to reset it to its default value.
+            operationId: updateOrgMaintenanceSettings
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/orgId'
+                - $ref: '#/components/parameters/pretty'
+            requestBody:
+                content:
+                    application/vnd.atlas.preview+json:
+                        schema:
+                            $ref: '#/components/schemas/OrganizationMaintenanceSettingsUpdateRequest'
+                        x-xgen-preview:
+                            name: organization-maintenance
+                        x-xgen-version: preview
+                description: Maintenance settings to update for the specified organization.
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/OrganizationMaintenanceSettingsResponse'
+                            x-xgen-preview:
+                                name: organization-maintenance
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Update Maintenance Settings for One Organization
+            tags:
+                - Organizations
+            x-rolesRequirements:
+                - Organization Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/updateOrgMaintenanceSettings
+    /api/atlas/v2/orgs/{orgId}/maintenanceSettings:reset:
+        post:
+            description: Resets maintenance settings for the specified organization to their default values. Restores the wave assignment mode to the default manual mode.
+            operationId: resetOrgMaintenanceSettings
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/orgId'
+                - $ref: '#/components/parameters/pretty'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/OrganizationMaintenanceSettingsResponse'
+                            x-xgen-preview:
+                                name: organization-maintenance
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Reset Maintenance Settings for One Organization
+            tags:
+                - Organizations
+            x-rolesRequirements:
+                - Organization Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/resetOrgMaintenanceSettings
+            x-xgen-method-verb-override:
+                customMethod: "True"
+                verb: reset
+            x-xgen-operation-id-override: resetOrgMaintenanceSettings
+    /api/atlas/v2/orgs/{orgId}/mcpConfigs:
+        get:
+            description: Returns all MCP configurations associated with the specified organization.
+            operationId: listOrgMcpConfigs
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/includeCount'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/orgId'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedOrgMcpConfigView'
+                            x-xgen-version: "2025-03-12"
+                    description: OK
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All MCP Configurations for One Organization
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Organization Read Only
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/listOrgMcpConfigs
+        post:
+            description: Creates an MCP configuration for the specified organization. Returns the configuration ID and ingress credentials.
+            operationId: createOrgMcpConfig
+            parameters:
+                - $ref: '#/components/parameters/orgId'
+            requestBody:
+                content:
+                    application/vnd.atlas.2025-03-12+json:
+                        schema:
+                            $ref: '#/components/schemas/CreateOrgMcpConfigRequest'
+                        x-xgen-version: "2025-03-12"
+                description: MCP configuration to create.
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/OrgMcpConfigResponse'
+                            x-xgen-version: "2025-03-12"
+                    description: Created
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Create One MCP Configuration for One Organization
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Organization Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/createOrgMcpConfig
+    /api/atlas/v2/orgs/{orgId}/mcpConfigs/{mcpConfigId}:
+        delete:
+            description: Deletes the MCP configuration with the specified ID for the specified organization.
+            operationId: deleteOrgMcpConfig
+            parameters:
+                - $ref: '#/components/parameters/orgId'
+                - description: Unique identifier of the MCP configuration to delete.
+                  in: path
+                  name: mcpConfigId
+                  required: true
+                  schema:
+                    type: string
+                - description: Flag that indicates whether to delete the MCP configuration even if it has active secrets. If false and active secrets exist, the request returns an error. Defaults to false.
+                  in: query
+                  name: cascading
+                  schema:
+                    default: false
+                    type: boolean
+            responses:
+                "204":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            x-xgen-version: "2025-03-12"
+                    description: No Content
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Delete One MCP Configuration for One Organization
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Organization Owner
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/deleteOrgMcpConfig
+        get:
+            description: Returns the MCP configuration with the specified ID for the specified organization.
+            operationId: getOrgMcpConfig
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/pretty'
+                - $ref: '#/components/parameters/orgId'
+                - description: Unique identifier of the MCP configuration.
+                  in: path
+                  name: mcpConfigId
+                  required: true
+                  schema:
+                    example: 32b6e34b3d91647adeabc012
+                    pattern: ^[a-fA-F0-9]{24}$
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2025-03-12+json:
+                            schema:
+                                $ref: '#/components/schemas/OrgMcpConfigResponse'
+                            x-xgen-version: "2025-03-12"
+                    description: OK
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return One MCP Configuration for One Organization
+            tags:
+                - Remote MCP Configurations
+            x-rolesRequirements:
+                - Organization Read Only
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Remote-MCP-Configurations/operation/getOrgMcpConfig
     /api/atlas/v2/orgs/{orgId}/nonCompliantResources:
         get:
             description: Return all non-compliant resources for an organization.
@@ -69502,6 +72459,47 @@ paths:
                 - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Resource-Policies/operation/getOrgNonCompliantResources
             x-xgen-operation-id-override: getNonCompliantResources
+    /api/atlas/v2/orgs/{orgId}/ratelimits:
+        get:
+            description: Retrieve rate limiting bucket state for the specified organization.
+            operationId: getOrgRatelimits
+            parameters:
+                - $ref: '#/components/parameters/orgId'
+                - $ref: '#/components/parameters/envelope'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/AtlasRateLimitInspectionResponse'
+                            x-xgen-preview:
+                                name: rate-limit
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Rate Limit State for One Organization
+            tags:
+                - Rate Limit
+            x-rolesRequirements:
+                - Organization Read Only
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/getOrgRatelimits
     /api/atlas/v2/orgs/{orgId}/resourcePolicies:
         get:
             description: Return all Atlas Resource Policies for the organization.
@@ -71108,7 +74106,7 @@ paths:
             x-xgen-operation-id-override: removeUserFromTeam
     /api/atlas/v2/orgs/{orgId}/teams/{teamId}:addUser:
         post:
-            description: "Adds one MongoDB Cloud user to one team. You can add an active user or a user that has not yet accepted the invitation to join the organization. \n\n**Note**: This resource cannot be used to add a user invited via the deprecated Invite One MongoDB Cloud User to Join One Project endpoint."
+            description: "Adds one MongoDB Cloud user to one team. You can add an active user or a user that has not yet accepted the invitation to join the organization. \n\n**Note**: This resource cannot be used to add a user invited via the deprecated Invite One MongoDB Cloud User to Join One Project endpoint. \n\nA user whose only organization invitation has `EXPIRED` or been `REJECTED` is treated as not belonging to the organization (`USER_NOT_IN_ORG`); re-invite them to the organization first (which creates a new pending invitation), then add them to the team."
             externalDocs:
                 description: 'Deprecated: Invite One MongoDB Cloud User to Join One Project endpoint'
                 url: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/updateProjectInvitation
@@ -71347,7 +74345,7 @@ paths:
                 - Organization Member
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/MongoDB-Cloud-Users/operation/listOrgUsers
         post:
-            description: "Invites one new or existing MongoDB Cloud user to join the organization. The invitation to join the organization will be sent to the username provided and must be accepted within 30 days. \n\n**Note**: If the user does not have an existing MongoDB Cloud account, they will be prompted to finish setting up an account upon accepting the invitation. If the user already has an account, they will still receive an invitation to access the organization."
+            description: "Invites one new or existing MongoDB Cloud user to join the organization. The invitation to join the organization will be sent to the username provided and must be accepted within 30 days. \n\n**Note**: If the user does not have an existing MongoDB Cloud account, they will be prompted to finish setting up an account upon accepting the invitation. If the user already has an account, they will still receive an invitation to access the organization. \n\nReplaces `INVITATION_EXPIRED` and `INVITATION_REJECTED` user with the same email. A conflict, if and only if, there is an existing `PENDING` or `ACTIVE` user."
             operationId: createOrgUser
             parameters:
                 - $ref: '#/components/parameters/envelope'
@@ -72003,6 +75001,128 @@ paths:
                 - Root
             x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Root/operation/listControlPlaneIpAddresses
             x-xgen-operation-id-override: listControlPlaneAddresses
+    /api/atlas/v2/unauth/openapi/versions:
+        get:
+            description: API that provides a list of available versions for a given environment.
+            operationId: listOpenapiVersions
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+                - $ref: '#/components/parameters/itemsPerPage'
+                - $ref: '#/components/parameters/pageNum'
+                - $ref: '#/components/parameters/pretty'
+                - description: The environment to get the versions from. If not provided, it returns the versions for the given MongoDB URL. (E.g. prod for cloud.mongodb.com).
+                  in: query
+                  name: env
+                  schema:
+                    enum:
+                        - dev
+                        - qa
+                        - prod
+                        - stage
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.2024-08-05+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiVersions'
+                            x-xgen-version: "2024-08-05"
+                        application/vnd.atlas.2024-08-05+yaml:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiVersions'
+                            x-xgen-version: "2024-08-05"
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiVersions'
+                            x-xgen-preview:
+                                name: version-resource
+                            x-xgen-version: preview
+                        application/vnd.atlas.preview+yaml:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedApiVersions'
+                            x-xgen-preview:
+                                name: version-resource
+                            x-xgen-version: preview
+                    description: OK
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return All Versions for One Environment
+            tags:
+                - OpenAPI
+    /api/atlas/v2/unauth/ratelimits:
+        get:
+            description: Retrieve rate limiting bucket state for unauthenticated requests.
+            operationId: listRatelimits
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/AtlasRateLimitInspectionResponse'
+                            x-xgen-preview:
+                                name: rate-limit
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "404":
+                    $ref: '#/components/responses/notFound'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Rate Limit State for Unauthenticated Requests
+            tags:
+                - Rate Limit
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/listRatelimits
+    /api/atlas/v2/userRateLimits:
+        get:
+            description: Retrieve rate limiting bucket state for the current user.
+            operationId: listUserRatelimits
+            parameters:
+                - $ref: '#/components/parameters/envelope'
+            responses:
+                "200":
+                    content:
+                        application/vnd.atlas.preview+json:
+                            schema:
+                                $ref: '#/components/schemas/AtlasRateLimitInspectionResponse'
+                            x-xgen-preview:
+                                name: rate-limit
+                                public: "false"
+                            x-xgen-version: preview
+                    description: OK
+                    headers:
+                        RateLimit-Limit:
+                            $ref: '#/components/headers/HeaderRateLimitLimit'
+                        RateLimit-Remaining:
+                            $ref: '#/components/headers/HeaderRateLimitRemaining'
+                "400":
+                    $ref: '#/components/responses/badRequest'
+                "401":
+                    $ref: '#/components/responses/unauthorized'
+                "403":
+                    $ref: '#/components/responses/forbidden'
+                "429":
+                    $ref: '#/components/responses/tooManyRequests'
+                "500":
+                    $ref: '#/components/responses/internalServerError'
+            summary: Return Rate Limit State for One User
+            tags:
+                - Rate Limit
+            x-xgen-docs-url: https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Rate-Limit/operation/listUserRatelimits
     /api/atlas/v2/users:
         post:
             deprecated: true
@@ -72165,6 +75285,8 @@ tags:
       name: Auditing
     - description: Returns and edits custom DNS configurations for MongoDB Cloud database deployments on AWS. The resource requires your Project ID. If you use the VPC peering on AWS and you use your own DNS servers instead of Amazon Route 53, enable custom DNS. Before 31 March 2020, applications deployed within AWS using custom DNS services and VPC-peered with MongoDB Cloud couldn't connect over private IP addresses. Custom DNS resolved to public IP addresses. AWS internal DNS resolved to private IP addresses. Applications deployed with custom DNS services in AWS should use Private IP for Peering connection strings.
       name: AWS Clusters DNS
+    - description: Returns, adds, and edits Charts Dashboard instances. This resource applies only to projects with a Charts tenant, and requires your Project ID.
+      name: Charts Dashboards
     - description: Manages Cloud Backup snapshots, snapshot export buckets, restore jobs, and schedules. This resource applies only to clusters that use Cloud Backups.
       name: Cloud Backups
     - description: Manages the Cloud Migration Service. Source organizations, projects, and MongoDB clusters reside on Cloud Manager or Ops Manager. Destination organizations, projects, and MongoDB clusters reside on MongoDB Cloud. Source databases can't use any authentication except SCRAM-SHA.
@@ -72226,6 +75348,8 @@ tags:
       name: Network Peering
     - description: Returns, adds, edits, or removes an online archive.
       name: Online Archive
+    - description: Returns information about the MongoDB Atlas Specification.
+      name: OpenAPI
     - description: Returns, adds, and edits organizational units in MongoDB Cloud.
       name: Organizations
     - description: Returns suggested indexes and slow query data for a database deployment. Also enables or disables MongoDB Cloud-managed slow operation thresholds. To view field values in a sample query, you must have the Project Data Access Read Only role or higher. Otherwise, MongoDB Cloud returns redacted data rather than the field values.
@@ -72245,6 +75369,8 @@ tags:
         description: Atlas API Rate Limits documentation
         url: http://dochub.mongodb.org/core/atlas-api-rate-limit
       name: Rate Limiting
+    - description: Returns and manages Remote MCP configurations for organizations and projects.
+      name: Remote MCP Configurations
     - description: Configure and manage Atlas Resource Policies within your organization.
       name: Resource Policies
     - description: Creates one index to a database deployment in a rolling manner. Rolling indexes build indexes on the applicable nodes sequentially and may reduce the performance impact of an index build if your deployment's average CPU utilization exceeds (N-1)/N-10% where N is the number of CPU threads available to mongod of if the WiredTiger cache fill ratio regularly exceeds 90%. If your deployment does not meet this criteria, use the default index build. You can't create a rolling index on an `M0` free cluster or `M2/M5` shared cluster.

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -531,7 +531,6 @@ resources:
           request_body_usage: "send_null_as_null_on_update"
           computability:
             optional: true
-            computed: true
     datasources:
       read:
         path: /api/atlas/v2/orgs/{orgId}/maintenanceSettings

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -518,12 +518,8 @@ resources:
       path: /api/atlas/v2/orgs/{orgId}/maintenanceSettings
       method: PATCH
     delete:
-      # Custom reset method will be implemented as a follow-up once it's available in OpenAPI spec
-      # See CLOUDP-414476
-      path: /api/atlas/v2/orgs/{orgId}/maintenanceSettings
-      method: PATCH
-      static_request_body: '{"waveAssignmentMode": null}'
-      resets_to_defaults: true
+      path: /api/atlas/v2/orgs/{orgId}/maintenanceSettings:reset
+      method: POST
       # TODO: version header will need to be updated before merge to master
     version_header: application/vnd.atlas.preview+json
     schema:

--- a/tools/codegen/models/org_maintenance_settings.yaml
+++ b/tools/codegen/models/org_maintenance_settings.yaml
@@ -25,10 +25,8 @@ schema:
           request_only_required_on_create: false
 operations:
     delete:
-        http_method: PATCH
-        path: /api/atlas/v2/orgs/{orgId}/maintenanceSettings
-        static_request_body: '{"waveAssignmentMode": null}'
-        resets_to_defaults: true
+        http_method: POST
+        path: /api/atlas/v2/orgs/{orgId}/maintenanceSettings:reset
     create:
         http_method: PATCH
         path: /api/atlas/v2/orgs/{orgId}/maintenanceSettings
@@ -66,7 +64,7 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
             - string: {}
-              description: Mode configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when unset. Atlas uses read-only `effectiveWaveAssignmentMode` (not this field) for scheduling. In a cross-organization billing hierarchy, a linked non-paying organization cannot update its `effectiveWaveAssignmentMode` field, which inherits from the paying organization's `waveAssignmentMode`. In this case, a linked non-paying organization's `effectiveWaveAssignmentMode` and `waveAssignmentMode` might differ.
+              description: Mode explicitly configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Omitted from the response when no explicit preference has been set; in that case `effectiveWaveAssignmentMode` reflects the value the system uses (`MANUAL` by default). Atlas uses read-only `effectiveWaveAssignmentMode` (not this field) for scheduling. In a cross-organization billing hierarchy, a linked non-paying organization cannot update its `effectiveWaveAssignmentMode` field, which inherits from the paying organization's `waveAssignmentMode`. In this case, a linked non-paying organization's `effectiveWaveAssignmentMode` and `waveAssignmentMode` might differ.
               computed_optional_required: computed
               tf_schema_name: wave_assignment_mode
               tf_model_name: WaveAssignmentMode

--- a/tools/codegen/models/org_maintenance_settings.yaml
+++ b/tools/codegen/models/org_maintenance_settings.yaml
@@ -14,7 +14,7 @@ schema:
           request_only_required_on_create: false
         - string: {}
           description: Mode configured for this organization that determines how maintenance waves are assigned to projects. Possible values are `MANUAL` and `ENV_TAG_MAPPING`. Defaults to `MANUAL` when unset. Only this field can be updated; Atlas derives read-only `effectiveWaveAssignmentMode` on GET responses and uses that value for scheduling when it differs from `waveAssignmentMode`. Omit this field to leave the current value unchanged. Specify null to reset to the default value (`MANUAL`).
-          computed_optional_required: computed_optional
+          computed_optional_required: optional
           tf_schema_name: wave_assignment_mode
           tf_model_name: WaveAssignmentMode
           api_name: waveAssignmentMode


### PR DESCRIPTION
## Description

Adapts the `mongodbatlas_org_maintenance_settings` resource to two API improvements:

**CLOUDP-414476 - Dedicated reset endpoint**: The API now exposes `POST /api/atlas/v2/orgs/{orgId}/maintenanceSettings:reset` for resetting org maintenance settings to defaults. The provider's destroy operation now calls this endpoint. 

**CLOUDP-415703 - Correct null handling**: The API no longer rewrites `waveAssignmentMode` to `MANUAL` in responses when the client sends `null`. The field is now omitted when no explicit preference is set, with `effectiveWaveAssignmentMode` reflecting the system value. The attribute `wave_assignment_mode` will only be `Optional` as a consequence, as it's a client-owned field. 

**NOTE**: dev OpenAPI spec is added in order to gain access to `/maintenanceSettings` endpoint. Once changes are public, this will be reverted to use the prod one. 

Link to any related issue(s): [CLOUDP-416869](https://jira.mongodb.org/browse/CLOUDP-416869)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments