### PR TITLE
feat: Add vertical autoscaling configuration for stream processors

### DIFF
--- a/.changelog/9999.txt
+++ b/.changelog/9999.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_processor: Adds `options.autoscaling` block (`enabled`, `min_tier`, `max_tier`) and read-only `effective_tier` attribute to support vertical autoscaling
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_processor: Adds `options.autoscaling` block and read-only `effective_tier` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_processors: Adds `options.autoscaling` block and read-only `effective_tier` attribute
+```

--- a/docs/data-sources/stream_processor.md
+++ b/docs/data-sources/stream_processor.md
@@ -155,7 +155,7 @@ output "stream_processors_results" {
 
 Read-Only:
 
-- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration. (see [below for nested schema](#nestedatt--options--autoscaling))
+- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When present, autoscaling is enabled and the processor automatically scales its tier between `min_tier` and `max_tier` based on load; `tier` is then used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). To disable autoscaling, remove this block — the backend clears the configuration on disable, so autoscaling cannot be turned off by setting `enabled = false`. (see [below for nested schema](#nestedatt--options--autoscaling))
 - `dlq` (Attributes) Dead letter queue for the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-dead-letter-queue) for more information. (see [below for nested schema](#nestedatt--options--dlq))
 
 <a id="nestedatt--options--autoscaling"></a>
@@ -163,7 +163,7 @@ Read-Only:
 
 Read-Only:
 
-- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.
+- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Must be `true` when the `options.autoscaling` block is present. To disable autoscaling, remove the block rather than setting this to `false` (the backend does not persist a disabled config, so `enabled = false` is rejected during planning).
 - `max_tier` (String) Tier ceiling for autoscaling (scale-up limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace maximum tier.
 - `min_tier` (String) Tier floor for autoscaling (scale-down limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace default tier.
 

--- a/docs/data-sources/stream_processor.md
+++ b/docs/data-sources/stream_processor.md
@@ -87,11 +87,19 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
     { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-cluster.connection_name, "db" : "kafka", "coll" : "topic_source", "timeseries" : { "timeField" : "ts" } }
   }])
   state = "CREATED"
+  # `tier` acts as the baseline tier; when autoscaling is enabled the processor scales
+  # between `min_tier` and `max_tier`, and the running tier is reported by `effective_tier`.
+  tier = "SP10"
   options = {
     dlq = {
       coll            = "exampleColumn"
       connection_name = resource.mongodbatlas_stream_connection.example-cluster.connection_name
       db              = "exampleDb"
+    }
+    autoscaling = {
+      enabled  = true
+      min_tier = "SP10"
+      max_tier = "SP50"
     }
   }
 }
@@ -132,6 +140,7 @@ output "stream_processors_results" {
 
 ### Read-Only
 
+- `effective_tier` (String) Tier the stream processor is currently running on. When autoscaling is disabled this equals `tier`; when autoscaling is enabled it reflects the tier chosen by the autoscaler within the configured bounds.
 - `id` (String) Unique 24-hexadecimal character string that identifies the stream processor.
 - `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--options))
 - `pipeline` (String) Stream aggregation pipeline you want to apply to your streaming data. [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/#std-label-stream-aggregation) contain more information. Using [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode) is recommended when setting this attribute. For more details see the [Aggregation Pipelines Documentation](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/)
@@ -139,14 +148,25 @@ output "stream_processors_results" {
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
 - `stats` (String) The stats associated with the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/manage-stream-processor/#view-statistics-of-a-stream-processor) for more information.
-- `tier` (String) Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50.
+- `tier` (String) Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50. When `options.autoscaling` is enabled, this is used only as the initial/baseline tier; the running tier is reported by `effective_tier`.
 
 <a id="nestedatt--options"></a>
 ### Nested Schema for `options`
 
 Read-Only:
 
+- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration. (see [below for nested schema](#nestedatt--options--autoscaling))
 - `dlq` (Attributes) Dead letter queue for the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-dead-letter-queue) for more information. (see [below for nested schema](#nestedatt--options--dlq))
+
+<a id="nestedatt--options--autoscaling"></a>
+### Nested Schema for `options.autoscaling`
+
+Read-Only:
+
+- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.
+- `max_tier` (String) Tier ceiling for autoscaling (scale-up limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace maximum tier.
+- `min_tier` (String) Tier floor for autoscaling (scale-down limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace default tier.
+
 
 <a id="nestedatt--options--dlq"></a>
 ### Nested Schema for `options.dlq`

--- a/docs/data-sources/stream_processors.md
+++ b/docs/data-sources/stream_processors.md
@@ -169,7 +169,7 @@ Read-Only:
 
 Read-Only:
 
-- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration. (see [below for nested schema](#nestedatt--results--options--autoscaling))
+- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When present, autoscaling is enabled and the processor automatically scales its tier between `min_tier` and `max_tier` based on load; `tier` is then used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). To disable autoscaling, remove this block — the backend clears the configuration on disable, so autoscaling cannot be turned off by setting `enabled = false`. (see [below for nested schema](#nestedatt--results--options--autoscaling))
 - `dlq` (Attributes) Dead letter queue for the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-dead-letter-queue) for more information. (see [below for nested schema](#nestedatt--results--options--dlq))
 
 <a id="nestedatt--results--options--autoscaling"></a>
@@ -177,7 +177,7 @@ Read-Only:
 
 Read-Only:
 
-- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.
+- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Must be `true` when the `options.autoscaling` block is present. To disable autoscaling, remove the block rather than setting this to `false` (the backend does not persist a disabled config, so `enabled = false` is rejected during planning).
 - `max_tier` (String) Tier ceiling for autoscaling (scale-up limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace maximum tier.
 - `min_tier` (String) Tier floor for autoscaling (scale-down limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace default tier.
 

--- a/docs/data-sources/stream_processors.md
+++ b/docs/data-sources/stream_processors.md
@@ -87,11 +87,19 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
     { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-cluster.connection_name, "db" : "kafka", "coll" : "topic_source", "timeseries" : { "timeField" : "ts" } }
   }])
   state = "CREATED"
+  # `tier` acts as the baseline tier; when autoscaling is enabled the processor scales
+  # between `min_tier` and `max_tier`, and the running tier is reported by `effective_tier`.
+  tier = "SP10"
   options = {
     dlq = {
       coll            = "exampleColumn"
       connection_name = resource.mongodbatlas_stream_connection.example-cluster.connection_name
       db              = "exampleDb"
+    }
+    autoscaling = {
+      enabled  = true
+      min_tier = "SP10"
+      max_tier = "SP50"
     }
   }
 }
@@ -142,6 +150,7 @@ role or Project Stream Processing Owner role. (see [below for nested schema](#ne
 
 Read-Only:
 
+- `effective_tier` (String) Tier the stream processor is currently running on. When autoscaling is disabled this equals `tier`; when autoscaling is enabled it reflects the tier chosen by the autoscaler within the configured bounds.
 - `id` (String) Unique 24-hexadecimal character string that identifies the stream processor.
 - `instance_name` (String, Deprecated) Label that identifies the stream processing workspace.
 - `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--results--options))
@@ -152,7 +161,7 @@ Read-Only:
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
 - `stats` (String) The stats associated with the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/manage-stream-processor/#view-statistics-of-a-stream-processor) for more information.
-- `tier` (String) Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50.
+- `tier` (String) Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50. When `options.autoscaling` is enabled, this is used only as the initial/baseline tier; the running tier is reported by `effective_tier`.
 - `workspace_name` (String) Label that identifies the stream processing workspace.
 
 <a id="nestedatt--results--options"></a>
@@ -160,7 +169,18 @@ Read-Only:
 
 Read-Only:
 
+- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration. (see [below for nested schema](#nestedatt--results--options--autoscaling))
 - `dlq` (Attributes) Dead letter queue for the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-dead-letter-queue) for more information. (see [below for nested schema](#nestedatt--results--options--dlq))
+
+<a id="nestedatt--results--options--autoscaling"></a>
+### Nested Schema for `results.options.autoscaling`
+
+Read-Only:
+
+- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.
+- `max_tier` (String) Tier ceiling for autoscaling (scale-up limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace maximum tier.
+- `min_tier` (String) Tier floor for autoscaling (scale-down limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace default tier.
+
 
 <a id="nestedatt--results--options--dlq"></a>
 ### Nested Schema for `results.options.dlq`

--- a/docs/resources/stream_processor.md
+++ b/docs/resources/stream_processor.md
@@ -170,7 +170,7 @@ Required:
 
 Optional:
 
-- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration. (see [below for nested schema](#nestedatt--options--autoscaling))
+- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When present, autoscaling is enabled and the processor automatically scales its tier between `min_tier` and `max_tier` based on load; `tier` is then used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). To disable autoscaling, remove this block — the backend clears the configuration on disable, so autoscaling cannot be turned off by setting `enabled = false`. (see [below for nested schema](#nestedatt--options--autoscaling))
 
 <a id="nestedatt--options--dlq"></a>
 ### Nested Schema for `options.dlq`
@@ -187,7 +187,7 @@ Required:
 
 Required:
 
-- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.
+- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Must be `true` when the `options.autoscaling` block is present. To disable autoscaling, remove the block rather than setting this to `false` (the backend does not persist a disabled config, so `enabled = false` is rejected during planning).
 
 Optional:
 

--- a/docs/resources/stream_processor.md
+++ b/docs/resources/stream_processor.md
@@ -93,11 +93,19 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
     { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-cluster.connection_name, "db" : "kafka", "coll" : "topic_source", "timeseries" : { "timeField" : "ts" } }
   }])
   state = "CREATED"
+  # `tier` acts as the baseline tier; when autoscaling is enabled the processor scales
+  # between `min_tier` and `max_tier`, and the running tier is reported by `effective_tier`.
+  tier = "SP10"
   options = {
     dlq = {
       coll            = "exampleColumn"
       connection_name = resource.mongodbatlas_stream_connection.example-cluster.connection_name
       db              = "exampleDb"
+    }
+    autoscaling = {
+      enabled  = true
+      min_tier = "SP10"
+      max_tier = "SP50"
     }
   }
 }
@@ -143,12 +151,13 @@ output "stream_processors_results" {
 - `state` (String) The state of the stream processor. Commonly occurring states are 'CREATED', 'STARTED', 'STOPPED' and 'FAILED'. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`. When a Stream Processor is created without specifying the state, it will default to `CREATED` state. When a Stream Processor is updated without specifying the state, it will default to the Previous state. 
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
-- `tier` (String) Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50.
+- `tier` (String) Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50. When `options.autoscaling` is enabled, this is used only as the initial/baseline tier; the running tier is reported by `effective_tier`.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `workspace_name` (String) Label that identifies the stream processing workspace.
 
 ### Read-Only
 
+- `effective_tier` (String) Tier the stream processor is currently running on. When autoscaling is disabled this equals `tier`; when autoscaling is enabled it reflects the tier chosen by the autoscaler within the configured bounds.
 - `id` (String) Unique 24-hexadecimal character string that identifies the stream processor.
 - `stats` (String) The stats associated with the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/manage-stream-processor/#view-statistics-of-a-stream-processor) for more information.
 
@@ -159,6 +168,10 @@ Required:
 
 - `dlq` (Attributes) Dead letter queue for the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-dead-letter-queue) for more information. (see [below for nested schema](#nestedatt--options--dlq))
 
+Optional:
+
+- `autoscaling` (Attributes) Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration. (see [below for nested schema](#nestedatt--options--autoscaling))
+
 <a id="nestedatt--options--dlq"></a>
 ### Nested Schema for `options.dlq`
 
@@ -167,6 +180,19 @@ Required:
 - `coll` (String) Name of the collection to use for the DLQ.
 - `connection_name` (String) Name of the connection to write DLQ messages to. Must be an Atlas connection.
 - `db` (String) Name of the database to use for the DLQ.
+
+
+<a id="nestedatt--options--autoscaling"></a>
+### Nested Schema for `options.autoscaling`
+
+Required:
+
+- `enabled` (Boolean) Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.
+
+Optional:
+
+- `max_tier` (String) Tier ceiling for autoscaling (scale-up limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace maximum tier.
+- `min_tier` (String) Tier floor for autoscaling (scale-down limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace default tier.
 
 
 

--- a/examples/mongodbatlas_stream_processor/main.tf
+++ b/examples/mongodbatlas_stream_processor/main.tf
@@ -77,11 +77,19 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
     { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-cluster.connection_name, "db" : "kafka", "coll" : "topic_source", "timeseries" : { "timeField" : "ts" } }
   }])
   state = "CREATED"
+  # `tier` acts as the baseline tier; when autoscaling is enabled the processor scales
+  # between `min_tier` and `max_tier`, and the running tier is reported by `effective_tier`.
+  tier = "SP10"
   options = {
     dlq = {
       coll            = "exampleColumn"
       connection_name = resource.mongodbatlas_stream_connection.example-cluster.connection_name
       db              = "exampleDb"
+    }
+    autoscaling = {
+      enabled  = true
+      min_tier = "SP10"
+      max_tier = "SP50"
     }
   }
 }

--- a/internal/service/streamprocessor/autoscaling.go
+++ b/internal/service/streamprocessor/autoscaling.go
@@ -58,20 +58,26 @@ func newAutoscalingReq(ctx context.Context, autoscaling types.Object) (*admin.St
 	return req, nil
 }
 
-// autoscalingBoundsRequireEnabledValidator rejects configs that set min_tier/max_tier
-// while enabled is false, mirroring the backend which returns a 400 for bounds on a
-// disabled autoscaling config. Validating at plan time surfaces the error earlier.
-type autoscalingBoundsRequireEnabledValidator struct{}
+// disableAutoscalingErrorDetail is the guidance shown when a user sets enabled = false.
+// It is shared by the plan-time validator so the docs, validator, and runtime message agree.
+const disableAutoscalingErrorDetail = "To disable autoscaling, remove the `options.autoscaling` block rather than setting `enabled = false`. The backend does not persist a disabled configuration, so `enabled = false` cannot round-trip."
 
-func (v autoscalingBoundsRequireEnabledValidator) Description(_ context.Context) string {
-	return "min_tier and max_tier can only be set when enabled is true"
+// autoscalingEnabledValidator rejects `enabled = false`. When the autoscaling block is
+// present, autoscaling must be enabled; disabling is expressed by removing the block (the
+// provider then sends the explicit disable to the API). This avoids the "inconsistent result
+// after apply" that would otherwise occur, since a disabled config is not persisted and reads
+// back as null.
+type autoscalingEnabledValidator struct{}
+
+func (v autoscalingEnabledValidator) Description(_ context.Context) string {
+	return "enabled must be true when the autoscaling block is present; disable by removing the block"
 }
 
-func (v autoscalingBoundsRequireEnabledValidator) MarkdownDescription(ctx context.Context) string {
+func (v autoscalingEnabledValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v autoscalingBoundsRequireEnabledValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+func (v autoscalingEnabledValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
@@ -84,15 +90,11 @@ func (v autoscalingBoundsRequireEnabledValidator) ValidateObject(ctx context.Con
 	if tfModel.Enabled.IsNull() || tfModel.Enabled.IsUnknown() || tfModel.Enabled.ValueBool() {
 		return
 	}
-	hasBound := (!tfModel.MinTier.IsNull() && !tfModel.MinTier.IsUnknown()) ||
-		(!tfModel.MaxTier.IsNull() && !tfModel.MaxTier.IsUnknown())
-	if hasBound {
-		resp.Diagnostics.AddAttributeError(
-			req.Path,
-			"Invalid autoscaling configuration",
-			"`min_tier` and `max_tier` can only be set when `enabled` is `true`. Set `enabled = true` or remove the tier bounds.",
-		)
-	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid autoscaling configuration",
+		disableAutoscalingErrorDetail,
+	)
 }
 
 // autoscalingFromPlanOptions extracts the autoscaling SDK request from the plan's

--- a/internal/service/streamprocessor/autoscaling.go
+++ b/internal/service/streamprocessor/autoscaling.go
@@ -1,0 +1,155 @@
+package streamprocessor
+
+// Vertical Autoscaling (Phase 1) for stream processors.
+//
+// The autoscaling config (`options.autoscaling`) and the read-only top-level
+// `effectiveTier` field are still `@Hidden` in the Atlas API and are therefore
+// not part of the officially generated SDK yet. During development they are
+// provided by a hand-patched LOCAL copy of the versioned SDK wired in via the
+// `replace` directive in go.mod (see .sdkstub/, per the ASP "Terraform
+// Development" wiki's "Local validation in Cloud Dev" guidance). Once the fields
+// are un-hidden and land in the official SDK, remove the stub + replace directive;
+// no changes to this file should be required because it already targets the real
+// admin.StreamsAutoscaling type.
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"go.mongodb.org/atlas-sdk/v20250312020/admin"
+)
+
+type TFAutoscalingModel struct {
+	Enabled types.Bool   `tfsdk:"enabled"`
+	MinTier types.String `tfsdk:"min_tier"`
+	MaxTier types.String `tfsdk:"max_tier"`
+}
+
+var AutoscalingObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"enabled":  types.BoolType,
+	"min_tier": types.StringType,
+	"max_tier": types.StringType,
+}}
+
+// newAutoscalingReq converts the TF autoscaling object into the SDK request type.
+// Returns nil when the block is not configured (unset), which the API treats as
+// "keep persisted config" on update and "no autoscaling" on create.
+func newAutoscalingReq(ctx context.Context, autoscaling types.Object) (*admin.StreamsAutoscaling, diag.Diagnostics) {
+	if autoscaling.IsNull() || autoscaling.IsUnknown() {
+		return nil, nil
+	}
+	tfModel := &TFAutoscalingModel{}
+	if diags := autoscaling.As(ctx, tfModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return nil, diags
+	}
+	req := &admin.StreamsAutoscaling{
+		Enabled: tfModel.Enabled.ValueBoolPointer(),
+	}
+	if !tfModel.MinTier.IsNull() && !tfModel.MinTier.IsUnknown() {
+		req.MinTier = tfModel.MinTier.ValueStringPointer()
+	}
+	if !tfModel.MaxTier.IsNull() && !tfModel.MaxTier.IsUnknown() {
+		req.MaxTier = tfModel.MaxTier.ValueStringPointer()
+	}
+	return req, nil
+}
+
+// autoscalingBoundsRequireEnabledValidator rejects configs that set min_tier/max_tier
+// while enabled is false, mirroring the backend which returns a 400 for bounds on a
+// disabled autoscaling config. Validating at plan time surfaces the error earlier.
+type autoscalingBoundsRequireEnabledValidator struct{}
+
+func (v autoscalingBoundsRequireEnabledValidator) Description(_ context.Context) string {
+	return "min_tier and max_tier can only be set when enabled is true"
+}
+
+func (v autoscalingBoundsRequireEnabledValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v autoscalingBoundsRequireEnabledValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	tfModel := &TFAutoscalingModel{}
+	if diags := req.ConfigValue.As(ctx, tfModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	// Only flag when enabled is explicitly false; unknown/true are allowed.
+	if tfModel.Enabled.IsNull() || tfModel.Enabled.IsUnknown() || tfModel.Enabled.ValueBool() {
+		return
+	}
+	hasBound := (!tfModel.MinTier.IsNull() && !tfModel.MinTier.IsUnknown()) ||
+		(!tfModel.MaxTier.IsNull() && !tfModel.MaxTier.IsUnknown())
+	if hasBound {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid autoscaling configuration",
+			"`min_tier` and `max_tier` can only be set when `enabled` is `true`. Set `enabled = true` or remove the tier bounds.",
+		)
+	}
+}
+
+// autoscalingFromPlanOptions extracts the autoscaling SDK request from the plan's
+// `options` object, for endpoints (e.g. :startWith) that take autoscaling top-level.
+// Returns nil when options or the autoscaling block is unset.
+func autoscalingFromPlanOptions(ctx context.Context, options types.Object) (*admin.StreamsAutoscaling, diag.Diagnostics) {
+	if options.IsNull() || options.IsUnknown() {
+		return nil, nil
+	}
+	optionsModel := &TFOptionsModel{}
+	if diags := options.As(ctx, optionsModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return nil, diags
+	}
+	return newAutoscalingReq(ctx, optionsModel.Autoscaling)
+}
+
+// resolveAutoscalingForUpdate applies the PATCH tri-state semantics: it returns the
+// plan's autoscaling request when configured; an explicit disable ({enabled:false})
+// when the block was removed from the plan but was present in prior state; or nil when
+// autoscaling is absent from both, so the API preserves whatever is persisted.
+func resolveAutoscalingForUpdate(ctx context.Context, plan, state *TFStreamProcessorRSModel) (*admin.StreamsAutoscaling, diag.Diagnostics) {
+	planAutoscaling, diags := autoscalingFromPlanOptions(ctx, plan.Options)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if planAutoscaling != nil {
+		return planAutoscaling, nil
+	}
+	stateAutoscaling, diags := autoscalingFromPlanOptions(ctx, state.Options)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if stateAutoscaling != nil {
+		return &admin.StreamsAutoscaling{Enabled: admin.PtrBool(false)}, nil
+	}
+	return nil, nil
+}
+
+// effectiveTierFromResp derives the read-only `effective_tier` from the API response.
+// Falls back to the baseline `tier` when the API does not return an explicit
+// effectiveTier (they are equal whenever autoscaling is disabled).
+func effectiveTierFromResp(effectiveTier, tier *string) types.String {
+	if effectiveTier != nil {
+		return types.StringPointerValue(effectiveTier)
+	}
+	return types.StringPointerValue(tier)
+}
+
+// convertAutoscalingToTF converts the SDK response type into a TF object.
+func convertAutoscalingToTF(ctx context.Context, autoscaling *admin.StreamsAutoscaling) (types.Object, diag.Diagnostics) {
+	if autoscaling == nil {
+		return types.ObjectNull(AutoscalingObjectType.AttributeTypes()), nil
+	}
+	tfModel := TFAutoscalingModel{
+		Enabled: types.BoolPointerValue(autoscaling.Enabled),
+		MinTier: types.StringPointerValue(autoscaling.MinTier),
+		MaxTier: types.StringPointerValue(autoscaling.MaxTier),
+	}
+	return types.ObjectValueFrom(ctx, AutoscalingObjectType.AttributeTypes(), tfModel)
+}

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -40,19 +40,28 @@ func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) 
 		if diags := optionsModel.Dlq.As(ctx, dlqModel, basetypes.ObjectAsOptions{}); diags.HasError() {
 			return nil, diags
 		}
+		autoscaling, diags := newAutoscalingReq(ctx, optionsModel.Autoscaling)
+		if diags.HasError() {
+			return nil, diags
+		}
 		streamProcessor.Options = &admin.StreamsOptions{
 			Dlq: &admin.StreamsDLQ{
 				Coll:           dlqModel.Coll.ValueStringPointer(),
 				ConnectionName: dlqModel.ConnectionName.ValueStringPointer(),
 				Db:             dlqModel.DB.ValueStringPointer(),
 			},
+			Autoscaling: autoscaling,
 		}
+	}
+
+	if !plan.Tier.IsNull() && !plan.Tier.IsUnknown() {
+		streamProcessor.Tier = plan.Tier.ValueStringPointer()
 	}
 
 	return streamProcessor, nil
 }
 
-func NewStreamProcessorUpdateReq(ctx context.Context, plan *TFStreamProcessorRSModel) (*admin.UpdateStreamProcessorApiParams, diag.Diagnostics) {
+func NewStreamProcessorUpdateReq(ctx context.Context, plan, state *TFStreamProcessorRSModel) (*admin.UpdateStreamProcessorApiParams, diag.Diagnostics) {
 	pipeline, diags := convertPipelineToSdk(plan.Pipeline.ValueString())
 	if diags != nil {
 		return nil, diags
@@ -70,6 +79,16 @@ func NewStreamProcessorUpdateReq(ctx context.Context, plan *TFStreamProcessorRSM
 		},
 	}
 
+	// Resolve the autoscaling operation with PATCH tri-state semantics:
+	//   - block present in the plan  => apply it as configured (enable / disable).
+	//   - block removed from the plan but present in prior state => explicit disable
+	//     ({enabled:false}); the API otherwise treats an omitted config as "preserve".
+	//   - block absent in both plan and state => nil (no autoscaling operation).
+	autoscaling, diags := resolveAutoscalingForUpdate(ctx, plan, state)
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	if !plan.Options.IsNull() && !plan.Options.IsUnknown() {
 		optionsModel := &TFOptionsModel{}
 		if diags := plan.Options.As(ctx, optionsModel, basetypes.ObjectAsOptions{}); diags.HasError() {
@@ -85,7 +104,20 @@ func NewStreamProcessorUpdateReq(ctx context.Context, plan *TFStreamProcessorRSM
 				ConnectionName: dlqModel.ConnectionName.ValueStringPointer(),
 				Db:             dlqModel.DB.ValueStringPointer(),
 			},
+			Autoscaling: autoscaling,
 		}
+	} else if autoscaling != nil {
+		// The whole options block was removed but autoscaling still needs an explicit
+		// disable. Dlq is left nil (omitted => preserved by the API).
+		streamProcessorAPIParams.StreamsModifyStreamProcessor.Options = &admin.StreamsModifyStreamProcessorOptions{
+			Autoscaling: autoscaling,
+		}
+	}
+
+	// Baseline tier is settable on the PATCH body; when autoscaling is enabled the API treats
+	// it as the initial tier only and reports the running tier via effectiveTier.
+	if !plan.Tier.IsNull() && !plan.Tier.IsUnknown() {
+		streamProcessorAPIParams.StreamsModifyStreamProcessor.Tier = plan.Tier.ValueStringPointer()
 	}
 
 	return streamProcessorAPIParams, nil
@@ -116,6 +148,7 @@ func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName, w
 		State:         types.StringPointerValue(&apiResp.State),
 		Stats:         statsTF,
 		Tier:          types.StringPointerValue(apiResp.Tier),
+		EffectiveTier: effectiveTierFromResp(apiResp.EffectiveTier, apiResp.Tier),
 	}
 
 	if workspaceName != "" {
@@ -161,6 +194,7 @@ func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName, w
 		State:         types.StringPointerValue(&apiResp.State),
 		Stats:         statsTF,
 		Tier:          types.StringPointerValue(apiResp.Tier),
+		EffectiveTier: effectiveTierFromResp(apiResp.EffectiveTier, apiResp.Tier),
 	}
 
 	if workspaceName != "" {
@@ -175,15 +209,20 @@ func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName, w
 }
 
 func ConvertOptionsToTF(ctx context.Context, options *admin.StreamsOptions) (*types.Object, diag.Diagnostics) {
-	if options == nil || !options.HasDlq() {
+	if options == nil || (!options.HasDlq() && options.Autoscaling == nil) {
 		return new(types.ObjectNull(OptionsObjectType.AttributeTypes())), nil
 	}
 	dlqTF, diags := convertDlqToTF(ctx, options.Dlq)
 	if diags.HasError() {
 		return nil, diags
 	}
+	autoscalingTF, diags := convertAutoscalingToTF(ctx, options.Autoscaling)
+	if diags.HasError() {
+		return nil, diags
+	}
 	optionsTF := &TFOptionsModel{
-		Dlq: *dlqTF,
+		Dlq:         *dlqTF,
+		Autoscaling: autoscalingTF,
 	}
 	optionsObject, diags := types.ObjectValueFrom(ctx, OptionsObjectType.AttributeTypes(), optionsTF)
 	if diags.HasError() {

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
@@ -37,6 +38,18 @@ var (
 			Coll:           conversion.StringPtr("testColl"),
 			ConnectionName: conversion.StringPtr("testConnection"),
 			Db:             conversion.StringPtr("testDB"),
+		},
+	}
+	streamOptionsWithAutoscaling = admin.StreamsOptions{
+		Dlq: &admin.StreamsDLQ{
+			Coll:           conversion.StringPtr("testColl"),
+			ConnectionName: conversion.StringPtr("testConnection"),
+			Db:             conversion.StringPtr("testDB"),
+		},
+		Autoscaling: &admin.StreamsAutoscaling{
+			Enabled: admin.PtrBool(true),
+			MinTier: conversion.StringPtr("SP10"),
+			MaxTier: conversion.StringPtr("SP50"),
 		},
 	}
 )
@@ -430,7 +443,7 @@ func TestNewStreamProcessorUpdateReq(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			updateReq, diags := streamprocessor.NewStreamProcessorUpdateReq(t.Context(), tc.model)
+			updateReq, diags := streamprocessor.NewStreamProcessorUpdateReq(t.Context(), tc.model, &streamprocessor.TFStreamProcessorRSModel{})
 			if tc.expectedResult == "" {
 				assert.False(t, diags.HasError())
 				assert.Empty(t, updateReq.TenantName)
@@ -440,6 +453,140 @@ func TestNewStreamProcessorUpdateReq(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertOptionsToTFAutoscaling(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("round-trips autoscaling through options", func(t *testing.T) {
+		optionsTF, diags := streamprocessor.ConvertOptionsToTF(ctx, &streamOptionsWithAutoscaling)
+		require.False(t, diags.HasError())
+		require.NotNil(t, optionsTF)
+
+		optionsModel := &streamprocessor.TFOptionsModel{}
+		diags = optionsTF.As(ctx, optionsModel, basetypes.ObjectAsOptions{})
+		require.False(t, diags.HasError())
+		require.False(t, optionsModel.Autoscaling.IsNull())
+
+		autoscalingModel := &streamprocessor.TFAutoscalingModel{}
+		diags = optionsModel.Autoscaling.As(ctx, autoscalingModel, basetypes.ObjectAsOptions{})
+		require.False(t, diags.HasError())
+		assert.True(t, autoscalingModel.Enabled.ValueBool())
+		assert.Equal(t, "SP10", autoscalingModel.MinTier.ValueString())
+		assert.Equal(t, "SP50", autoscalingModel.MaxTier.ValueString())
+	})
+
+	t.Run("autoscaling is null when absent from response", func(t *testing.T) {
+		optionsTF, diags := streamprocessor.ConvertOptionsToTF(ctx, &streamOptionsExample)
+		require.False(t, diags.HasError())
+		optionsModel := &streamprocessor.TFOptionsModel{}
+		diags = optionsTF.As(ctx, optionsModel, basetypes.ObjectAsOptions{})
+		require.False(t, diags.HasError())
+		assert.True(t, optionsModel.Autoscaling.IsNull())
+	})
+}
+
+func TestEffectiveTierFromResp(t *testing.T) {
+	testCases := map[string]struct {
+		effectiveTier *string
+		tier          *string
+		expected      types.String
+	}{
+		"prefers explicit effectiveTier": {
+			effectiveTier: conversion.StringPtr("SP30"),
+			tier:          conversion.StringPtr("SP10"),
+			expected:      types.StringValue("SP30"),
+		},
+		"falls back to tier when effectiveTier is nil": {
+			effectiveTier: nil,
+			tier:          conversion.StringPtr("SP10"),
+			expected:      types.StringValue("SP10"),
+		},
+		"null when neither is set": {
+			effectiveTier: nil,
+			tier:          nil,
+			expected:      types.StringNull(),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			resp := streamProcessorWithStats(t, nil)
+			resp.Tier = tc.tier
+			resp.EffectiveTier = tc.effectiveTier
+			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(t.Context(), projectID, workspaceName, "", resp, nil, nil)
+			require.False(t, diags.HasError())
+			assert.Equal(t, tc.expected, resultModel.EffectiveTier)
+		})
+	}
+}
+
+func TestNewStreamProcessorReqAutoscaling(t *testing.T) {
+	ctx := t.Context()
+	validPipeline := jsontypes.NewNormalizedValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}}]")
+	optionsWithAutoscaling := optionsToTFModel(t, &streamOptionsWithAutoscaling)
+
+	plan := &streamprocessor.TFStreamProcessorRSModel{
+		WorkspaceName: types.StringValue(workspaceName),
+		Pipeline:      validPipeline,
+		ProcessorName: types.StringValue(processorName),
+		ProjectID:     types.StringValue(projectID),
+		Tier:          types.StringValue("SP10"),
+		Options:       optionsWithAutoscaling,
+	}
+	req, diags := streamprocessor.NewStreamProcessorReq(ctx, plan)
+	require.False(t, diags.HasError())
+	require.NotNil(t, req.Options)
+	require.NotNil(t, req.Options.Autoscaling)
+	assert.True(t, req.Options.Autoscaling.GetEnabled())
+	assert.Equal(t, "SP10", req.Options.Autoscaling.GetMinTier())
+	assert.Equal(t, "SP50", req.Options.Autoscaling.GetMaxTier())
+	assert.Equal(t, "SP10", req.GetTier())
+}
+
+func TestNewStreamProcessorUpdateReqAutoscaling(t *testing.T) {
+	ctx := t.Context()
+	validPipeline := jsontypes.NewNormalizedValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}}]")
+	optionsWithAutoscaling := optionsToTFModel(t, &streamOptionsWithAutoscaling)
+	optionsDlqOnly := optionsToTFModel(t, &streamOptionsExample)
+	optionsNull := types.ObjectNull(streamprocessor.OptionsObjectType.AttributeTypes())
+
+	base := func(options types.Object) *streamprocessor.TFStreamProcessorRSModel {
+		return &streamprocessor.TFStreamProcessorRSModel{
+			WorkspaceName: types.StringValue(workspaceName),
+			Pipeline:      validPipeline,
+			ProcessorName: types.StringValue(processorName),
+			ProjectID:     types.StringValue(projectID),
+			Options:       options,
+		}
+	}
+
+	t.Run("plan configures autoscaling => sent as configured", func(t *testing.T) {
+		req, diags := streamprocessor.NewStreamProcessorUpdateReq(ctx, base(optionsWithAutoscaling), base(optionsDlqOnly))
+		require.False(t, diags.HasError())
+		require.NotNil(t, req.StreamsModifyStreamProcessor.Options.Autoscaling)
+		assert.True(t, req.StreamsModifyStreamProcessor.Options.Autoscaling.GetEnabled())
+	})
+
+	t.Run("autoscaling removed but present in state => explicit disable", func(t *testing.T) {
+		req, diags := streamprocessor.NewStreamProcessorUpdateReq(ctx, base(optionsDlqOnly), base(optionsWithAutoscaling))
+		require.False(t, diags.HasError())
+		require.NotNil(t, req.StreamsModifyStreamProcessor.Options.Autoscaling)
+		assert.False(t, req.StreamsModifyStreamProcessor.Options.Autoscaling.GetEnabled())
+	})
+
+	t.Run("whole options block removed but autoscaling in state => explicit disable", func(t *testing.T) {
+		req, diags := streamprocessor.NewStreamProcessorUpdateReq(ctx, base(optionsNull), base(optionsWithAutoscaling))
+		require.False(t, diags.HasError())
+		require.NotNil(t, req.StreamsModifyStreamProcessor.Options)
+		require.NotNil(t, req.StreamsModifyStreamProcessor.Options.Autoscaling)
+		assert.False(t, req.StreamsModifyStreamProcessor.Options.Autoscaling.GetEnabled())
+	})
+
+	t.Run("autoscaling absent in plan and state => no autoscaling operation", func(t *testing.T) {
+		req, diags := streamprocessor.NewStreamProcessorUpdateReq(ctx, base(optionsDlqOnly), base(optionsDlqOnly))
+		require.False(t, diags.HasError())
+		assert.Nil(t, req.StreamsModifyStreamProcessor.Options.Autoscaling)
+	})
 }
 
 func TestGetWorkspaceOrInstanceName(t *testing.T) {

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -111,6 +111,13 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		if plan.Tier.ValueString() != "" {
 			startWithOptions.SetTier(plan.Tier.ValueString())
 		}
+		// On the :startWith endpoint, `autoscaling` is TOP-LEVEL (no options wrapper).
+		autoscaling, diags := autoscalingFromPlanOptions(ctx, plan.Options)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		startWithOptions.Autoscaling = autoscaling
 
 		_, err := connV2.StreamsApi.StartStreamProcessorWith(ctx, projectID, workspaceOrInstanceName, processorName, startWithOptions).Execute()
 		if err != nil {
@@ -223,7 +230,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// modify the stream processor
-	modifyAPIRequestParams, diags := NewStreamProcessorUpdateReq(ctx, &plan)
+	modifyAPIRequestParams, diags := NewStreamProcessorUpdateReq(ctx, &plan, &state)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -240,6 +247,13 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		if plan.Tier.ValueString() != "" {
 			startWithOptions.SetTier(plan.Tier.ValueString())
 		}
+		// On the :startWith endpoint, `autoscaling` is TOP-LEVEL (see create path).
+		autoscaling, diags := autoscalingFromPlanOptions(ctx, plan.Options)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		startWithOptions.Autoscaling = autoscaling
 
 		_, err := r.Client.AtlasV2.StreamsApi.StartStreamProcessorWith(ctx, projectID, workspaceOrInstanceName, processorName, startWithOptions).Execute()
 		if err != nil {

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -95,14 +95,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 					"autoscaling": schema.SingleNestedAttribute{
 						Optional:            true,
-						MarkdownDescription: "Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration.",
+						MarkdownDescription: "Vertical autoscaling configuration for the stream processor. When present, autoscaling is enabled and the processor automatically scales its tier between `min_tier` and `max_tier` based on load; `tier` is then used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). To disable autoscaling, remove this block — the backend clears the configuration on disable, so autoscaling cannot be turned off by setting `enabled = false`.",
 						Validators: []validator.Object{
-							autoscalingBoundsRequireEnabledValidator{},
+							autoscalingEnabledValidator{},
 						},
 						Attributes: map[string]schema.Attribute{
 							"enabled": schema.BoolAttribute{
 								Required:            true,
-								MarkdownDescription: "Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.",
+								MarkdownDescription: "Flag that indicates whether autoscaling is enabled. Must be `true` when the `options.autoscaling` block is present. To disable autoscaling, remove the block rather than setting this to `false` (the backend does not persist a disabled config, so `enabled = false` is rejected during planning).",
 							},
 							"min_tier": schema.StringAttribute{
 								Optional:            true,

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -18,6 +18,10 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 )
 
+// streamProcessorTiers enumerates the valid stream processor tiers, used for
+// both `tier`/`effective_tier` and the autoscaling `min_tier`/`max_tier` bounds.
+var streamProcessorTiers = []string{"SP2", "SP5", "SP10", "SP30", "SP50"}
+
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
@@ -89,6 +93,35 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Required:            true,
 						MarkdownDescription: "Dead letter queue for the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-dead-letter-queue) for more information.",
 					},
+					"autoscaling": schema.SingleNestedAttribute{
+						Optional:            true,
+						MarkdownDescription: "Vertical autoscaling configuration for the stream processor. When enabled, the processor automatically scales its tier between `min_tier` and `max_tier` based on load, and the `tier` attribute is used only as the initial/baseline tier (the tier it is actually running on is reported by `effective_tier`). Removing this block or setting `enabled` to `false` disables autoscaling and clears its configuration.",
+						Validators: []validator.Object{
+							autoscalingBoundsRequireEnabledValidator{},
+						},
+						Attributes: map[string]schema.Attribute{
+							"enabled": schema.BoolAttribute{
+								Required:            true,
+								MarkdownDescription: "Flag that indicates whether autoscaling is enabled. Set to `true` to enable autoscaling. Setting it to `false` (or removing the `options.autoscaling` block) disables autoscaling and clears its persisted configuration.",
+							},
+							"min_tier": schema.StringAttribute{
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "Tier floor for autoscaling (scale-down limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace default tier.",
+								Validators: []validator.String{
+									stringvalidator.OneOf(streamProcessorTiers...),
+								},
+							},
+							"max_tier": schema.StringAttribute{
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "Tier ceiling for autoscaling (scale-up limit). Valid options are SP2, SP5, SP10, SP30, and SP50. When not set, it defaults to the workspace maximum tier.",
+								Validators: []validator.String{
+									stringvalidator.OneOf(streamProcessorTiers...),
+								},
+							},
+						},
+					},
 				},
 			},
 			"stats": schema.StringAttribute{
@@ -98,7 +131,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"tier": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50.",
+				MarkdownDescription: "Selected tier to start a stream processor on rather than defaulting to the workspace setting. Configures Memory / VCPU allowances. Valid options are SP2, SP5, SP10, SP30, and SP50. When `options.autoscaling` is enabled, this is used only as the initial/baseline tier; the running tier is reported by `effective_tier`.",
+			},
+			"effective_tier": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Tier the stream processor is currently running on. When autoscaling is disabled this equals `tier`; when autoscaling is enabled it reflects the tier chosen by the autoscaler within the configured bounds.",
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create:            true,
@@ -127,12 +164,14 @@ type TFStreamProcessorRSModel struct {
 	State                 types.String         `tfsdk:"state"`
 	Stats                 types.String         `tfsdk:"stats"`
 	Tier                  types.String         `tfsdk:"tier"`
+	EffectiveTier         types.String         `tfsdk:"effective_tier"`
 	Timeouts              timeouts.Value       `tfsdk:"timeouts"`
 	DeleteOnCreateTimeout types.Bool           `tfsdk:"delete_on_create_timeout"`
 }
 
 type TFOptionsModel struct {
-	Dlq types.Object `tfsdk:"dlq"`
+	Dlq         types.Object `tfsdk:"dlq"`
+	Autoscaling types.Object `tfsdk:"autoscaling"`
 }
 
 type TFDlqModel struct {
@@ -142,7 +181,8 @@ type TFDlqModel struct {
 }
 
 var OptionsObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	"dlq": DlqObjectType,
+	"dlq":         DlqObjectType,
+	"autoscaling": AutoscalingObjectType,
 }}
 
 var DlqObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
@@ -163,6 +203,7 @@ type TFStreamProcessorDSModel struct {
 	State         types.String `tfsdk:"state"`
 	Stats         types.String `tfsdk:"stats"`
 	Tier          types.String `tfsdk:"tier"`
+	EffectiveTier types.String `tfsdk:"effective_tier"`
 }
 
 type TFStreamProcessorsDSModel struct {

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -85,6 +85,62 @@ func TestAccStreamProcessor_withTier(t *testing.T) {
 		}})
 }
 
+func TestAccStreamProcessor_withAutoscaling(t *testing.T) {
+	var (
+		projectID, workspaceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		_, clusterName           = acc.ClusterNameExecution(t, false)
+		randomSuffix             = acctest.RandString(5)
+		processorName            = "new-processor-autoscaling" + randomSuffix
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithAutoscaling(t, projectID, workspaceName, clusterName, processorName, "SP10", "SP50", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.min_tier", "SP10"),
+					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.max_tier", "SP50"),
+					resource.TestCheckResourceAttrSet(resourceName, "effective_tier"),
+				),
+			},
+			{
+				// Removing the autoscaling block disables autoscaling.
+				Config: configWithAutoscaling(t, projectID, workspaceName, clusterName, processorName, "", "", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckNoResourceAttr(resourceName, "options.autoscaling"),
+				),
+			},
+			importStep(),
+		}})
+}
+
+// TestAccStreamProcessor_autoscalingBoundsRequireEnabled verifies the plan-time validator
+// rejects tier bounds when autoscaling is disabled.
+func TestAccStreamProcessor_autoscalingBoundsRequireEnabled(t *testing.T) {
+	var (
+		projectID, workspaceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		_, clusterName           = acc.ClusterNameExecution(t, false)
+		processorName            = "new-processor-autoscaling-invalid" + acctest.RandString(5)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config:      configWithAutoscaling(t, projectID, workspaceName, clusterName, processorName, "SP10", "SP50", false),
+				ExpectError: regexp.MustCompile("can only be set when `enabled` is `true`"),
+			},
+		}})
+}
+
 func basicTestCase(t *testing.T) *resource.TestCase {
 	t.Helper()
 	var (
@@ -739,6 +795,68 @@ func configWithTier(t *testing.T, projectID, workspaceName, processorName, tier 
 		depends_on     = [mongodbatlas_stream_processor.processor]
 	}
 	`, projectID, workspaceName, processorName, tier)
+}
+
+// configWithAutoscaling builds a processor whose DLQ points at a cluster connection.
+// When enabled is true the options.autoscaling block is included with the given bounds;
+// when false and both tiers are empty the block is omitted (autoscaling disabled). When
+// enabled is false but bounds are provided, the (invalid) block is emitted to exercise the
+// plan-time validator.
+func configWithAutoscaling(t *testing.T, projectID, workspaceName, clusterName, processorName, minTier, maxTier string, enabled bool) string {
+	t.Helper()
+
+	autoscalingBlock := ""
+	if enabled || minTier != "" || maxTier != "" {
+		bounds := ""
+		if minTier != "" {
+			bounds += fmt.Sprintf("\n\t\t\t\tmin_tier = %[1]q", minTier)
+		}
+		if maxTier != "" {
+			bounds += fmt.Sprintf("\n\t\t\t\tmax_tier = %[1]q", maxTier)
+		}
+		autoscalingBlock = fmt.Sprintf(`
+			autoscaling = {
+				enabled = %[1]t%[2]s
+			}`, enabled, bounds)
+	}
+
+	return fmt.Sprintf(`
+	resource "mongodbatlas_stream_connection" "cluster" {
+		project_id      = %[1]q
+		workspace_name  = %[2]q
+		connection_name = "ClusterConnection"
+		type            = "Cluster"
+		cluster_name    = %[3]q
+		db_role_to_execute = {
+			role = "atlasAdmin"
+			type = "BUILT_IN"
+		}
+	}
+
+	resource "mongodbatlas_stream_processor" "processor" {
+		project_id     = %[1]q
+		workspace_name = %[2]q
+		processor_name = %[4]q
+		pipeline = jsonencode([
+			{ "$source" = { "connectionName" = mongodbatlas_stream_connection.cluster.connection_name, "db" = "sample", "coll" = "solar" } },
+			{ "$emit" = { "connectionName" = "__testLog" } }
+		])
+		tier = "SP10"
+		options = {
+			dlq = {
+				coll            = "dlq_coll"
+				connection_name = mongodbatlas_stream_connection.cluster.connection_name
+				db              = "dlq_db"
+			}%[5]s
+		}
+	}
+
+	data "mongodbatlas_stream_processor" "test" {
+		project_id     = mongodbatlas_stream_processor.processor.project_id
+		workspace_name = mongodbatlas_stream_processor.processor.workspace_name
+		processor_name = mongodbatlas_stream_processor.processor.processor_name
+	}
+	`, projectID, workspaceName, clusterName, processorName, autoscalingBlock)
 }
 
 func configMigration(t *testing.T, projectID, instanceName, processorName, state, nameSuffix string, src, dest connectionConfig, timeoutConfig string, deleteOnCreateTimeout *bool) string {

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -120,9 +120,9 @@ func TestAccStreamProcessor_withAutoscaling(t *testing.T) {
 		}})
 }
 
-// TestAccStreamProcessor_autoscalingBoundsRequireEnabled verifies the plan-time validator
-// rejects tier bounds when autoscaling is disabled.
-func TestAccStreamProcessor_autoscalingBoundsRequireEnabled(t *testing.T) {
+// TestAccStreamProcessor_autoscalingDisabledRejected verifies the plan-time validator rejects
+// `enabled = false`; disabling is done by removing the options.autoscaling block instead.
+func TestAccStreamProcessor_autoscalingDisabledRejected(t *testing.T) {
 	var (
 		projectID, workspaceName = acc.ProjectIDExecutionWithStreamInstance(t)
 		_, clusterName           = acc.ClusterNameExecution(t, false)
@@ -135,8 +135,9 @@ func TestAccStreamProcessor_autoscalingBoundsRequireEnabled(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
+				// bounds present forces the block to be emitted with enabled = false, which the validator rejects.
 				Config:      configWithAutoscaling(t, projectID, workspaceName, clusterName, processorName, "SP10", "SP50", false),
-				ExpectError: regexp.MustCompile("can only be set when `enabled` is `true`"),
+				ExpectError: regexp.MustCompile("remove the `options.autoscaling` block"),
 			},
 		}})
 }


### PR DESCRIPTION
## Summary

Adds Phase 1 vertical autoscaling support to `mongodbatlas_stream_processor` and its singular and plural data sources:

- `options.autoscaling` block with `enabled`, `min_tier`, and `max_tier`
- computed, read-only `effective_tier`, which reports the processor's current running tier
- `tier` remains the user-configured baseline tier; it does not autoscale or drift

## Included

- Resource and data-source schema, model, conversion, and CRUD updates.
- Declarative disable behavior: removing `options.autoscaling` sends explicit `enabled: false` on PATCH. The provider rejects `enabled = false` in configuration because disabled autoscaling is cleared by the backend and cannot round-trip in Terraform state.
- Correct API shape for `:startWith`, where autoscaling is top-level rather than nested in `options`.
- Unit and acceptance coverage for conversions, `effective_tier`, create/update requests, enablement, block-removal disablement, and invalid configuration.
- Regenerated documentation, example configuration, and release-note entries.

## Draft status / dependency

This PR is intentionally a draft. It is waiting for the **Atlas Go SDK release generated from the `v20260819` MMS release**, which contains the required OpenAPI changes for stream-processor autoscaling and `effectiveTier`.

Until that SDK is available, this branch uses an uncommitted local SDK stub for development only; CI will not build this feature from a clean checkout. Before this PR leaves draft, we will:

1. Update to the released Atlas Go SDK containing the `v20260819` OpenAPI changes.
2. Remove the local SDK stub and local `go.mod` replacement.
3. Run targeted unit tests and acceptance tests against an environment with the Phase 1 autoscaling flag enabled.

**Expected Terraform release: August 27, 2026.**
