### PR TITLE
test: Update error assertion in TestAccPrivateLinkEndpointService_failedAWS

### DIFF
--- a/internal/service/privatelinkendpointservice/resource.go
+++ b/internal/service/privatelinkendpointservice/resource.go
@@ -29,6 +29,7 @@ const (
 	errorEndpointDelete            = "error deleting MongoDB Private Service Endpoint Connection(%s): %s"
 	errorEndpointSetting           = "error setting `%s` for MongoDB Private Service Endpoint Connection(%s): %s"
 	errorAdvancedClusterListStatus = "error awaiting MongoDB ClusterAdvanced List IDLE: %s"
+	FailedStateErrorPrefix         = "privatelink endpoint service is in a failed state"
 	delayAndMinTimeout             = 10 * time.Second
 )
 
@@ -332,7 +333,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	}
 
 	if privateEndpoint.GetErrorMessage() != "" {
-		return diag.FromErr(fmt.Errorf("privatelink endpoint service is in a failed state: %s", privateEndpoint.GetErrorMessage()))
+		return diag.FromErr(fmt.Errorf(FailedStateErrorPrefix+": %s", privateEndpoint.GetErrorMessage()))
 	}
 	return nil
 }

--- a/internal/service/privatelinkendpointservice/resource_test.go
+++ b/internal/service/privatelinkendpointservice/resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/privatelinkendpointservice"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -59,7 +60,7 @@ func TestAccPrivateLinkEndpointService_failedAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configFailedAWS(projectID, "EU_WEST_1", dummyVPCEndpointID), // Different region to avoid project conflicts.
-				ExpectError: regexp.MustCompile("privatelink endpoint service is in a failed state: Interface endpoint " + dummyVPCEndpointID + " was not found."),
+				ExpectError: regexp.MustCompile(privatelinkendpointservice.FailedStateErrorPrefix),
 			},
 		},
 	})


### PR DESCRIPTION
## Description

`TestAccPrivateLinkEndpointService_failedAWS` asserted the full failed-state error string, including the backend-supplied detail:

```
privatelink endpoint service is in a failed state: Interface endpoint vpce-11111111111111111 was not found.
```

The Atlas backend changed that detail in (CLOUDP-426024) to:

```
privatelink endpoint service is in a failed state: Verify endpoint ID and accepted regions, then retry your connection.
```

The test will now fail deterministically (seen in the nightly [run 29880854355](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29880854355)).

Assert only on the provider-generated prefix (`privatelink endpoint service is in a failed state:`). The text after the colon is passed through verbatim from the Atlas backend and can change so reducing the coupling. The test still verifies the intended behavior.

Link to any related issue(s): CLOUDP-426024

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
