### PR TITLE
fix: Propagate stream_config on mongodbatlas_stream_workspace update

### DIFF
--- a/.changelog/4559.txt
+++ b/.changelog/4559.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_stream_workspace: Fixes `stream_config` (`tier` and `max_tier_size`) being dropped on in-place update, causing an inconsistent result after apply
+```

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -71,6 +71,26 @@ func newStreamWorkspaceUpdateReq(ctx context.Context, plan, state *TFModel) (*ad
 		}
 		updateReq.CloudProvider = dataProcessRegion.CloudProvider.ValueStringPointer()
 		updateReq.Region = dataProcessRegion.Region.ValueStringPointer()
+		// stream_config must be sent on update, otherwise in-place changes to tier /
+		// max_tier_size are dropped and the read-back mismatches the plan.
+		if !plan.StreamConfig.IsNull() && !plan.StreamConfig.IsUnknown() {
+			streamConfig := new(TFWorkspaceStreamConfigModel)
+			if diags := plan.StreamConfig.As(ctx, streamConfig, basetypes.ObjectAsOptions{}); diags.HasError() {
+				return nil, diags
+			}
+			var maxTierSize *string
+			if streamConfig.MaxTierSize.ValueString() != "" {
+				maxTierSize = streamConfig.MaxTierSize.ValueStringPointer()
+			}
+			var tier *string
+			if streamConfig.Tier.ValueString() != "" {
+				tier = streamConfig.Tier.ValueStringPointer()
+			}
+			updateReq.StreamConfig = &admin.StreamConfig{
+				MaxTierSize: maxTierSize,
+				Tier:        tier,
+			}
+		}
 	}
 	return updateReq, nil
 }

--- a/internal/service/streamworkspace/resource_test.go
+++ b/internal/service/streamworkspace/resource_test.go
@@ -25,24 +25,34 @@ func TestAccStreamWorkspaceRS_basic(t *testing.T) {
 		projectID      = acc.ProjectIDExecution(t)
 		workspaceName  = acc.RandomName()
 	)
-	attrsMap := map[string]string{
-		"workspace_name":                     workspaceName,
-		"data_process_region.region":         region,
-		"data_process_region.cloud_provider": cloudProvider,
-		"stream_config.max_tier_size":        "SP30",
-		"stream_config.tier":                 "SP10",
-	}
 	attrsSet := []string{"project_id", "hostnames.#"}
+	attrsMap := func(tier, maxTierSize string) map[string]string {
+		return map[string]string{
+			"workspace_name":                     workspaceName,
+			"data_process_region.region":         region,
+			"data_process_region.cloud_provider": cloudProvider,
+			"stream_config.max_tier_size":        maxTierSize,
+			"stream_config.tier":                 tier,
+		}
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: streamsWorkspaceResourceWithDataSourcesConfig(projectID, workspaceName, region, cloudProvider),
+				Config: streamsWorkspaceResourceWithDataSourcesConfig(projectID, workspaceName, region, cloudProvider, "SP10", "SP30"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkStreamsWorkspaceExists(resourceName),
-					acc.CheckRSAndDS(resourceName, &dataSourceName, &pluralDSName, attrsSet, attrsMap),
+					acc.CheckRSAndDS(resourceName, &dataSourceName, &pluralDSName, attrsSet, attrsMap("SP10", "SP30")),
+				),
+			},
+			{
+				// In-place update of stream_config.tier and stream_config.max_tier_size.
+				Config: streamsWorkspaceResourceWithDataSourcesConfig(projectID, workspaceName, region, cloudProvider, "SP30", "SP50"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkStreamsWorkspaceExists(resourceName),
+					acc.CheckRSAndDS(resourceName, &dataSourceName, &pluralDSName, attrsSet, attrsMap("SP30", "SP50")),
 				),
 			},
 			{
@@ -252,7 +262,7 @@ func streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cl
 	`, projectID, workspaceName, region, cloudProvider, tier, maxTierSize)
 }
 
-func streamsWorkspaceResourceWithDataSourcesConfig(projectID, workspaceName, region, cloudProvider string) string {
+func streamsWorkspaceResourceWithDataSourcesConfig(projectID, workspaceName, region, cloudProvider, tier, maxTierSize string) string {
 	return fmt.Sprintf(`
 		%s
 
@@ -264,5 +274,5 @@ func streamsWorkspaceResourceWithDataSourcesConfig(projectID, workspaceName, reg
 		data "mongodbatlas_stream_workspaces" "test" {
 			project_id = mongodbatlas_stream_workspace.test.project_id
 		}
-	`, streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider))
+	`, streamsWorkspaceWithStreamConfigConfig(projectID, workspaceName, region, cloudProvider, tier, maxTierSize))
 }


### PR DESCRIPTION
## Description

`mongodbatlas_stream_workspace` did not send `stream_config` in its update (PATCH) request, so an in-place change to `stream_config.tier` or `stream_config.max_tier_size` was dropped before reaching Atlas. The post-apply read-back then returned the stale/null value while Terraform expected the planned value, producing:

```
Error: Provider produced inconsistent result after apply
.stream_config.max_tier_size: was cty.StringVal("SP50"), but now null.
```

The create path already sends `stream_config`; only the update path was missing it. This fix populates `StreamConfig` in the update request from the plan, mirroring the create builder.

Distinct from #4277 (which fixed the read-back path); this is the update-request side.

An in-place update step (`tier`/`max_tier_size` SP10/SP30 -> SP30/SP50) was added to `TestAccStreamWorkspaceRS_basic` as the regression guard.

Link to any related issue(s): CLOUDP-421637, HELP-96456

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
