### PR TITLE
fix: Fix intermittent failure when upgrading to a dedicated cluster

### DIFF
--- a/.changelog/4548.txt
+++ b/.changelog/4548.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Fixes intermittent failure when upgrading a tenant or flex cluster to a dedicated cluster
+```

--- a/internal/service/advancedcluster/common_admin_sdk.go
+++ b/internal/service/advancedcluster/common_admin_sdk.go
@@ -61,7 +61,7 @@ func upgradeTenant(ctx context.Context, diags *diag.Diagnostics, client *config.
 		addErrorDiag(diags, operationTenantUpgrade, defaultAPIErrorDetails(waitParams.ClusterName, err))
 		return nil
 	}
-	return AwaitChangesUpgrade(ctx, client, waitParams, operationTenantUpgrade, diags)
+	return AwaitUpgradeToDedicated(ctx, client, waitParams, operationTenantUpgrade, diags)
 }
 
 func upgradeFlexToDedicated(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, waitParams *ClusterWaitParams, req *admin.AtlasTenantClusterUpgradeRequest20240805) *admin.ClusterDescription20240805 {
@@ -70,7 +70,7 @@ func upgradeFlexToDedicated(ctx context.Context, diags *diag.Diagnostics, client
 		addErrorDiag(diags, operationFlexUpgrade, defaultAPIErrorDetails(waitParams.ClusterName, err))
 		return nil
 	}
-	return AwaitChangesUpgrade(ctx, client, waitParams, operationFlexUpgrade, diags)
+	return AwaitUpgradeToDedicated(ctx, client, waitParams, operationFlexUpgrade, diags)
 }
 
 func PinFCV(ctx context.Context, api admin.ClustersApi, projectID, clusterName, expirationDateStr string) error {

--- a/internal/service/advancedcluster/common_await_changes.go
+++ b/internal/service/advancedcluster/common_await_changes.go
@@ -27,24 +27,18 @@ var (
 )
 
 type ClusterWaitParams struct {
-	ProjectID          string
-	ClusterName        string
-	Timeout            time.Duration
-	IsDelete           bool
-	UseEffectiveFields bool
+	ProjectID                string
+	ClusterName              string
+	Timeout                  time.Duration
+	IsDelete                 bool
+	WaitForDedicatedProvider bool
+	UseEffectiveFields       bool
 }
 
 func AwaitChangesUpgrade(ctx context.Context, client *config.MongoDBClient, waitParams *ClusterWaitParams, errorLocator string, diags *diag.Diagnostics) *admin.ClusterDescription20240805 {
-	upgraded := AwaitChanges(ctx, client, waitParams, errorLocator, diags)
-	if diags.HasError() || upgraded == nil {
-		return nil
-	}
-	providerName := getProviderName(upgraded.ReplicationSpecs)
-	if slices.Contains([]string{flexcluster.FlexClusterType, constant.TENANT}, providerName) {
-		tflog.Warn(ctx, fmt.Sprintf("cluster upgrade unexpected provider %s, retrying", providerName))
-		return AwaitChanges(ctx, client, waitParams, errorLocator, diags)
-	}
-	return upgraded
+	upgradeWaitParams := *waitParams
+	upgradeWaitParams.WaitForDedicatedProvider = true
+	return AwaitChanges(ctx, client, &upgradeWaitParams, errorLocator, diags)
 }
 
 func AwaitChanges(ctx context.Context, client *config.MongoDBClient, waitParams *ClusterWaitParams, errorLocator string, diags *diag.Diagnostics) *admin.ClusterDescription20240805 {
@@ -121,6 +115,18 @@ func ResourceRefreshFunc(ctx context.Context, waitParams *ClusterWaitParams, api
 		}
 
 		state := cluster.GetStateName()
+		providerName := getProviderName(cluster.ReplicationSpecs)
+		// Atlas can briefly return the pre-upgrade cluster as IDLE while the upgrade is still propagating.
+		if waitParams.WaitForDedicatedProvider &&
+			state == retrystrategy.RetryStrategyIdleState &&
+			isNonDedicatedProvider(providerName) {
+			tflog.Warn(ctx, fmt.Sprintf("cluster upgrade still reports non-dedicated provider %s, retrying", providerName))
+			return cluster, retrystrategy.RetryStrategyUpdatingState, nil
+		}
 		return cluster, state, nil
 	}
+}
+
+func isNonDedicatedProvider(providerName string) bool {
+	return providerName == flexcluster.FlexClusterType || providerName == constant.TENANT
 }

--- a/internal/service/advancedcluster/common_await_changes.go
+++ b/internal/service/advancedcluster/common_await_changes.go
@@ -35,7 +35,7 @@ type ClusterWaitParams struct {
 	UseEffectiveFields       bool
 }
 
-func AwaitChangesUpgrade(ctx context.Context, client *config.MongoDBClient, waitParams *ClusterWaitParams, errorLocator string, diags *diag.Diagnostics) *admin.ClusterDescription20240805 {
+func AwaitUpgradeToDedicated(ctx context.Context, client *config.MongoDBClient, waitParams *ClusterWaitParams, errorLocator string, diags *diag.Diagnostics) *admin.ClusterDescription20240805 {
 	upgradeWaitParams := *waitParams
 	upgradeWaitParams.WaitForDedicatedProvider = true
 	return AwaitChanges(ctx, client, &upgradeWaitParams, errorLocator, diags)
@@ -116,10 +116,7 @@ func ResourceRefreshFunc(ctx context.Context, waitParams *ClusterWaitParams, api
 
 		state := cluster.GetStateName()
 		providerName := getProviderName(cluster.ReplicationSpecs)
-		// Atlas can briefly return the pre-upgrade cluster as IDLE while the upgrade is still propagating.
-		if waitParams.WaitForDedicatedProvider &&
-			state == retrystrategy.RetryStrategyIdleState &&
-			isNonDedicatedProvider(providerName) {
+		if isUpgradeToDedicatedPending(waitParams, state, providerName) {
 			tflog.Warn(ctx, fmt.Sprintf("cluster upgrade still reports non-dedicated provider %s, retrying", providerName))
 			return cluster, retrystrategy.RetryStrategyUpdatingState, nil
 		}
@@ -127,6 +124,9 @@ func ResourceRefreshFunc(ctx context.Context, waitParams *ClusterWaitParams, api
 	}
 }
 
-func isNonDedicatedProvider(providerName string) bool {
-	return providerName == flexcluster.FlexClusterType || providerName == constant.TENANT
+// isUpgradeToDedicatedPending handles Atlas briefly returning the pre-upgrade cluster as IDLE while the upgrade is still propagating.
+func isUpgradeToDedicatedPending(waitParams *ClusterWaitParams, state, providerName string) bool {
+	return waitParams.WaitForDedicatedProvider &&
+		state == retrystrategy.RetryStrategyIdleState &&
+		(providerName == flexcluster.FlexClusterType || providerName == constant.TENANT)
 }

--- a/internal/service/advancedcluster/common_await_changes.go
+++ b/internal/service/advancedcluster/common_await_changes.go
@@ -117,7 +117,7 @@ func ResourceRefreshFunc(ctx context.Context, waitParams *ClusterWaitParams, api
 		state := cluster.GetStateName()
 		providerName := getProviderName(cluster.ReplicationSpecs)
 		if isUpgradeToDedicatedPending(waitParams, state, providerName) {
-			tflog.Warn(ctx, fmt.Sprintf("cluster upgrade still reports non-dedicated provider %s, retrying", providerName))
+			tflog.Debug(ctx, fmt.Sprintf("cluster upgrade still reports non-dedicated provider %s, retrying", providerName))
 			return cluster, retrystrategy.RetryStrategyUpdatingState, nil
 		}
 		return cluster, state, nil


### PR DESCRIPTION
## Description

`TestAccMockableAdvancedCluster_tenantUpgrade` failed twice in the nightly Test Suite ([run 28630942076](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/28630942076), [run 28342217217](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/28342217217)).

Root cause: Atlas can transiently return the pre-upgrade cluster (`stateName=IDLE`, `providerName=TENANT`/`FLEX`) while a tenant/flex-to-dedicated upgrade is still propagating. This is a known Atlas behavior, previously addressed in #3148 with a one-shot retry when the post-wait result still showed a non-dedicated provider. That single retry is not enough: two consecutive stale IDLE/TENANT reads caused Terraform to return the old cluster state as if the upgrade had completed.

This PR replaces the one-shot retry with a bounded wait that keeps polling for the whole wait timeout as long as the cluster reports idle with a non-dedicated provider, only returning once the cluster is both idle and dedicated.

Link to any related issue(s): CLOUDP-419301

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments