### PR TITLE
feat: Warn when base_url, realm_base_url, or is_mongodbgov_cloud are set alongside AWS Secrets Manager credentials

### DIFF
--- a/.changelog/4580.txt
+++ b/.changelog/4580.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Warns when `base_url`, `realm_base_url`, or `is_mongodbgov_cloud` are set while using AWS Secrets Manager credentials, as these values are ignored on that path and must be defined in the secret payload
+```

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -52,6 +53,31 @@ func GetCredentials(ctx context.Context, providerVars, envVars *Vars, getAWSCred
 	}
 	creds.applyGovBaseURL()
 	return creds, nil
+}
+
+// AWSSecretsManagerIgnoredWarning returns a warning when base_url, realm_base_url or
+// is_mongodbgov_cloud are set (as provider attributes or env vars) while AWS Secrets Manager
+// credentials are in use, since those values are ignored on that path and must be defined in
+// the secret payload instead. It returns an empty string when there is nothing to warn about.
+func AWSSecretsManagerIgnoredWarning(providerVars, envVars *Vars) string {
+	if CoalesceAWSVars(providerVars.GetAWS(), envVars.GetAWS()) == nil {
+		return ""
+	}
+	var ignored []string
+	if providerVars.BaseURL != "" || envVars.BaseURL != "" {
+		ignored = append(ignored, "base_url")
+	}
+	if providerVars.RealmBaseURL != "" || envVars.RealmBaseURL != "" {
+		ignored = append(ignored, "realm_base_url")
+	}
+	if providerVars.IsMongodbGovCloud || envVars.IsMongodbGovCloud {
+		ignored = append(ignored, "is_mongodbgov_cloud")
+	}
+	if len(ignored) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("The following attributes are ignored when using AWS Secrets Manager credentials: %s. "+
+		"Define these values in the secret payload instead.", strings.Join(ignored, ", "))
 }
 
 // AuthMethod follows the order of token, SA and PAK.

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -411,6 +411,61 @@ func TestCredentials_Errors(t *testing.T) {
 	}
 }
 
+func TestAWSSecretsManagerIgnoredWarning(t *testing.T) {
+	const (
+		baseURLWarning = "The following attributes are ignored when using AWS Secrets Manager credentials: base_url. Define these values in the secret payload instead."
+		allWarning     = "The following attributes are ignored when using AWS Secrets Manager credentials: base_url, realm_base_url, is_mongodbgov_cloud. Define these values in the secret payload instead."
+	)
+	testCases := map[string]struct {
+		providerVars *config.Vars
+		envVars      *config.Vars
+		want         string
+	}{
+		"AWS path with base_url set as provider attribute": {
+			providerVars: &config.Vars{AWSAssumeRoleARN: "arn", BaseURL: "https://cloud-qa.mongodb.com"},
+			envVars:      &config.Vars{},
+			want:         baseURLWarning,
+		},
+		"AWS path with base_url set as env var": {
+			providerVars: &config.Vars{AWSAssumeRoleARN: "arn"},
+			envVars:      &config.Vars{BaseURL: "https://cloud-qa.mongodb.com"},
+			want:         baseURLWarning,
+		},
+		"AWS path via env var role_arn with realm_base_url set": {
+			providerVars: &config.Vars{},
+			envVars:      &config.Vars{AWSAssumeRoleARN: "arn", RealmBaseURL: "https://realm.example.com"},
+			want:         "The following attributes are ignored when using AWS Secrets Manager credentials: realm_base_url. Define these values in the secret payload instead.",
+		},
+		"AWS path with is_mongodbgov_cloud set": {
+			providerVars: &config.Vars{AWSAssumeRoleARN: "arn", IsMongodbGovCloud: true},
+			envVars:      &config.Vars{},
+			want:         "The following attributes are ignored when using AWS Secrets Manager credentials: is_mongodbgov_cloud. Define these values in the secret payload instead.",
+		},
+		"AWS path with all three attributes set": {
+			providerVars: &config.Vars{AWSAssumeRoleARN: "arn", BaseURL: "https://cloud-qa.mongodb.com", RealmBaseURL: "https://realm.example.com", IsMongodbGovCloud: true},
+			envVars:      &config.Vars{},
+			want:         allWarning,
+		},
+		"AWS path with none of the three attributes set": {
+			providerVars: &config.Vars{AWSAssumeRoleARN: "arn", PublicKey: "public"},
+			envVars:      &config.Vars{},
+			want:         "",
+		},
+		"No AWS path with all three attributes set": {
+			providerVars: &config.Vars{BaseURL: "https://cloud-qa.mongodb.com", RealmBaseURL: "https://realm.example.com", IsMongodbGovCloud: true},
+			envVars:      &config.Vars{},
+			want:         "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := config.AWSSecretsManagerIgnoredWarning(tc.providerVars, tc.envVars)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestGetCredentials(t *testing.T) {
 	mockGetAWSCredentials := func(_ context.Context, awsVars *config.AWSVars) (*config.Credentials, error) {
 		if awsVars.AssumeRoleARN == "error" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -208,7 +208,8 @@ func (p *MongodbatlasProvider) Configure(ctx context.Context, req provider.Confi
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	c, err := config.GetCredentials(ctx, providerVars, config.NewEnvVars(), getAWSCredentials)
+	envVars := config.NewEnvVars()
+	c, err := config.GetCredentials(ctx, providerVars, envVars, getAWSCredentials)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting credentials for provider", err.Error())
 		return
@@ -219,6 +220,9 @@ func (p *MongodbatlasProvider) Configure(ctx context.Context, req provider.Confi
 	}
 	if c.Warnings() != "" {
 		resp.Diagnostics.AddWarning("Warning getting credentials for provider", c.Warnings())
+	}
+	if w := config.AWSSecretsManagerIgnoredWarning(providerVars, envVars); w != "" {
+		resp.Diagnostics.AddWarning("Configuration ignored when using AWS Secrets Manager", w)
 	}
 	client, err := config.NewClient(c, req.TerraformVersion)
 	if err != nil {


### PR DESCRIPTION
## Description

On the AWS Secrets Manager auth path (`assume_role.role_arn` set), the provider builds its client exclusively from the secret payload. `base_url`, `realm_base_url`, and `is_mongodbgov_cloud` set as provider attributes or env vars are silently ignored, which can route requests to the default control plane and produce a hard-to-diagnose 401 (surfaced by HELP-96418).

This adds a Terraform warning during provider configuration when any of those three attributes is set while AWS Secrets Manager credentials are in use. The warning names the ignored attribute(s) and points to the secret payload as the fix. Behavior is otherwise unchanged.

The check is a pure function `config.AWSSecretsManagerIgnoredWarning`, wired into the framework provider's `Configure` only (the SDKv2 provider intentionally suppresses these warnings, as they are surfaced by the framework provider).

Jira: https://jira.mongodb.org/browse/CLOUDP-421953
Related: #4564 (support `is_mongodbgov_cloud` in the secret payload)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
