### PR TITLE
test: Remove orphan project in cloud user project assignment test

### DIFF
--- a/internal/service/clouduserprojectassignment/resource_test.go
+++ b/internal/service/clouduserprojectassignment/resource_test.go
@@ -105,26 +105,25 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 
 func errorTestCase(t *testing.T) *resource.TestCase {
 	t.Helper()
-	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	projectID := acc.ProjectIDExecution(t)
 	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config:      configError(orgID, projectID),
+				Config:      configError(projectID),
 				ExpectError: regexp.MustCompile("either username or user_id must be provided"),
 			},
 		},
 	}
 }
 
-func configError(orgID, projectID string) string {
+func configError(projectID string) string {
 	return fmt.Sprintf(`
 		data "mongodbatlas_cloud_user_project_assignment" "test" {
 			project_id = %[1]q
 		}
-	`, projectID, orgID)
+	`, projectID)
 }
 
 func configBasic(pendingUsername, activeUsername, projectID string, roles []string) string {

--- a/internal/service/clouduserprojectassignment/resource_test.go
+++ b/internal/service/clouduserprojectassignment/resource_test.go
@@ -35,7 +35,6 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 	activeUsername := os.Getenv("MONGODB_ATLAS_USERNAME_2")
 	pendingUsername := acc.RandomEmail()
 	projectID := acc.ProjectIDExecution(t)
-	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	roles := []string{"GROUP_OWNER", "GROUP_CLUSTER_MANAGER"}
 	updatedRoles := []string{"GROUP_OWNER", "GROUP_SEARCH_INDEX_EDITOR", "GROUP_READ_ONLY"}
 
@@ -45,11 +44,11 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(orgID, pendingUsername, activeUsername, projectID, roles),
+				Config: configBasic(pendingUsername, activeUsername, projectID, roles),
 				Check:  checks(pendingUsername, activeUsername, projectID, roles),
 			},
 			{
-				Config: configBasic(orgID, pendingUsername, activeUsername, projectID, updatedRoles),
+				Config: configBasic(pendingUsername, activeUsername, projectID, updatedRoles),
 				Check:  checks(pendingUsername, activeUsername, projectID, updatedRoles),
 			},
 			{
@@ -128,24 +127,19 @@ func configError(orgID, projectID string) string {
 	`, projectID, orgID)
 }
 
-func configBasic(orgID, pendingUsername, activeUsername, projectID string, roles []string) string {
+func configBasic(pendingUsername, activeUsername, projectID string, roles []string) string {
 	rolesStr := `"` + strings.Join(roles, `", "`) + `"`
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "test" {
-			name   = %[1]q
-			org_id = %[2]q
-		}
-
 		resource "mongodbatlas_cloud_user_project_assignment" "test_pending" {
-			username = %[3]q
+			username = %[2]q
 			project_id = %[1]q
-			roles = [%[5]s]
+			roles = [%[4]s]
 		}
 
 		resource "mongodbatlas_cloud_user_project_assignment" "test_active" {
-			username = %[4]q
+			username = %[3]q
 			project_id = %[1]q
-			roles = [%[5]s]
+			roles = [%[4]s]
 		}
 
 		data "mongodbatlas_cloud_user_project_assignment" "test_username" {
@@ -157,7 +151,7 @@ func configBasic(orgID, pendingUsername, activeUsername, projectID string, roles
 			project_id = %[1]q
 			user_id = mongodbatlas_cloud_user_project_assignment.test_pending.user_id
 		}`,
-		projectID, orgID, pendingUsername, activeUsername, rolesStr)
+		projectID, pendingUsername, activeUsername, rolesStr)
 }
 
 func checks(pendingUsername, activeUsername, projectID string, roles []string) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

`configBasic` in the cloud user project assignment test declared an inline `mongodbatlas_project "test"` block whose `name` was set from the misaligned `%[1]` arg — which is `projectID` (an existing shared project's 24-char hex ID). This provisioned a redundant, unreferenced project named like `697ff214197cc66080b0d916` on every run of `TestAccCloudUserProjectAssignment_basic` and `TestMigCloudUserProjectAssignmentRS_basic`. That name carries none of the org-cleanup bot prefixes (`test-acc-tf-p-`, `cfn-`, `ct-`), so the nightly org cleanup skips it as "not bot project" and it leaks indefinitely, contributing to `MAX_GROUPS_PER_ORG_EXCEEDED` saturation.

The block was dead code — the assignments already reference the shared `projectID` directly, not `mongodbatlas_project.test.id`. This removes the block and the now-unused `orgID` plumbing. Test-infrastructure only; no provider behavior change.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
