### PR TITLE
ci: Add curl retry to get-provider-version step

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -255,7 +255,7 @@ jobs:
         id: get_last_release
         shell: bash
         run: |
-          LAST_RELEASE=$(curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -sSfL -X GET https://api.github.com/repos/mongodb/terraform-provider-mongodbatlas/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          LAST_RELEASE=$(curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' --retry 3 --retry-delay 5 --retry-all-errors -sSfL -X GET https://api.github.com/repos/mongodb/terraform-provider-mongodbatlas/releases/latest | jq -r '.tag_name | ltrimstr("v")')
           echo "Last release: $LAST_RELEASE"
           echo "last_provider_version=${LAST_RELEASE}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -255,7 +255,7 @@ jobs:
         id: get_last_release
         shell: bash
         run: |
-          LAST_RELEASE=$(curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' --retry 3 --retry-delay 5 --retry-all-errors -sSfL -X GET https://api.github.com/repos/mongodb/terraform-provider-mongodbatlas/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          LAST_RELEASE=$(curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' --connect-timeout 10 --retry 3 --retry-delay 5 --retry-all-errors -sSfL -X GET https://api.github.com/repos/mongodb/terraform-provider-mongodbatlas/releases/latest | jq -r '.tag_name | ltrimstr("v")')
           echo "Last release: $LAST_RELEASE"
           echo "last_provider_version=${LAST_RELEASE}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Description

The `get-provider-version` job fetches the latest release via the GitHub API. It intermittently fails on transient GitHub API 503s, which cascades to skip the entire acceptance test suite (every test job `needs` it). This adds curl retry (`--retry 3 --retry-delay 5 --retry-all-errors`) so a transient blip no longer fails the run.

Recent failed run: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29709878272

`--retry-all-errors` is required because `--retry` alone does not retry arbitrary HTTP 5xx responses (like the 503 we hit) — only transport-level failures. Without it the retry would never trigger for this case.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

_Chore: CI workflow reliability fix (not user-facing). Please add the "chore" label._

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Verified by manually running the Acceptance Tests workflow on this branch (`project` group); the `get-provider-version` job completed successfully with the retry flags in place: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29771608502

