### PR TITLE
test: Fix API key assignment in TestAccProject_slowOperationReadOnly

### DIFF
--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -1204,13 +1204,19 @@ func TestAccProject_slowOperationReadOnly(t *testing.T) {
 
 func changeRoles(t *testing.T, orgID, projectName, roleName string) {
 	t.Helper()
-	respProject, _, _ := acc.ConnV2().ProjectsApi.GetGroupByName(t.Context(), projectName).Execute()
+	respProject, _, err := acc.ConnV2().ProjectsApi.GetGroupByName(t.Context(), projectName).Execute()
+	if err != nil {
+		t.Fatalf("PreConfig: error finding project %s: %s", projectName, err)
+	}
 	projectID := respProject.GetId()
 	if projectID == "" {
 		t.Fatalf("PreConfig: error finding project %s", projectName)
 	}
 	api := acc.ConnV2().ProgrammaticAPIKeysApi
-	respList, _, _ := api.ListOrgApiKeys(t.Context(), orgID).Execute()
+	respList, _, err := api.ListOrgApiKeys(t.Context(), orgID).Execute()
+	if err != nil {
+		t.Fatalf("PreConfig: error listing org API keys for org %s: %s", orgID, err)
+	}
 	publicKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY_READ_ONLY")
 	keys := respList.GetResults()
 	for _, result := range keys {
@@ -1218,7 +1224,7 @@ func changeRoles(t *testing.T, orgID, projectName, roleName string) {
 			continue
 		}
 		apiKeyID := result.GetId()
-		// Assign the org API key to the project with the given role; the project must have the key assigned before its roles can be used.
+		// The project must have the key assigned before its roles can be used.
 		assignment := []admin.UserAccessRoleAssignment{{Roles: &[]string{roleName}}}
 		_, err := api.AddGroupApiKey(t.Context(), projectID, apiKeyID, &assignment).Execute()
 		if err != nil {

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -1218,10 +1218,11 @@ func changeRoles(t *testing.T, orgID, projectName, roleName string) {
 			continue
 		}
 		apiKeyID := result.GetId()
-		assignment := admin.UpdateAtlasProjectApiKey{Roles: &[]string{roleName}}
-		_, _, err := api.UpdateApiKeyRoles(t.Context(), projectID, apiKeyID, &assignment).Execute()
+		// Assign the org API key to the project with the given role; the project must have the key assigned before its roles can be used.
+		assignment := []admin.UserAccessRoleAssignment{{Roles: &[]string{roleName}}}
+		_, err := api.AddGroupApiKey(t.Context(), projectID, apiKeyID, &assignment).Execute()
 		if err != nil {
-			t.Errorf("PreConfig: error updating key %s", err)
+			t.Errorf("PreConfig: error assigning key to project %s", err)
 		}
 		return
 	}

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -1207,7 +1207,7 @@ func changeRoles(t *testing.T, orgID, projectName, roleName string) {
 	respProject, _, _ := acc.ConnV2().ProjectsApi.GetGroupByName(t.Context(), projectName).Execute()
 	projectID := respProject.GetId()
 	if projectID == "" {
-		t.Errorf("PreConfig: error finding project %s", projectName)
+		t.Fatalf("PreConfig: error finding project %s", projectName)
 	}
 	api := acc.ConnV2().ProgrammaticAPIKeysApi
 	respList, _, _ := api.ListOrgApiKeys(t.Context(), orgID).Execute()
@@ -1222,11 +1222,11 @@ func changeRoles(t *testing.T, orgID, projectName, roleName string) {
 		assignment := []admin.UserAccessRoleAssignment{{Roles: &[]string{roleName}}}
 		_, err := api.AddGroupApiKey(t.Context(), projectID, apiKeyID, &assignment).Execute()
 		if err != nil {
-			t.Errorf("PreConfig: error assigning key to project %s", err)
+			t.Fatalf("PreConfig: error assigning key %s to project %s: %s", apiKeyID, projectID, err)
 		}
 		return
 	}
-	t.Error("PreConfig: key not found")
+	t.Fatal("PreConfig: key not found")
 }
 
 func createDataFederationLimit(limitName string) admin.DataFederationLimit {


### PR DESCRIPTION
## Description

Fixes `TestAccProject_slowOperationReadOnly`, which has been failing in the nightly Test Suite `project` job with `HTTP 400 (API_KEY_NOT_FOUND)`.

The `changeRoles` test helper assigned the read-only org API key to the freshly-created test project using the project-scoped PATCH endpoint (`UpdateApiKeyRoles`). The Atlas backend security fix in CLOUDP-421397 (merged 2026-07-10) tightened that endpoint to require the key to already be a member of the project, so it now returns `API_KEY_NOT_FOUND` for a key that has not been assigned yet. This switches the helper to the POST assign endpoint (`AddGroupApiKey`), which assigns the key to the project with the given role, the operation the new behavior requires.

The helper's setup-failure checks were also changed from `t.Errorf` to `t.Fatalf` (including the failing IDs in the message) so a failed assignment aborts the step immediately instead of cascading into a confusing `USER_CANNOT_ACCESS_GROUP` error. This aligns with the `mongodbatlas_project_api_key` acceptance test, whose `PreConfig` block performs similar imperative API-key calls and uses `t.Fatalf` for setup failures.

This is a test-only change. The `mongodbatlas_project_api_key` resource itself is unaffected, as it already uses `AddGroupApiKey` to assign keys and only uses `UpdateApiKeyRoles` for keys already assigned to a project.

Failing `project` job runs:
- 2026-07-14: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29296414867/job/86971105755
- 2026-07-13: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29215895326/job/86711812376
- 2026-07-12: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29174147142/job/86600443914

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue).

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have run make fix and verified my code

## Further comments

No changelog entry needed (test-only change). Root cause is an intentional Atlas backend security hardening (CLOUDP-421397), not a provider regression.
