### PR TITLE
doc: Document adjusting auto-scaling range with use_effective_fields

### DIFF
--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -993,16 +993,21 @@ This workflow allows you to set specific baseline values from which auto-scaling
 
 ### Adjusting the Auto-Scaling Range with use_effective_fields
 
-Changing the compute auto-scaling range (`compute_min_instance_size` or `compute_max_instance_size`) requires extra care when the new range would no longer contain the cluster's **current effective** instance size, for example raising `compute_min_instance_size` above the effective size or lowering `compute_max_instance_size` below it. Atlas validates the new range against the current effective instance size, so attempting either in a single apply fails with a validation error from Atlas. Updating `instance_size` in the same apply does not avoid the error, because the configured `instance_size` is not applied while auto-scaling is enabled with `use_effective_fields = true`.
+Changing the compute auto-scaling range (`compute_min_instance_size` or `compute_max_instance_size`) requires extra care when the new range would no longer contain the cluster's **current effective** instance size. This includes:
 
-To adjust the range in this case, first move the effective instance size into the new range, then change the bounds:
+- Raising `compute_min_instance_size` above the effective size.
+- Lowering `compute_max_instance_size` below the effective size.
 
-1. Temporarily disable compute auto-scaling (`compute_enabled = false`) and set `instance_size` to a value inside your intended new range, then apply. See [Manually Updating Specs with use_effective_fields](#manually-updating-specs-with-use_effective_fields) for details.
+Atlas validates the new range against the current effective instance size, so attempting either in a single apply fails with a validation error from Atlas. Updating `instance_size` in the same apply as changing the range does not avoid the error, because the updated `instance_size` value is not applied while auto-scaling is enabled with `use_effective_fields = true`.
+
+To adjust the range when the new range would exclude the current effective instance size, move the effective instance size into the new range before changing the bounds:
+
+1. Disable auto-scaling and set `instance_size` to a value inside your intended new range, then apply. Follow the [Manually Updating Specs with use_effective_fields](#manually-updating-specs-with-use_effective_fields) workflow, which also covers disabling disk auto-scaling and the related `oplog_min_retention_hours` requirement.
 2. Re-enable compute auto-scaling (`compute_enabled = true`) with the new `compute_min_instance_size` and `compute_max_instance_size` bounds, then apply.
 
-The same process applies to the [`analytics_auto_scaling`](#analytics_auto_scaling) block: disable `analytics_auto_scaling.compute_enabled` and set `analytics_specs.instance_size` in step 1.
+The same process applies to the [`analytics_auto_scaling`](#analytics_auto_scaling) block, using `analytics_specs.instance_size` in step 1.
 
--> **NOTE:** This multi-step process is only required while the current effective instance size would fall outside the new range. If the new range still contains the effective size, you can change the bounds in a single apply. This requirement may be removed in a future Atlas release, after which adjusting the range in a single apply will be supported.
+-> **NOTE:** This multi-step process is only required while the current effective instance size would fall outside the new range. If the new range still contains the effective size, you can change the bounds in a single apply.
 
 ### Terraform Modules
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -1003,7 +1003,7 @@ Atlas validates the new range against the current effective instance size, so at
 To adjust the range when the new range would exclude the current effective instance size, move the effective instance size into the new range before changing the bounds:
 
 1. Disable auto-scaling and set `instance_size` to a value inside your intended new range, then apply. Follow the [Manually Updating Specs with use_effective_fields](#manually-updating-specs-with-use_effective_fields) workflow, which also covers disabling disk auto-scaling and the related `oplog_min_retention_hours` requirement.
-2. Re-enable compute auto-scaling (`compute_enabled = true`) with the new `compute_min_instance_size` and `compute_max_instance_size` bounds, then apply.
+2. Re-enable auto-scaling with the new `compute_min_instance_size` and `compute_max_instance_size` bounds, then apply.
 
 The same process applies to the [`analytics_auto_scaling`](#analytics_auto_scaling) block, using `analytics_specs.instance_size` in step 1.
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -993,7 +993,7 @@ This workflow allows you to set specific baseline values from which auto-scaling
 
 ### Adjusting the Auto-Scaling Range with use_effective_fields
 
-Changing the compute auto-scaling range (`compute_min_instance_size` or `compute_max_instance_size`) requires extra care when the new range would no longer contain the cluster's **current effective** instance size, for example raising `compute_min_instance_size` above the effective size or lowering `compute_max_instance_size` below it. Atlas validates the new range against the current effective instance size, so attempting either in a single apply fails with an `INVALID_ATTRIBUTE` error. Updating `instance_size` in the same apply does not avoid the error, because the configured `instance_size` is not applied while auto-scaling is enabled with `use_effective_fields = true`.
+Changing the compute auto-scaling range (`compute_min_instance_size` or `compute_max_instance_size`) requires extra care when the new range would no longer contain the cluster's **current effective** instance size, for example raising `compute_min_instance_size` above the effective size or lowering `compute_max_instance_size` below it. Atlas validates the new range against the current effective instance size, so attempting either in a single apply fails with a validation error from Atlas. Updating `instance_size` in the same apply does not avoid the error, because the configured `instance_size` is not applied while auto-scaling is enabled with `use_effective_fields = true`.
 
 To adjust the range in this case, first move the effective instance size into the new range, then change the bounds:
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -991,6 +991,19 @@ When `use_effective_fields = true` and auto-scaling is enabled, you can update `
 
 This workflow allows you to set specific baseline values from which auto-scaling will resume dynamic adjustments based on workload.
 
+### Adjusting the Auto-Scaling Range with use_effective_fields
+
+Changing the compute auto-scaling range (`compute_min_instance_size` or `compute_max_instance_size`) requires extra care when the new range would no longer contain the cluster's **current effective** instance size, for example raising `compute_min_instance_size` above the effective size or lowering `compute_max_instance_size` below it. Atlas validates the new range against the current effective instance size, so attempting either in a single apply fails with an `INVALID_ATTRIBUTE` error. Updating `instance_size` in the same apply does not avoid the error, because the configured `instance_size` is not applied while auto-scaling is enabled with `use_effective_fields = true`.
+
+To adjust the range in this case, first move the effective instance size into the new range, then change the bounds:
+
+1. Temporarily disable compute auto-scaling (`compute_enabled = false`) and set `instance_size` to a value inside your intended new range, then apply. See [Manually Updating Specs with use_effective_fields](#manually-updating-specs-with-use_effective_fields) for details.
+2. Re-enable compute auto-scaling (`compute_enabled = true`) with the new `compute_min_instance_size` and `compute_max_instance_size` bounds, then apply.
+
+The same process applies to the [`analytics_auto_scaling`](#analytics_auto_scaling) block: disable `analytics_auto_scaling.compute_enabled` and set `analytics_specs.instance_size` in step 1.
+
+-> **NOTE:** This multi-step process is only required while the current effective instance size would fall outside the new range. If the new range still contains the effective size, you can change the bounds in a single apply. This requirement may be removed in a future Atlas release, after which adjusting the range in a single apply will be supported.
+
 ### Terraform Modules
 
 `use_effective_fields` is particularly valuable for reusable Terraform modules. Without it, separate module implementations are required (one with lifecycle blocks for auto-scaling, one without). With `use_effective_fields`, a single module handles both scenarios without lifecycle blocks. See the [Effective Fields Examples](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.13.0/examples/mongodbatlas_advanced_cluster/effective_fields) for complete implementations.


### PR DESCRIPTION
## Description

Documents the multi-step process required to adjust a compute auto-scaling range (`compute_min_instance_size` / `compute_max_instance_size`) when the new range would no longer contain the cluster's current effective instance size, for clusters using `use_effective_fields = true`.

Today, raising the min above the effective size (or lowering the max below it) in a single apply fails with a validation error from Atlas. Setting `instance_size` in the same apply does not avoid it, because the configured `instance_size` is not applied while auto-scaling is enabled with `use_effective_fields = true`. The new subsection documents the disable-then-reenable workaround and notes it applies to both `auto_scaling` and `analytics_auto_scaling`. It also notes the requirement may be removed in a future Atlas release.

Reproduced end to end against cloud-dev (create at M10, trigger the error raising min to M20, apply the workaround, confirm auto-scaling resumes on the new range).

Link to any related issue(s): CLOUDP-416877

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.