### PR TITLE
chore: Refine acceptance-test skill with untyped-client guidance for autogen resources

### DIFF
--- a/.agents/skills/acceptance-test-patterns/SKILL.md
+++ b/.agents/skills/acceptance-test-patterns/SKILL.md
@@ -17,7 +17,7 @@ Before adding a test, verify no existing test already covers the same configurat
 
 ## CheckExists / CheckDestroy for Autogen Resources
 
-Autogen resources map directly from the OpenAPI spec and never use the Atlas SDK, so their `checkExists` / `checkDestroy` should verify against Atlas with an untyped client, not a typed SDK method. Add a helper under `internal/testutil/acc/` that issues a raw HTTP request with the resource's version header (see `acc.GetMetricIntegration`). Promoting a preview API to stable then only requires bumping the version header, not a rewrite.
+Autogen resources map directly from the OpenAPI spec and never use the Atlas SDK, so their `checkExists` / `checkDestroy` should verify against Atlas with an untyped client, not a typed SDK method. Add a helper under `internal/testutil/acc/` that issues a raw HTTP request with the resource's version header (see the `apiVersionHeader` const in the resource’s `resource.go`). Promoting a preview API to stable then only requires bumping the version header, not a rewrite.
 
 ## Plural Data Source Ordering
 

--- a/.agents/skills/acceptance-test-patterns/SKILL.md
+++ b/.agents/skills/acceptance-test-patterns/SKILL.md
@@ -17,7 +17,7 @@ Before adding a test, verify no existing test already covers the same configurat
 
 ## CheckExists / CheckDestroy for Autogen Resources
 
-Autogen resources map directly from the OpenAPI spec and never use the Atlas SDK, so their `checkExists` / `checkDestroy` should verify against Atlas with an untyped client, not a typed SDK method. Add a helper under `internal/testutil/acc/` that issues a raw HTTP request with the resource's version header (see the `apiVersionHeader` const in the resource’s `resource.go`). Promoting a preview API to stable then only requires bumping the version header, not a rewrite.
+Autogen resources map directly from the OpenAPI spec and avoid typed Atlas SDK methods, calling the API through the SDK's untyped client instead. Their `checkExists` / `checkDestroy` should follow the same approach: verify against Atlas with an untyped client rather than a typed SDK method. Keep these check functions in the resource's own `resource_test.go`, since they are resource-specific. Issue the untyped request with the resource's version header (see the `apiVersionHeader` const in the resource’s `resource.go`). Promoting a preview API to stable then only requires bumping the version header, not a rewrite.
 
 ## Plural Data Source Ordering
 

--- a/.agents/skills/acceptance-test-patterns/SKILL.md
+++ b/.agents/skills/acceptance-test-patterns/SKILL.md
@@ -15,6 +15,10 @@ Merge basic tests for a resource, its singular data source, and its plural data 
 
 Before adding a test, verify no existing test already covers the same configuration and assertions. Tests with identical configs and checks waste CI time.
 
+## CheckExists / CheckDestroy for Autogen Resources
+
+Autogen resources map directly from the OpenAPI spec and never use the Atlas SDK, so their `checkExists` / `checkDestroy` should verify against Atlas with an untyped client, not a typed SDK method. Add a helper under `internal/testutil/acc/` that issues a raw HTTP request with the resource's version header (see `acc.GetMetricIntegration`). Promoting a preview API to stable then only requires bumping the version header, not a rewrite.
+
 ## Plural Data Source Ordering
 
 Avoid hardcoded indices (e.g., `results.0`) when asserting on plural data source results unless the parent resource is guaranteed to be unique within the test execution. When uniqueness is ensured, using `results.0` is acceptable. Otherwise, the API may return items in any order and the test resource may not be at a predictable index.


### PR DESCRIPTION
## Description

Adds guidance to the `acceptance-test-patterns` skill on how `checkExists` / `checkDestroy` should verify autogenerated resources against Atlas.

Autogen resources map directly from the OpenAPI spec and never use the Atlas SDK, so their existence and destroy checks should use an untyped client that mirrors how the resource calls the API, rather than a typed SDK method. This keeps tests consistent with the resource and means promoting a preview API to stable only requires bumping the version header, not a rewrite.

This captures a team decision from a discussion on acceptance-test conventions for autogen resources.

Link to any related issue(s): CLOUDP-417642

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Skill-only change under `.agents/skills/`, no changelog entry needed.