### PR TITLE
test: Enable org_maintenance_settings acceptance tests in CI

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -317,6 +317,7 @@ jobs:
             - 'internal/serviceapi/customdbroleapi/*.go'
             - 'internal/serviceapi/databaseuserapi/*.go'
             - 'internal/serviceapi/maintenancewindowapi/*.go'
+            - 'internal/serviceapi/orgmaintenancesettings/*.go'
             - 'internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/*.go'
             - 'internal/serviceapi/projectapi/*.go'
             - 'internal/serviceapi/projectsettingsapi/*.go'
@@ -695,6 +696,7 @@ jobs:
             ./internal/serviceapi/databaseuserapi
             ./internal/serviceapi/logintegration
             ./internal/serviceapi/maintenancewindowapi
+            ./internal/serviceapi/orgmaintenancesettings
             ./internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive
             ./internal/serviceapi/projectapi
             ./internal/serviceapi/projectsettingsapi

--- a/internal/serviceapi/orgmaintenancesettings/resource_test.go
+++ b/internal/serviceapi/orgmaintenancesettings/resource_test.go
@@ -22,9 +22,6 @@ func TestAccOrgMaintenanceSettings_basic(t *testing.T) {
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
-			// TODO: CLOUDP-418087 to track behavior of setting an org for the first time to MANUAL.
-			// We need to ensure that feature is working as expected before merging to master
-			// Tests are passing in this org because it was set to ENV_TAG_MAPPING after
 			{
 				Config: configWithMode(orgID, "MANUAL"),
 				Check:  checkWithMode(orgID, "MANUAL"),


### PR DESCRIPTION
## Description

Enables the `mongodbatlas_org_maintenance_settings` acceptance test in CI by adding the package to the `autogen_fast` group (both the change-detection paths filter and the job's test package list).

Also removes an obsolete comment in the test that documented an upstream API behavior which has since been fixed, so setting `wave_assignment_mode = "MANUAL"` on an organization in its default state now works as expected.

Link to any related issue(s): CLOUDP-418087

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Test + CI only, no changelog required. The acceptance test was verified passing against an organization confirmed to be in its default state beforehand, exercising the previously-failing first-time `MANUAL` path.