### PR TITLE
chore: Use preview SDK for maintenance_window wave fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/mongodb-forks/digest v1.1.0
-	github.com/mongodb/atlas-sdk-go v1.0.1-0.20260622102447-2d26641d2510
+	github.com/mongodb/atlas-sdk-go v1.0.1-0.20260713160812-98aa3fecbef9 // TODO: Temporary pin to the CLOUDP-417642 private-preview SDK branch for maintenance_window wave fields. Revert to the standard dev-latest/tagged release once CLOUDP-421608 ships private previews. Do not merge to master.
 	github.com/pb33f/libopenapi v0.38.5
 	github.com/sebdah/goldie/v2 v2.8.0
 	github.com/spf13/cast v1.10.0
@@ -44,7 +44,6 @@ require (
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	go.mongodb.org/atlas-sdk/v20250312020 v20250312020.1.0
 	go.mongodb.org/atlas-sdk/v20250312021 v20250312021.0.0
 	golang.org/x/oauth2 v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mmcloughlin/avo v0.5.0/go.mod h1:ChHFdoV7ql95Wi7vuq2YT1bwCJqiWdZrQ1im3VujLYM=
 github.com/mongodb-forks/digest v1.1.0 h1:7eUdsR1BtqLv0mdNm4OXs6ddWvR4X2/OsLwdKksrOoc=
 github.com/mongodb-forks/digest v1.1.0/go.mod h1:rb+EX8zotClD5Dj4NdgxnJXG9nwrlx3NWKJ8xttz1Dg=
-github.com/mongodb/atlas-sdk-go v1.0.1-0.20260622102447-2d26641d2510 h1:vlVNeXmwMOij0yh1giHhJwnYjm22L5RpW5C1S+iDQr0=
-github.com/mongodb/atlas-sdk-go v1.0.1-0.20260622102447-2d26641d2510/go.mod h1:d2msU6EcBb/cCdKQ2KEcPcRfqu345BeURbEL9EOjlFM=
+github.com/mongodb/atlas-sdk-go v1.0.1-0.20260713160812-98aa3fecbef9 h1:xRMV/mVwreOd9M7aroBg4SiC1cgpZchLAYtP8fJ6TE0=
+github.com/mongodb/atlas-sdk-go v1.0.1-0.20260713160812-98aa3fecbef9/go.mod h1:d2msU6EcBb/cCdKQ2KEcPcRfqu345BeURbEL9EOjlFM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -597,8 +597,6 @@ go.mongodb.org/atlas-sdk/v20240530005 v20240530005.0.0 h1:d/gbYJ+obR0EM/3DZf7+ZM
 go.mongodb.org/atlas-sdk/v20240530005 v20240530005.0.0/go.mod h1:O47ZrMMfcWb31wznNIq2PQkkdoFoK0ea2GlmRqGJC2s=
 go.mongodb.org/atlas-sdk/v20241113005 v20241113005.0.0 h1:aaU2E4rtzYXuEDxv9MoSON2gOEAA9M2gsDf2CqjcGj8=
 go.mongodb.org/atlas-sdk/v20241113005 v20241113005.0.0/go.mod h1:eV9REWR36iVMrpZUAMZ5qPbXEatoVfmzwT+Ue8yqU+U=
-go.mongodb.org/atlas-sdk/v20250312020 v20250312020.1.0 h1:Ba+iX5yraZiwXGs6mCyjWxMDbs5bC7kLGYpHu3R8RGM=
-go.mongodb.org/atlas-sdk/v20250312020 v20250312020.1.0/go.mod h1:8OGHqMpalr/OTRHA9kjSSg2EKfig5lrNEeNaVYphYYo=
 go.mongodb.org/atlas-sdk/v20250312021 v20250312021.0.0 h1:bZYcZVnXNr7QO6uIRawTMxmEk2otUY4U3JC57DfKHgw=
 go.mongodb.org/atlas-sdk/v20250312021 v20250312021.0.0/go.mod h1:zp4x/Ub4/nYjlMRSSVd+IRr5AgZDE+tmBtRcTpNEPs4=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -12,7 +12,6 @@ import (
 
 	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
 	admin20241113 "go.mongodb.org/atlas-sdk/v20241113005/admin"
-	admin20250312020 "go.mongodb.org/atlas-sdk/v20250312020/admin" // TODO: Remove before merging to master.
 	"go.mongodb.org/atlas-sdk/v20250312021/admin"
 	matlasClient "go.mongodb.org/atlas/mongodbatlas"
 	realmAuth "go.mongodb.org/realm/auth"
@@ -106,15 +105,14 @@ func tfLoggingInterceptor(base http.RoundTripper) http.RoundTripper {
 
 // MongoDBClient contains the mongodbatlas clients and configurations.
 type MongoDBClient struct {
-	Atlas              *matlasClient.Client
-	AtlasV2            *admin.APIClient
-	AtlasPreview       *adminpreview.APIClient
-	AtlasV220240530    *admin20240530.APIClient    // Used in cluster to support deprecated attributes default_read_concern and fail_index_key_too_long in advanced_configuration.
-	AtlasV220241113    *admin20241113.APIClient    // Used in teams and atlas_users to avoid breaking changes. Also used for serverless instances and shared tier, whose APIs were sunset and are no longer available in newer SDK versions.
-	AtlasV220250312020 *admin20250312020.APIClient // TODO: Remove before merging to master — pinned for maintenance_window wave fields until OpenAPI spec includes them.
-	Realm              *RealmClient
-	BaseURL            string // Needed by organization resource.
-	TerraformVersion   string // Needed by organization resource.
+	Atlas            *matlasClient.Client
+	AtlasV2          *admin.APIClient
+	AtlasPreview     *adminpreview.APIClient
+	AtlasV220240530  *admin20240530.APIClient // Used in cluster to support deprecated attributes default_read_concern and fail_index_key_too_long in advanced_configuration.
+	AtlasV220241113  *admin20241113.APIClient // Used in teams and atlas_users to avoid breaking changes. Also used for serverless instances and shared tier, whose APIs were sunset and are no longer available in newer SDK versions.
+	Realm            *RealmClient
+	BaseURL          string // Needed by organization resource.
+	TerraformVersion string // Needed by organization resource.
 }
 
 type RealmClient struct {
@@ -158,21 +156,14 @@ func NewClient(c *Credentials, terraformVersion string) (*MongoDBClient, error) 
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Remove before merging to master.
-	sdkV220250312020Client, err := newSDKV220250312020Client(client, c.BaseURL, userAgent)
-	if err != nil {
-		return nil, err
-	}
-
 	clients := &MongoDBClient{
-		Atlas:              atlasClient,
-		AtlasV2:            sdkV2Client,
-		AtlasPreview:       sdkPreviewClient,
-		AtlasV220240530:    sdkV220240530Client,
-		AtlasV220241113:    sdkV220241113Client,
-		AtlasV220250312020: sdkV220250312020Client, // TODO: Remove before merging to master.
-		BaseURL:            c.BaseURL,
-		TerraformVersion:   terraformVersion,
+		Atlas:            atlasClient,
+		AtlasV2:          sdkV2Client,
+		AtlasPreview:     sdkPreviewClient,
+		AtlasV220240530:  sdkV220240530Client,
+		AtlasV220241113:  sdkV220241113Client,
+		BaseURL:          c.BaseURL,
+		TerraformVersion: terraformVersion,
 		Realm: &RealmClient{
 			publicKey:        c.PublicKey,
 			privateKey:       c.PrivateKey,
@@ -253,16 +244,6 @@ func newSDKV220241113Client(client *http.Client, baseURL, userAgent string) (*ad
 		admin20241113.UseUserAgent(userAgent),
 		admin20241113.UseBaseURL(baseURL),
 		admin20241113.UseDebug(false),
-	)
-}
-
-// TODO: Remove before merging to master.
-func newSDKV220250312020Client(client *http.Client, baseURL, userAgent string) (*admin20250312020.APIClient, error) {
-	return admin20250312020.NewClient(
-		admin20250312020.UseHTTPClient(client),
-		admin20250312020.UseUserAgent(userAgent),
-		admin20250312020.UseBaseURL(baseURL),
-		admin20250312020.UseDebug(false),
 	)
 }
 

--- a/internal/service/maintenancewindow/data_source_maintenance_window.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window.go
@@ -71,10 +71,10 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Get("project_id").(string)
 
-	maintenance, _, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(ctx, projectID).Execute()
+	maintenance, _, err := connV2.MaintenanceWindowsAPI.GetMaintenanceWindow(ctx, projectID).Execute()
 	if err != nil {
 		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -8,10 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spf13/cast"
 
+	admin "github.com/mongodb/atlas-sdk-go/admin"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	admin "go.mongodb.org/atlas-sdk/v20250312020/admin" // TODO: Remove before merging to master — pinned for wave fields.
 )
 
 const (
@@ -112,17 +112,17 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Get("project_id").(string)
 
 	if deferValue := d.Get("defer").(bool); deferValue {
-		_, err := connV2.MaintenanceWindowsApi.DeferMaintenanceWindow(ctx, projectID).Execute()
+		_, err := connV2.MaintenanceWindowsAPI.DeferMaintenanceWindow(ctx, projectID).Execute()
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorMaintenanceDefer, projectID, err))
 		}
 	}
 
-	params := new(admin.GroupMaintenanceWindow)
+	params := new(admin.GroupMaintenanceWindowPreviewUpdateRequest)
 
 	params.DayOfWeek = cast.ToInt(d.Get("day_of_week"))
 	params.HourOfDay = new(cast.ToInt(d.Get("hour_of_day")))
@@ -137,13 +137,13 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	params.ProtectedHours = newProtectedHours(d)
-	_, err := connV2.MaintenanceWindowsApi.UpdateMaintenanceWindow(ctx, projectID, params).Execute()
+	_, err := connV2.MaintenanceWindowsAPI.UpdateMaintenanceWindow(ctx, projectID, params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorMaintenanceCreate, projectID, err))
 	}
 
 	if autoDeferValue := d.Get("auto_defer").(bool); autoDeferValue {
-		_, err := connV2.MaintenanceWindowsApi.ToggleMaintenanceAutoDefer(ctx, projectID).Execute()
+		_, err := connV2.MaintenanceWindowsAPI.ToggleMaintenanceAutoDefer(ctx, projectID).Execute()
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorMaintenanceAutoDefer, projectID, err))
 		}
@@ -168,10 +168,10 @@ func newProtectedHours(d *schema.ResourceData) *admin.ProtectedHours {
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Id()
 
-	maintenanceWindow, resp, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(ctx, projectID).Execute()
+	maintenanceWindow, resp, err := connV2.MaintenanceWindowsAPI.GetMaintenanceWindow(ctx, projectID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")
@@ -236,7 +236,7 @@ func flattenProtectedHours(protectedHours admin.ProtectedHours) []map[string]int
 func clearMaintenanceWave(ctx context.Context, client *config.MongoDBClient, projectID string) diag.Diagnostics {
 	body := []byte(`{"waveAssignment":null}`)
 	_, err := client.UntypedAPICall(ctx, config.APICallParams{
-		VersionHeader: "application/vnd.atlas.2023-01-01+json",
+		VersionHeader: "application/vnd.atlas.preview+json",
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
 		PathParams:    map[string]string{"groupId": projectID},
 		Method:        "PATCH",
@@ -248,17 +248,17 @@ func clearMaintenanceWave(ctx context.Context, client *config.MongoDBClient, pro
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Id()
 
 	if d.HasChange("defer") {
-		_, err := connV2.MaintenanceWindowsApi.DeferMaintenanceWindow(ctx, projectID).Execute()
+		_, err := connV2.MaintenanceWindowsAPI.DeferMaintenanceWindow(ctx, projectID).Execute()
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorMaintenanceDefer, projectID, err))
 		}
 	}
 
-	params := new(admin.GroupMaintenanceWindow)
+	params := new(admin.GroupMaintenanceWindowPreviewUpdateRequest)
 	params.DayOfWeek = cast.ToInt(d.Get("day_of_week"))
 
 	if d.HasChange("hour_of_day") {
@@ -296,13 +296,13 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 	}
 
-	_, err := connV2.MaintenanceWindowsApi.UpdateMaintenanceWindow(ctx, projectID, params).Execute()
+	_, err := connV2.MaintenanceWindowsAPI.UpdateMaintenanceWindow(ctx, projectID, params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorMaintenanceUpdate, projectID, err))
 	}
 
 	if d.HasChange("auto_defer") {
-		_, err := connV2.MaintenanceWindowsApi.ToggleMaintenanceAutoDefer(ctx, projectID).Execute()
+		_, err := connV2.MaintenanceWindowsAPI.ToggleMaintenanceAutoDefer(ctx, projectID).Execute()
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorMaintenanceAutoDefer, projectID, err))
 		}
@@ -312,10 +312,10 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV220250312020 // TODO: Remove before merging to master.
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Id()
 
-	_, err := connV2.MaintenanceWindowsApi.ResetMaintenanceWindow(ctx, projectID).Execute()
+	_, err := connV2.MaintenanceWindowsAPI.ResetMaintenanceWindow(ctx, projectID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorMaintenanceDelete, projectID, err))
 	}


### PR DESCRIPTION
## Description

Migrates the `mongodbatlas_maintenance_window` resource and data source to read and write the `wave_assignment` and `effective_wave_assignment` fields through the preview Atlas SDK (`AtlasPreview`), instead of a pinned versioned SDK.

These fields are exposed only under the preview API, so the provider now uses the preview client for the maintenance window get and update operations. The previously pinned SDK version used as a temporary workaround has been removed.

The `atlas-sdk-go` dependency is temporarily pinned to a private-preview build to obtain these fields. This must be reverted to a standard release before merging to master (tracked in the `go.mod` comment).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Dependency migration, no changelog required. Verified with `make fix`, unit tests, and `TestAccConfigRSMaintenanceWindow_waveAssignment` against cloud-dev.