### PR TITLE
feat: IAM/mTLS auth for Kafka connections and TLS/IAM for MSK private link (CLOUDP-417873)

### DIFF
--- a/.changelog/4565.txt
+++ b/.changelog/4565.txt
@@ -11,7 +11,7 @@ data-source/mongodbatlas_stream_connections: Adds `authentication.aws` attribute
 ```
 
 ```release-note:enhancement
-resource/mongodbatlas_stream_privatelink_endpoint: Adds `authentication_scheme` attribute to support TLS and IAM authentication for MSK Private Link connections
+resource/mongodbatlas_stream_privatelink_endpoint: Adds `authentication_scheme` attribute to support `SASL/SCRAM`, `TLS`, and `IAM` authentication for MSK Private Link connections (defaults to `SASL/SCRAM`)
 ```
 
 ```release-note:enhancement

--- a/.changelog/4565.txt
+++ b/.changelog/4565.txt
@@ -1,13 +1,13 @@
 ```release-note:enhancement
-resource/mongodbatlas_stream_connection: Adds support for IAM (`AWS_MSK_IAM`) and mutual TLS authentication for Kafka connections via the new `authentication.ssl_certificate`, `authentication.ssl_key`, `authentication.ssl_key_password`, and `authentication.aws` attributes
+resource/mongodbatlas_stream_connection: Adds support for IAM (`AWS_MSK_IAM`) authentication for Kafka connections via the new `authentication.aws` attribute
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_stream_connection: Adds `authentication.ssl_certificate`, `authentication.ssl_key`, `authentication.ssl_key_password`, and `authentication.aws` attributes
+data-source/mongodbatlas_stream_connection: Adds `authentication.aws` attribute
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_stream_connections: Adds `authentication.ssl_certificate`, `authentication.ssl_key`, `authentication.ssl_key_password`, and `authentication.aws` attributes
+data-source/mongodbatlas_stream_connections: Adds `authentication.aws` attribute
 ```
 
 ```release-note:enhancement

--- a/.changelog/4565.txt
+++ b/.changelog/4565.txt
@@ -1,0 +1,23 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds support for IAM (`AWS_MSK_IAM`) and mutual TLS authentication for Kafka connections via the new `authentication.ssl_certificate`, `authentication.ssl_key`, `authentication.ssl_key_password`, and `authentication.aws` attributes
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connection: Adds `authentication.ssl_certificate`, `authentication.ssl_key`, `authentication.ssl_key_password`, and `authentication.aws` attributes
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connections: Adds `authentication.ssl_certificate`, `authentication.ssl_key`, `authentication.ssl_key_password`, and `authentication.aws` attributes
+```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_privatelink_endpoint: Adds `authentication_scheme` attribute to support TLS and IAM authentication for MSK Private Link connections
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_privatelink_endpoint: Adds `authentication_scheme` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_privatelink_endpoints: Adds `authentication_scheme` attribute
+```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -90,9 +90,6 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Scope of the access request to the broker specified by the Kafka clients.
 * `sasl_oauthbearer_extensions` - Additional information to provide to the Kafka broker.
-* `ssl_certificate` - SSL certificate for client authentication to Kafka (mutual TLS).
-* `ssl_key` - SSL key for client authentication to Kafka (mutual TLS). This is a write-only value that is not returned by the API.
-* `ssl_key_password` - Password for the SSL key, if it is password protected. This is a write-only value that is not returned by the API.
 * `aws` - AWS configuration used for `AWS_MSK_IAM` authentication. See [authentication AWS](#authentication-aws).
 
 ### Authentication AWS

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -81,7 +81,7 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 
 ### Authentication
 
-* `mechanism` - Method of authentication. Value can be `PLAIN`, `SCRAM-256`, `SCRAM-512`, or `OAUTHBEARER`.
+* `mechanism` - Method of authentication. Value can be `PLAIN`, `SCRAM-256`, `SCRAM-512`, `OAUTHBEARER`, or `AWS_MSK_IAM`.
 * `method` - SASL OAUTHBEARER authentication method. Value must be OIDC.
 * `username` - Username of the account to connect to the Kafka cluster.
 * `password` - Password of the account to connect to the Kafka cluster.
@@ -90,6 +90,13 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Scope of the access request to the broker specified by the Kafka clients.
 * `sasl_oauthbearer_extensions` - Additional information to provide to the Kafka broker.
+* `ssl_certificate` - SSL certificate for client authentication to Kafka (mutual TLS).
+* `ssl_key` - SSL key for client authentication to Kafka (mutual TLS). This is a write-only value that is not returned by the API.
+* `ssl_key_password` - Password for the SSL key, if it is password protected. This is a write-only value that is not returned by the API.
+* `aws` - AWS configuration used for `AWS_MSK_IAM` authentication. See [authentication AWS](#authentication-aws).
+
+### Authentication AWS
+* `role_arn` - Amazon Resource Name (ARN) that identifies the AWS IAM role that MongoDB Cloud assumes to authenticate to the Amazon MSK cluster.
 
 ### Security
 

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -92,9 +92,6 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Scope of the access request to the broker specified by the Kafka clients.
 * `sasl_oauthbearer_extensions` - Additional information to provide to the Kafka broker.
-* `ssl_certificate` - SSL certificate for client authentication to Kafka (mutual TLS).
-* `ssl_key` - SSL key for client authentication to Kafka (mutual TLS). This is a write-only value that is not returned by the API.
-* `ssl_key_password` - Password for the SSL key, if it is password protected. This is a write-only value that is not returned by the API.
 * `aws` - AWS configuration used for `AWS_MSK_IAM` authentication. See [authentication AWS](#authentication-aws).
 
 ### Authentication AWS

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -83,7 +83,7 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 
 ### Authentication
 
-* `mechanism` - Method of authentication. Value can be `PLAIN`, `SCRAM-256`, `SCRAM-512`, or `OAUTHBEARER`.
+* `mechanism` - Method of authentication. Value can be `PLAIN`, `SCRAM-256`, `SCRAM-512`, `OAUTHBEARER`, or `AWS_MSK_IAM`.
 * `method` - SASL OAUTHBEARER authentication method. Value must be OIDC.
 * `username` - Username of the account to connect to the Kafka cluster.
 * `password` - Password of the account to connect to the Kafka cluster.
@@ -92,6 +92,13 @@ If `type` is of value `SchemaRegistry` the following additional attributes are d
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Scope of the access request to the broker specified by the Kafka clients.
 * `sasl_oauthbearer_extensions` - Additional information to provide to the Kafka broker.
+* `ssl_certificate` - SSL certificate for client authentication to Kafka (mutual TLS).
+* `ssl_key` - SSL key for client authentication to Kafka (mutual TLS). This is a write-only value that is not returned by the API.
+* `ssl_key_password` - Password for the SSL key, if it is password protected. This is a write-only value that is not returned by the API.
+* `aws` - AWS configuration used for `AWS_MSK_IAM` authentication. See [authentication AWS](#authentication-aws).
+
+### Authentication AWS
+* `role_arn` - Amazon Resource Name (ARN) that identifies the AWS IAM role that MongoDB Cloud assumes to authenticate to the Amazon MSK cluster.
 
 ### Security
 

--- a/docs/data-sources/stream_privatelink_endpoint.md
+++ b/docs/data-sources/stream_privatelink_endpoint.md
@@ -391,7 +391,7 @@ output "privatelink_endpoint_id" {
 ### Read-Only
 
 - `arn` (String) Amazon Resource Name (ARN). Required for AWS Provider and MSK vendor.
-- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.
+- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Only applies when the vendor is `MSK`. Valid values are `SASL/SCRAM`, `TLS`, and `IAM`. Defaults to `SASL/SCRAM` when not specified.
 - `dns_domain` (String) The domain hostname. Optional for AWS Confluent Enterprise Kafka Cluster. Required for the following provider and vendor combinations:
 
 	* AWS provider with CONFLUENT vendor for Dedicated Kafka Cluster.

--- a/docs/data-sources/stream_privatelink_endpoint.md
+++ b/docs/data-sources/stream_privatelink_endpoint.md
@@ -391,6 +391,7 @@ output "privatelink_endpoint_id" {
 ### Read-Only
 
 - `arn` (String) Amazon Resource Name (ARN). Required for AWS Provider and MSK vendor.
+- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.
 - `dns_domain` (String) The domain hostname. Optional for AWS Confluent Enterprise Kafka Cluster. Required for the following provider and vendor combinations:
 
 	* AWS provider with CONFLUENT vendor for Dedicated Kafka Cluster.

--- a/docs/data-sources/stream_privatelink_endpoints.md
+++ b/docs/data-sources/stream_privatelink_endpoints.md
@@ -397,7 +397,7 @@ output "privatelink_endpoint_id" {
 Read-Only:
 
 - `arn` (String) Amazon Resource Name (ARN). Required for AWS Provider and MSK vendor.
-- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.
+- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Only applies when the vendor is `MSK`. Valid values are `SASL/SCRAM`, `TLS`, and `IAM`. Defaults to `SASL/SCRAM` when not specified.
 - `dns_domain` (String) The domain hostname. Optional for AWS Confluent Enterprise Kafka Cluster. Required for the following provider and vendor combinations:
 
 	* AWS provider with CONFLUENT vendor for Dedicated Kafka Cluster.

--- a/docs/data-sources/stream_privatelink_endpoints.md
+++ b/docs/data-sources/stream_privatelink_endpoints.md
@@ -397,6 +397,7 @@ output "privatelink_endpoint_id" {
 Read-Only:
 
 - `arn` (String) Amazon Resource Name (ARN). Required for AWS Provider and MSK vendor.
+- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.
 - `dns_domain` (String) The domain hostname. Optional for AWS Confluent Enterprise Kafka Cluster. Required for the following provider and vendor combinations:
 
 	* AWS provider with CONFLUENT vendor for Dedicated Kafka Cluster.

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -386,7 +386,7 @@ If `type` is of value `SchemaRegistry` the following additional arguments are de
 
 ### Authentication
 
-* `mechanism` - Method of authentication. Value can be `PLAIN`, `SCRAM-256`, `SCRAM-512`, or `OAUTHBEARER`.
+* `mechanism` - Method of authentication. Value can be `PLAIN`, `SCRAM-256`, `SCRAM-512`, `OAUTHBEARER`, or `AWS_MSK_IAM`.
 * `method` - SASL OAUTHBEARER authentication method. Value must be OIDC.
 * `username` - Username of the account to connect to the Kafka cluster.
 * `password` - Password of the account to connect to the Kafka cluster.
@@ -395,6 +395,13 @@ If `type` is of value `SchemaRegistry` the following additional arguments are de
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Scope of the access request to the broker specified by the Kafka clients.
 * `sasl_oauthbearer_extensions` - Additional information to provide to the Kafka broker.
+* `ssl_certificate` - SSL certificate for client authentication to Kafka (mutual TLS). Used when `mechanism` relies on client certificate authentication.
+* `ssl_key` - SSL key for client authentication to Kafka (mutual TLS). This is a write-only value that is not returned by the API.
+* `ssl_key_password` - Password for the SSL key, if it is password protected. This is a write-only value that is not returned by the API.
+* `aws` - AWS configuration used for `AWS_MSK_IAM` authentication to an Amazon MSK cluster. See [authentication AWS](#authentication-aws).
+
+### Authentication AWS
+* `role_arn` - Amazon Resource Name (ARN) that identifies the AWS IAM role that MongoDB Cloud assumes to authenticate to the Amazon MSK cluster.
 
 ### Security
 

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -395,9 +395,6 @@ If `type` is of value `SchemaRegistry` the following additional arguments are de
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Scope of the access request to the broker specified by the Kafka clients.
 * `sasl_oauthbearer_extensions` - Additional information to provide to the Kafka broker.
-* `ssl_certificate` - SSL certificate for client authentication to Kafka (mutual TLS). Used when `mechanism` relies on client certificate authentication.
-* `ssl_key` - SSL key for client authentication to Kafka (mutual TLS). This is a write-only value that is not returned by the API.
-* `ssl_key_password` - Password for the SSL key, if it is password protected. This is a write-only value that is not returned by the API.
 * `aws` - AWS configuration used for `AWS_MSK_IAM` authentication to an Amazon MSK cluster. See [authentication AWS](#authentication-aws).
 
 ### Authentication AWS

--- a/docs/resources/stream_privatelink_endpoint.md
+++ b/docs/resources/stream_privatelink_endpoint.md
@@ -411,6 +411,7 @@ output "privatelink_endpoint_id" {
 ### Optional
 
 - `arn` (String) Amazon Resource Name (ARN). Required for AWS Provider and MSK vendor.
+- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.
 - `dns_domain` (String) The domain hostname. Optional for AWS Confluent Enterprise Kafka Cluster. Required for the following provider and vendor combinations:
 
 	* AWS provider with CONFLUENT vendor for Dedicated Kafka Cluster.

--- a/docs/resources/stream_privatelink_endpoint.md
+++ b/docs/resources/stream_privatelink_endpoint.md
@@ -411,7 +411,7 @@ output "privatelink_endpoint_id" {
 ### Optional
 
 - `arn` (String) Amazon Resource Name (ARN). Required for AWS Provider and MSK vendor.
-- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.
+- `authentication_scheme` (String) Authentication mechanism to use with this private link connection. Only applies when the vendor is `MSK`. Valid values are `SASL/SCRAM`, `TLS`, and `IAM`. Defaults to `SASL/SCRAM` when not specified.
 - `dns_domain` (String) The domain hostname. Optional for AWS Confluent Enterprise Kafka Cluster. Required for the following provider and vendor combinations:
 
 	* AWS provider with CONFLUENT vendor for Dedicated Kafka Cluster.

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -104,6 +104,48 @@ resource "mongodbatlas_stream_connection" "example-kafka-ssl" {
   }
 }
 
+# Kafka connection using AWS MSK IAM authentication
+resource "mongodbatlas_stream_connection" "example-kafka-iam" {
+  project_id      = var.project_id
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "KafkaIAMConnection"
+  type            = "Kafka"
+  authentication = {
+    mechanism = "AWS_MSK_IAM"
+    aws = {
+      role_arn = var.kafka_iam_role_arn
+    }
+  }
+  bootstrap_servers = "b-1.example.kafka.us-east-1.amazonaws.com:9098"
+  config = {
+    "auto.offset.reset" : "earliest"
+  }
+  security = {
+    protocol = "SASL_SSL"
+  }
+}
+
+# Kafka connection using mutual TLS (client certificate) authentication
+resource "mongodbatlas_stream_connection" "example-kafka-mtls" {
+  project_id      = var.project_id
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "KafkaMTLSConnection"
+  type            = "Kafka"
+  authentication = {
+    ssl_certificate  = var.kafka_ssl_certificate
+    ssl_key          = var.kafka_ssl_key
+    ssl_key_password = var.kafka_ssl_key_password
+  }
+  bootstrap_servers = "localhost:9092"
+  config = {
+    "auto.offset.reset" : "earliest"
+  }
+  security = {
+    broker_public_certificate = var.kafka_ssl_cert
+    protocol                  = "SSL"
+  }
+}
+
 resource "mongodbatlas_stream_connection" "example-azure-blob-storage" {
   project_id      = var.project_id
   workspace_name  = mongodbatlas_stream_instance.example.instance_name

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -125,27 +125,6 @@ resource "mongodbatlas_stream_connection" "example-kafka-iam" {
   }
 }
 
-# Kafka connection using mutual TLS (client certificate) authentication
-resource "mongodbatlas_stream_connection" "example-kafka-mtls" {
-  project_id      = var.project_id
-  workspace_name  = mongodbatlas_stream_instance.example.instance_name
-  connection_name = "KafkaMTLSConnection"
-  type            = "Kafka"
-  authentication = {
-    ssl_certificate  = var.kafka_ssl_certificate
-    ssl_key          = var.kafka_ssl_key
-    ssl_key_password = var.kafka_ssl_key_password
-  }
-  bootstrap_servers = "localhost:9092"
-  config = {
-    "auto.offset.reset" : "earliest"
-  }
-  security = {
-    broker_public_certificate = var.kafka_ssl_cert
-    protocol                  = "SSL"
-  }
-}
-
 resource "mongodbatlas_stream_connection" "example-azure-blob-storage" {
   project_id      = var.project_id
   workspace_name  = mongodbatlas_stream_instance.example.instance_name

--- a/examples/mongodbatlas_stream_connection/variables.tf
+++ b/examples/mongodbatlas_stream_connection/variables.tf
@@ -83,23 +83,3 @@ variable "kafka_iam_role_arn" {
   type        = string
   default     = ""
 }
-
-variable "kafka_ssl_certificate" {
-  description = "SSL certificate for client authentication to Kafka (mutual TLS)"
-  type        = string
-  default     = ""
-}
-
-variable "kafka_ssl_key" {
-  description = "SSL key for client authentication to Kafka (mutual TLS)"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
-
-variable "kafka_ssl_key_password" {
-  description = "Password for the SSL key, if it is password protected"
-  type        = string
-  sensitive   = true
-  default     = ""
-}

--- a/examples/mongodbatlas_stream_connection/variables.tf
+++ b/examples/mongodbatlas_stream_connection/variables.tf
@@ -77,3 +77,29 @@ variable "schema_registry_password" {
   sensitive   = true
   default     = ""
 }
+
+variable "kafka_iam_role_arn" {
+  description = "ARN of the AWS IAM role that MongoDB Cloud assumes to authenticate to an Amazon MSK cluster (AWS_MSK_IAM)"
+  type        = string
+  default     = ""
+}
+
+variable "kafka_ssl_certificate" {
+  description = "SSL certificate for client authentication to Kafka (mutual TLS)"
+  type        = string
+  default     = ""
+}
+
+variable "kafka_ssl_key" {
+  description = "SSL key for client authentication to Kafka (mutual TLS)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "kafka_ssl_key_password" {
+  description = "Password for the SSL key, if it is password protected"
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/examples/mongodbatlas_stream_privatelink_endpoint/aws_msk_cluster/main.tf
+++ b/examples/mongodbatlas_stream_privatelink_endpoint/aws_msk_cluster/main.tf
@@ -106,10 +106,11 @@ PROPERTIES
 }
 
 resource "mongodbatlas_stream_privatelink_endpoint" "test" {
-  project_id    = var.project_id
-  provider_name = "AWS"
-  vendor        = "MSK"
-  arn           = aws_msk_cluster.example.arn
+  project_id            = var.project_id
+  provider_name         = "AWS"
+  vendor                = "MSK"
+  arn                   = aws_msk_cluster.example.arn
+  authentication_scheme = "IAM" # authentication mechanism for MSK. Valid values are TLS and IAM.
 }
 
 data "mongodbatlas_stream_privatelink_endpoint" "singular_datasource" {

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -38,6 +38,20 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 			ClientSecret:              authenticationModel.ClientSecret.ValueStringPointer(),
 			Scope:                     authenticationModel.Scope.ValueStringPointer(),
 			SaslOauthbearerExtensions: authenticationModel.SaslOauthbearerExtensions.ValueStringPointer(),
+			SslCertificate:            authenticationModel.SSLCertificate.ValueStringPointer(),
+			SslKey:                    authenticationModel.SSLKey.ValueStringPointer(),
+			SslKeyPassword:            authenticationModel.SSLKeyPassword.ValueStringPointer(),
+		}
+		// authentication.aws is a nested block used for AWS_MSK_IAM authentication,
+		// distinct from the top-level aws block used by other connection types.
+		if !authenticationModel.AWS.IsNull() && !authenticationModel.AWS.IsUnknown() {
+			awsModel := &TFAWSModel{}
+			if diags := authenticationModel.AWS.As(ctx, awsModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+				return nil, diags
+			}
+			streamConnection.Authentication.Aws = &admin.StreamsAWSConnectionConfig{
+				RoleArn: awsModel.RoleArn.ValueStringPointer(),
+			}
 		}
 	}
 	if !plan.Security.IsNull() {
@@ -371,6 +385,24 @@ func newTFConnectionAuthenticationModel(ctx context.Context, currAuthConfig *typ
 			ClientID:                  types.StringPointerValue(authResp.ClientId),
 			Scope:                     types.StringPointerValue(authResp.Scope),
 			SaslOauthbearerExtensions: types.StringPointerValue(authResp.SaslOauthbearerExtensions),
+			SSLCertificate:            types.StringPointerValue(authResp.SslCertificate),
+			// ssl_key and ssl_key_password are write-only and not returned by the API;
+			// they are preserved from prior config below when available.
+			SSLKey:         types.StringNull(),
+			SSLKeyPassword: types.StringNull(),
+			// aws is always set to a typed value (real object or typed null) so the
+			// parent authentication object type is always satisfied.
+			AWS: types.ObjectNull(AWSObjectType.AttrTypes),
+		}
+
+		if authResp.Aws != nil {
+			awsObject, diags := types.ObjectValueFrom(ctx, AWSObjectType.AttrTypes, TFAWSModel{
+				RoleArn: types.StringPointerValue(authResp.Aws.RoleArn),
+			})
+			if diags.HasError() {
+				return nil, diags
+			}
+			resultAuthModel.AWS = awsObject
 		}
 
 		if currAuthConfig != nil && !currAuthConfig.IsNull() { // if config is available (create & update of resource) password value is set in new state
@@ -380,6 +412,8 @@ func newTFConnectionAuthenticationModel(ctx context.Context, currAuthConfig *typ
 			}
 			resultAuthModel.Password = configAuthModel.Password
 			resultAuthModel.ClientSecret = configAuthModel.ClientSecret
+			resultAuthModel.SSLKey = configAuthModel.SSLKey
+			resultAuthModel.SSLKeyPassword = configAuthModel.SSLKeyPassword
 		}
 
 		resultObject, diags := types.ObjectValueFrom(ctx, ConnectionAuthenticationObjectType.AttrTypes, resultAuthModel)

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -38,9 +38,6 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 			ClientSecret:              authenticationModel.ClientSecret.ValueStringPointer(),
 			Scope:                     authenticationModel.Scope.ValueStringPointer(),
 			SaslOauthbearerExtensions: authenticationModel.SaslOauthbearerExtensions.ValueStringPointer(),
-			SslCertificate:            authenticationModel.SSLCertificate.ValueStringPointer(),
-			SslKey:                    authenticationModel.SSLKey.ValueStringPointer(),
-			SslKeyPassword:            authenticationModel.SSLKeyPassword.ValueStringPointer(),
 		}
 		// authentication.aws is a nested block used for AWS_MSK_IAM authentication,
 		// distinct from the top-level aws block used by other connection types.
@@ -385,11 +382,6 @@ func newTFConnectionAuthenticationModel(ctx context.Context, currAuthConfig *typ
 			ClientID:                  types.StringPointerValue(authResp.ClientId),
 			Scope:                     types.StringPointerValue(authResp.Scope),
 			SaslOauthbearerExtensions: types.StringPointerValue(authResp.SaslOauthbearerExtensions),
-			SSLCertificate:            types.StringPointerValue(authResp.SslCertificate),
-			// ssl_key and ssl_key_password are write-only and not returned by the API;
-			// they are preserved from prior config below when available.
-			SSLKey:         types.StringNull(),
-			SSLKeyPassword: types.StringNull(),
 			// aws is always set to a typed value (real object or typed null) so the
 			// parent authentication object type is always satisfied.
 			AWS: types.ObjectNull(AWSObjectType.AttrTypes),
@@ -412,8 +404,6 @@ func newTFConnectionAuthenticationModel(ctx context.Context, currAuthConfig *typ
 			}
 			resultAuthModel.Password = configAuthModel.Password
 			resultAuthModel.ClientSecret = configAuthModel.ClientSecret
-			resultAuthModel.SSLKey = configAuthModel.SSLKey
-			resultAuthModel.SSLKeyPassword = configAuthModel.SSLKeyPassword
 		}
 
 		resultObject, diags := types.ObjectValueFrom(ctx, ConnectionAuthenticationObjectType.AttrTypes, resultAuthModel)

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1139,6 +1140,7 @@ func tfAuthenticationObject(t *testing.T, mechanism, username, password string) 
 		Mechanism: types.StringValue(mechanism),
 		Username:  types.StringValue(username),
 		Password:  types.StringValue(password),
+		AWS:       types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
 	})
 	if diags.HasError() {
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
@@ -1156,6 +1158,7 @@ func tfAuthenticationObjectForOAuth(t *testing.T, mechanism, clientID, clientSec
 		TokenEndpointURL:          types.StringValue(tokenEndpointURL),
 		Scope:                     types.StringValue(scope),
 		SaslOauthbearerExtensions: types.StringValue(saslOauthbearerExtensions),
+		AWS:                       types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
 	})
 	if diags.HasError() {
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
@@ -1168,6 +1171,7 @@ func tfAuthenticationObjectWithNoPassword(t *testing.T, mechanism, username stri
 	auth, diags := types.ObjectValueFrom(t.Context(), streamconnection.ConnectionAuthenticationObjectType.AttrTypes, streamconnection.TFConnectionAuthenticationModel{
 		Mechanism: types.StringValue(mechanism),
 		Username:  types.StringValue(username),
+		AWS:       types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
 	})
 	if diags.HasError() {
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
@@ -1289,4 +1293,186 @@ func tfGCPConfigObject(t *testing.T, serviceAccountID string) types.Object {
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
 	}
 	return gcp
+}
+
+// tfKafkaIAMAuthObject builds a Kafka authentication object using AWS MSK IAM auth.
+func tfKafkaIAMAuthObject(t *testing.T, mechanism, roleArn string) types.Object {
+	t.Helper()
+	awsObj, diags := types.ObjectValueFrom(t.Context(), streamconnection.AWSObjectType.AttrTypes, streamconnection.TFAWSModel{
+		RoleArn: types.StringValue(roleArn),
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to create aws object: %s", diags.Errors()[0].Summary())
+	}
+	auth, diags := types.ObjectValueFrom(t.Context(), streamconnection.ConnectionAuthenticationObjectType.AttrTypes, streamconnection.TFConnectionAuthenticationModel{
+		Mechanism: types.StringValue(mechanism),
+		AWS:       awsObj,
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to create auth object: %s", diags.Errors()[0].Summary())
+	}
+	return auth
+}
+
+// tfKafkaMTLSAuthObject builds a Kafka authentication object using mTLS (client cert) auth.
+func tfKafkaMTLSAuthObject(t *testing.T, sslCertificate, sslKey, sslKeyPassword string) types.Object {
+	t.Helper()
+	auth, diags := types.ObjectValueFrom(t.Context(), streamconnection.ConnectionAuthenticationObjectType.AttrTypes, streamconnection.TFConnectionAuthenticationModel{
+		SSLCertificate: types.StringValue(sslCertificate),
+		SSLKey:         types.StringValue(sslKey),
+		SSLKeyPassword: types.StringValue(sslKeyPassword),
+		AWS:            types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to create auth object: %s", diags.Errors()[0].Summary())
+	}
+	return auth
+}
+
+// TestStreamConnectionKafkaIAMAuth verifies AWS_MSK_IAM authentication round-trips (Task 8).
+func TestStreamConnectionKafkaIAMAuth(t *testing.T) {
+	const (
+		iamMechanism = "AWS_MSK_IAM"
+		roleArn      = "arn:aws:iam::123456789123:role/kafka-iam"
+	)
+	authConfig := tfKafkaIAMAuthObject(t, iamMechanism, roleArn)
+	tfModel := &streamconnection.TFStreamConnectionModel{
+		TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
+			ProjectID:      types.StringValue(dummyProjectID),
+			WorkspaceName:  types.StringValue(instanceName),
+			ConnectionName: types.StringValue(connectionName),
+			Type:           types.StringValue("Kafka"),
+			Authentication: authConfig,
+		},
+	}
+
+	// TF -> SDK
+	sdkReq, diags := streamconnection.NewStreamConnectionReq(t.Context(), tfModel)
+	require.False(t, diags.HasError(), "unexpected diags: %v", diags)
+	require.NotNil(t, sdkReq.Authentication)
+	assert.Equal(t, iamMechanism, sdkReq.Authentication.GetMechanism())
+	require.NotNil(t, sdkReq.Authentication.Aws, "authentication.aws should be set for AWS_MSK_IAM")
+	assert.Equal(t, roleArn, sdkReq.Authentication.Aws.GetRoleArn())
+
+	// SDK -> TF (round-trip): aws.role_arn should be reflected back in state
+	sdkResp := &admin.StreamsConnection{
+		Name: new(connectionName),
+		Type: new("Kafka"),
+		Authentication: &admin.StreamsKafkaAuthentication{
+			Mechanism: new(iamMechanism),
+			Aws:       &admin.StreamsAWSConnectionConfig{RoleArn: new(roleArn)},
+		},
+	}
+	result, diags := streamconnection.NewTFStreamConnection(t.Context(), dummyProjectID, "", instanceName, &authConfig, nil, sdkResp, nil)
+	require.False(t, diags.HasError(), "unexpected diags: %v", diags)
+	awsModel := &streamconnection.TFAWSModel{}
+	authModel := &streamconnection.TFConnectionAuthenticationModel{}
+	require.False(t, result.Authentication.As(t.Context(), authModel, basetypes.ObjectAsOptions{}).HasError())
+	require.False(t, authModel.AWS.IsNull(), "authentication.aws should be populated")
+	require.False(t, authModel.AWS.As(t.Context(), awsModel, basetypes.ObjectAsOptions{}).HasError())
+	assert.Equal(t, roleArn, awsModel.RoleArn.ValueString())
+}
+
+// TestStreamConnectionKafkaMTLSAuth verifies mTLS auth mapping and that write-only
+// ssl_key/ssl_key_password are preserved from prior config on read (Task 8).
+func TestStreamConnectionKafkaMTLSAuth(t *testing.T) {
+	const (
+		sslCertificate = "-----BEGIN CERTIFICATE-----\nMII...\n-----END CERTIFICATE-----"
+		sslKey         = "-----BEGIN PRIVATE KEY-----\nMII...\n-----END PRIVATE KEY-----"
+		sslKeyPassword = "keyPass123"
+	)
+	authConfig := tfKafkaMTLSAuthObject(t, sslCertificate, sslKey, sslKeyPassword)
+	tfModel := &streamconnection.TFStreamConnectionModel{
+		TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
+			ProjectID:      types.StringValue(dummyProjectID),
+			WorkspaceName:  types.StringValue(instanceName),
+			ConnectionName: types.StringValue(connectionName),
+			Type:           types.StringValue("Kafka"),
+			Authentication: authConfig,
+		},
+	}
+
+	// TF -> SDK
+	sdkReq, diags := streamconnection.NewStreamConnectionReq(t.Context(), tfModel)
+	require.False(t, diags.HasError(), "unexpected diags: %v", diags)
+	require.NotNil(t, sdkReq.Authentication)
+	assert.Equal(t, sslCertificate, sdkReq.Authentication.GetSslCertificate())
+	assert.Equal(t, sslKey, sdkReq.Authentication.GetSslKey())
+	assert.Equal(t, sslKeyPassword, sdkReq.Authentication.GetSslKeyPassword())
+
+	// SDK -> TF: API returns ssl_certificate but NOT ssl_key/ssl_key_password.
+	sdkResp := &admin.StreamsConnection{
+		Name: new(connectionName),
+		Type: new("Kafka"),
+		Authentication: &admin.StreamsKafkaAuthentication{
+			SslCertificate: new(sslCertificate),
+		},
+	}
+	result, diags := streamconnection.NewTFStreamConnection(t.Context(), dummyProjectID, "", instanceName, &authConfig, nil, sdkResp, nil)
+	require.False(t, diags.HasError(), "unexpected diags: %v", diags)
+	authModel := &streamconnection.TFConnectionAuthenticationModel{}
+	require.False(t, result.Authentication.As(t.Context(), authModel, basetypes.ObjectAsOptions{}).HasError())
+	assert.Equal(t, sslCertificate, authModel.SSLCertificate.ValueString())
+	// write-only values preserved from prior config
+	assert.Equal(t, sslKey, authModel.SSLKey.ValueString())
+	assert.Equal(t, sslKeyPassword, authModel.SSLKeyPassword.ValueString())
+	// aws must remain a typed null (not IAM)
+	assert.True(t, authModel.AWS.IsNull())
+}
+
+// TestStreamConnectionKafkaAuthAWSTypedNull is the regression guard (Task 8b): when
+// no aws block is configured, the authentication.aws attr must be a typed null and
+// never produce diagnostics, across all construction paths.
+func TestStreamConnectionKafkaAuthAWSTypedNull(t *testing.T) {
+	// Object-type parity guard: ensure "aws" attr exists and maps to AWSObjectType.
+	awsAttrType, ok := streamconnection.ConnectionAuthenticationObjectType.AttrTypes["aws"]
+	require.True(t, ok, "authentication object type must include an 'aws' attribute")
+	assert.True(t, awsAttrType.Equal(streamconnection.AWSObjectType), "'aws' attr must be AWSObjectType")
+
+	// (a) Kafka auth with PLAIN mechanism, no aws configured.
+	authConfig := tfAuthenticationObject(t, authMechanism, authUsername, "raw password")
+
+	// (b) API response with Aws == nil.
+	sdkResp := &admin.StreamsConnection{
+		Name: new(connectionName),
+		Type: new("Kafka"),
+		Authentication: &admin.StreamsKafkaAuthentication{
+			Mechanism: new(authMechanism),
+			Username:  new(authUsername),
+		},
+	}
+
+	assertAWSTypedNull := func(t *testing.T, obj types.Object) {
+		t.Helper()
+		authModel := &streamconnection.TFConnectionAuthenticationModel{}
+		require.False(t, obj.As(t.Context(), authModel, basetypes.ObjectAsOptions{}).HasError())
+		assert.True(t, authModel.AWS.IsNull(), "aws should be null")
+		assert.False(t, authModel.AWS.IsUnknown(), "aws should not be unknown/invalid")
+		assert.True(t, authModel.AWS.Type(t.Context()).Equal(streamconnection.AWSObjectType), "aws must retain AWSObjectType")
+	}
+
+	// create/update path (currAuthConfig provided)
+	resultWithCfg, diags := streamconnection.NewTFStreamConnection(t.Context(), dummyProjectID, "", instanceName, &authConfig, nil, sdkResp, nil)
+	require.False(t, diags.HasError(), "unexpected diags (with config): %v", diags)
+	assertAWSTypedNull(t, resultWithCfg.Authentication)
+
+	// (c)/(d) data source / import path (currAuthConfig == nil)
+	resultDS, diags := streamconnection.NewTFStreamConnectionDS(t.Context(), dummyProjectID, "", instanceName, nil, nil, sdkResp)
+	require.False(t, diags.HasError(), "unexpected diags (nil config): %v", diags)
+	assertAWSTypedNull(t, resultDS.Authentication)
+
+	// (e) TF -> SDK with null aws => Aws omitted from request.
+	tfModel := &streamconnection.TFStreamConnectionModel{
+		TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
+			ProjectID:      types.StringValue(dummyProjectID),
+			WorkspaceName:  types.StringValue(instanceName),
+			ConnectionName: types.StringValue(connectionName),
+			Type:           types.StringValue("Kafka"),
+			Authentication: authConfig,
+		},
+	}
+	sdkReq, diags := streamconnection.NewStreamConnectionReq(t.Context(), tfModel)
+	require.False(t, diags.HasError(), "unexpected diags (req): %v", diags)
+	require.NotNil(t, sdkReq.Authentication)
+	assert.Nil(t, sdkReq.Authentication.Aws, "authentication.aws should be omitted when not configured")
 }

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -1314,21 +1314,6 @@ func tfKafkaIAMAuthObject(t *testing.T, mechanism, roleArn string) types.Object 
 	return auth
 }
 
-// tfKafkaMTLSAuthObject builds a Kafka authentication object using mTLS (client cert) auth.
-func tfKafkaMTLSAuthObject(t *testing.T, sslCertificate, sslKey, sslKeyPassword string) types.Object {
-	t.Helper()
-	auth, diags := types.ObjectValueFrom(t.Context(), streamconnection.ConnectionAuthenticationObjectType.AttrTypes, streamconnection.TFConnectionAuthenticationModel{
-		SSLCertificate: types.StringValue(sslCertificate),
-		SSLKey:         types.StringValue(sslKey),
-		SSLKeyPassword: types.StringValue(sslKeyPassword),
-		AWS:            types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
-	})
-	if diags.HasError() {
-		t.Fatalf("failed to create auth object: %s", diags.Errors()[0].Summary())
-	}
-	return auth
-}
-
 // TestStreamConnectionKafkaIAMAuth verifies AWS_MSK_IAM authentication round-trips (Task 8).
 func TestStreamConnectionKafkaIAMAuth(t *testing.T) {
 	const (
@@ -1371,53 +1356,6 @@ func TestStreamConnectionKafkaIAMAuth(t *testing.T) {
 	require.False(t, authModel.AWS.IsNull(), "authentication.aws should be populated")
 	require.False(t, authModel.AWS.As(t.Context(), awsModel, basetypes.ObjectAsOptions{}).HasError())
 	assert.Equal(t, roleArn, awsModel.RoleArn.ValueString())
-}
-
-// TestStreamConnectionKafkaMTLSAuth verifies mTLS auth mapping and that write-only
-// ssl_key/ssl_key_password are preserved from prior config on read (Task 8).
-func TestStreamConnectionKafkaMTLSAuth(t *testing.T) {
-	const (
-		sslCertificate = "-----BEGIN CERTIFICATE-----\nMII...\n-----END CERTIFICATE-----"
-		sslKey         = "-----BEGIN PRIVATE KEY-----\nMII...\n-----END PRIVATE KEY-----"
-		sslKeyPassword = "keyPass123"
-	)
-	authConfig := tfKafkaMTLSAuthObject(t, sslCertificate, sslKey, sslKeyPassword)
-	tfModel := &streamconnection.TFStreamConnectionModel{
-		TFStreamConnectionCommonModel: streamconnection.TFStreamConnectionCommonModel{
-			ProjectID:      types.StringValue(dummyProjectID),
-			WorkspaceName:  types.StringValue(instanceName),
-			ConnectionName: types.StringValue(connectionName),
-			Type:           types.StringValue("Kafka"),
-			Authentication: authConfig,
-		},
-	}
-
-	// TF -> SDK
-	sdkReq, diags := streamconnection.NewStreamConnectionReq(t.Context(), tfModel)
-	require.False(t, diags.HasError(), "unexpected diags: %v", diags)
-	require.NotNil(t, sdkReq.Authentication)
-	assert.Equal(t, sslCertificate, sdkReq.Authentication.GetSslCertificate())
-	assert.Equal(t, sslKey, sdkReq.Authentication.GetSslKey())
-	assert.Equal(t, sslKeyPassword, sdkReq.Authentication.GetSslKeyPassword())
-
-	// SDK -> TF: API returns ssl_certificate but NOT ssl_key/ssl_key_password.
-	sdkResp := &admin.StreamsConnection{
-		Name: new(connectionName),
-		Type: new("Kafka"),
-		Authentication: &admin.StreamsKafkaAuthentication{
-			SslCertificate: new(sslCertificate),
-		},
-	}
-	result, diags := streamconnection.NewTFStreamConnection(t.Context(), dummyProjectID, "", instanceName, &authConfig, nil, sdkResp, nil)
-	require.False(t, diags.HasError(), "unexpected diags: %v", diags)
-	authModel := &streamconnection.TFConnectionAuthenticationModel{}
-	require.False(t, result.Authentication.As(t.Context(), authModel, basetypes.ObjectAsOptions{}).HasError())
-	assert.Equal(t, sslCertificate, authModel.SSLCertificate.ValueString())
-	// write-only values preserved from prior config
-	assert.Equal(t, sslKey, authModel.SSLKey.ValueString())
-	assert.Equal(t, sslKeyPassword, authModel.SSLKeyPassword.ValueString())
-	// aws must remain a typed null (not IAM)
-	assert.True(t, authModel.AWS.IsNull())
 }
 
 // TestStreamConnectionKafkaAuthAWSTypedNull is the regression guard (Task 8b): when

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -124,6 +124,25 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"sasl_oauthbearer_extensions": schema.StringAttribute{
 						Optional: true,
 					},
+					"ssl_certificate": schema.StringAttribute{
+						Optional: true,
+					},
+					"ssl_key": schema.StringAttribute{
+						Optional:  true,
+						Sensitive: true,
+					},
+					"ssl_key_password": schema.StringAttribute{
+						Optional:  true,
+						Sensitive: true,
+					},
+					"aws": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"role_arn": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
 				},
 			},
 			"bootstrap_servers": schema.StringAttribute{

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -124,17 +124,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"sasl_oauthbearer_extensions": schema.StringAttribute{
 						Optional: true,
 					},
-					"ssl_certificate": schema.StringAttribute{
-						Optional: true,
-					},
-					"ssl_key": schema.StringAttribute{
-						Optional:  true,
-						Sensitive: true,
-					},
-					"ssl_key_password": schema.StringAttribute{
-						Optional:  true,
-						Sensitive: true,
-					},
 					"aws": schema.SingleNestedAttribute{
 						Optional: true,
 						Attributes: map[string]schema.Attribute{

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -102,6 +102,10 @@ type TFConnectionAuthenticationModel struct {
 	ClientSecret              types.String `tfsdk:"client_secret"`
 	Scope                     types.String `tfsdk:"scope"`
 	SaslOauthbearerExtensions types.String `tfsdk:"sasl_oauthbearer_extensions"`
+	SSLCertificate            types.String `tfsdk:"ssl_certificate"`
+	SSLKey                    types.String `tfsdk:"ssl_key"`
+	SSLKeyPassword            types.String `tfsdk:"ssl_key_password"`
+	AWS                       types.Object `tfsdk:"aws"`
 }
 
 var ConnectionAuthenticationObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
@@ -114,6 +118,10 @@ var ConnectionAuthenticationObjectType = types.ObjectType{AttrTypes: map[string]
 	"client_secret":               types.StringType,
 	"scope":                       types.StringType,
 	"sasl_oauthbearer_extensions": types.StringType,
+	"ssl_certificate":             types.StringType,
+	"ssl_key":                     types.StringType,
+	"ssl_key_password":            types.StringType,
+	"aws":                         AWSObjectType,
 }}
 
 type TFSchemaRegistryAuthenticationModel struct {

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -102,9 +102,6 @@ type TFConnectionAuthenticationModel struct {
 	ClientSecret              types.String `tfsdk:"client_secret"`
 	Scope                     types.String `tfsdk:"scope"`
 	SaslOauthbearerExtensions types.String `tfsdk:"sasl_oauthbearer_extensions"`
-	SSLCertificate            types.String `tfsdk:"ssl_certificate"`
-	SSLKey                    types.String `tfsdk:"ssl_key"`
-	SSLKeyPassword            types.String `tfsdk:"ssl_key_password"`
 	AWS                       types.Object `tfsdk:"aws"`
 }
 
@@ -118,9 +115,6 @@ var ConnectionAuthenticationObjectType = types.ObjectType{AttrTypes: map[string]
 	"client_secret":               types.StringType,
 	"scope":                       types.StringType,
 	"sasl_oauthbearer_extensions": types.StringType,
-	"ssl_certificate":             types.StringType,
-	"ssl_key":                     types.StringType,
-	"ssl_key_password":            types.StringType,
 	"aws":                         AWSObjectType,
 }}
 

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -771,41 +771,6 @@ func TestAccStreamRSStreamConnection_kafkaIAM(t *testing.T) {
 	})
 }
 
-func TestAccStreamRSStreamConnection_kafkaMTLS(t *testing.T) {
-	var (
-		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
-		connectionName          = "kafka-conn-mtls"
-		sslCertificate          = os.Getenv("MONGODB_ATLAS_STREAM_KAFKA_SSL_CERTIFICATE")
-		sslKey                  = os.Getenv("MONGODB_ATLAS_STREAM_KAFKA_SSL_KEY")
-		bootstrapServersEnv     = os.Getenv("MONGODB_ATLAS_STREAM_KAFKA_MTLS_BOOTSTRAP_SERVERS")
-	)
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acc.PreCheckBasic(t)
-			if sslCertificate == "" || sslKey == "" || bootstrapServersEnv == "" {
-				t.Skip("MONGODB_ATLAS_STREAM_KAFKA_SSL_CERTIFICATE, MONGODB_ATLAS_STREAM_KAFKA_SSL_KEY and MONGODB_ATLAS_STREAM_KAFKA_MTLS_BOOTSTRAP_SERVERS must be set for Kafka mTLS acceptance test")
-			}
-		},
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             CheckDestroyStreamConnection,
-		Steps: []resource.TestStep{
-			{
-				Config: configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaMTLSAuthenticationConfig(sslCertificate, sslKey, ""), bootstrapServersEnv, "earliest", "", true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "authentication.ssl_certificate"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       checkStreamConnectionImportStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"authentication.ssl_key", "authentication.ssl_key_password"},
-			},
-		},
-	})
-}
-
 // TestAccStreamRSStreamConnection_kafkaNoAWSNoDrift is the real-provider regression
 // guard for the typed-null authentication.aws handling (Task 11b): a PLAIN auth
 // config with no aws block must produce an empty follow-up plan and null aws.
@@ -841,14 +806,6 @@ func getKafkaIAMAuthenticationConfig(roleArn string) string {
 				role_arn = %[1]q
 			}
 		}`, roleArn)
-}
-
-func getKafkaMTLSAuthenticationConfig(sslCertificate, sslKey, sslKeyPassword string) string {
-	return fmt.Sprintf(`authentication = {
-			ssl_certificate = %[1]q
-			ssl_key = %[2]q
-			ssl_key_password = %[3]q
-		}`, sslCertificate, sslKey, sslKeyPassword)
 }
 
 func getKafkaAuthenticationConfig(mechanism, username, password, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions, method string) string {

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -737,6 +737,120 @@ func checkSchemaRegistrySASLInheritAttributes(resourceName, workspaceName, conne
 	return acc.CheckRSAndDS(resourceName, conversion.StringPtr(dataSourceName), nil, setChecks, mapChecks, extra...)
 }
 
+func TestAccStreamRSStreamConnection_kafkaIAM(t *testing.T) {
+	var (
+		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		connectionName          = "kafka-conn-iam"
+		roleArn                 = os.Getenv("AWS_ROLE_ARN")
+		bootstrapServersEnv     = os.Getenv("MONGODB_ATLAS_STREAM_KAFKA_MSK_BOOTSTRAP_SERVERS")
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acc.PreCheckBasic(t)
+			if roleArn == "" || bootstrapServersEnv == "" {
+				t.Skip("AWS_ROLE_ARN and MONGODB_ATLAS_STREAM_KAFKA_MSK_BOOTSTRAP_SERVERS must be set for Kafka IAM acceptance test")
+			}
+		},
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaIAMAuthenticationConfig(roleArn), bootstrapServersEnv, "earliest", "", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "authentication.mechanism", "AWS_MSK_IAM"),
+					resource.TestCheckResourceAttr(resourceName, "authentication.aws.role_arn", roleArn),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: checkStreamConnectionImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccStreamRSStreamConnection_kafkaMTLS(t *testing.T) {
+	var (
+		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		connectionName          = "kafka-conn-mtls"
+		sslCertificate          = os.Getenv("MONGODB_ATLAS_STREAM_KAFKA_SSL_CERTIFICATE")
+		sslKey                  = os.Getenv("MONGODB_ATLAS_STREAM_KAFKA_SSL_KEY")
+		bootstrapServersEnv     = os.Getenv("MONGODB_ATLAS_STREAM_KAFKA_MTLS_BOOTSTRAP_SERVERS")
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acc.PreCheckBasic(t)
+			if sslCertificate == "" || sslKey == "" || bootstrapServersEnv == "" {
+				t.Skip("MONGODB_ATLAS_STREAM_KAFKA_SSL_CERTIFICATE, MONGODB_ATLAS_STREAM_KAFKA_SSL_KEY and MONGODB_ATLAS_STREAM_KAFKA_MTLS_BOOTSTRAP_SERVERS must be set for Kafka mTLS acceptance test")
+			}
+		},
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaMTLSAuthenticationConfig(sslCertificate, sslKey, ""), bootstrapServersEnv, "earliest", "", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "authentication.ssl_certificate"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       checkStreamConnectionImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication.ssl_key", "authentication.ssl_key_password"},
+			},
+		},
+	})
+}
+
+// TestAccStreamRSStreamConnection_kafkaNoAWSNoDrift is the real-provider regression
+// guard for the typed-null authentication.aws handling (Task 11b): a PLAIN auth
+// config with no aws block must produce an empty follow-up plan and null aws.
+func TestAccStreamRSStreamConnection_kafkaNoAWSNoDrift(t *testing.T) {
+	var (
+		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		connectionName          = "kafka-conn-no-aws"
+		cfg                     = configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", "", false)
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, "authentication.aws"),
+				),
+			},
+			{
+				Config:   cfg,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func getKafkaIAMAuthenticationConfig(roleArn string) string {
+	return fmt.Sprintf(`authentication = {
+			mechanism = "AWS_MSK_IAM"
+			aws = {
+				role_arn = %[1]q
+			}
+		}`, roleArn)
+}
+
+func getKafkaMTLSAuthenticationConfig(sslCertificate, sslKey, sslKeyPassword string) string {
+	return fmt.Sprintf(`authentication = {
+			ssl_certificate = %[1]q
+			ssl_key = %[2]q
+			ssl_key_password = %[3]q
+		}`, sslCertificate, sslKey, sslKeyPassword)
+}
+
 func getKafkaAuthenticationConfig(mechanism, username, password, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions, method string) string {
 	if mechanism == "PLAIN" {
 		return fmt.Sprintf(`authentication = {

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -21,6 +21,16 @@ const (
 	VendorAzureBlobStorage = "AZURE_BLOB_STORAGE"
 )
 
+// Authentication schemes supported for MSK Private Link connections.
+const (
+	AuthenticationSchemeSaslScram = "SASL/SCRAM"
+	AuthenticationSchemeTLS       = "TLS"
+	AuthenticationSchemeIAM       = "IAM"
+
+	// DefaultAuthenticationScheme is used for MSK when no authentication_scheme is provided.
+	DefaultAuthenticationScheme = AuthenticationSchemeSaslScram
+)
+
 func NewTFModel(ctx context.Context, projectID string, apiResp *admin.StreamsPrivateLinkConnection) (*TFModel, diag.Diagnostics) {
 	result := &TFModel{
 		Id:                    types.StringPointerValue(apiResp.Id),
@@ -83,9 +93,6 @@ func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.StreamsPrivateLinkC
 		if plan.Region.ValueString() != "" {
 			diags.AddError(fmt.Sprintf("region cannot be set for vendor %s", VendorMSK), "")
 		}
-		if plan.AuthenticationScheme.IsNull() || plan.AuthenticationScheme.ValueString() == "" {
-			diags.AddError(fmt.Sprintf("authentication_scheme is required for vendor %s", VendorMSK), "Valid values are TLS and IAM")
-		}
 	}
 
 	if plan.Vendor.ValueString() == VendorS3 {
@@ -129,6 +136,11 @@ func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.StreamsPrivateLinkC
 		Vendor:               plan.Vendor.ValueStringPointer(),
 		Arn:                  plan.Arn.ValueStringPointer(),
 		AuthenticationScheme: plan.AuthenticationScheme.ValueStringPointer(),
+	}
+
+	// authentication_scheme only applies to MSK. When it is not provided, default to SASL/SCRAM.
+	if plan.Vendor.ValueString() == VendorMSK && (plan.AuthenticationScheme.IsNull() || plan.AuthenticationScheme.ValueString() == "") {
+		result.AuthenticationScheme = admin.PtrString(DefaultAuthenticationScheme)
 	}
 
 	if !plan.DnsSubDomain.IsNull() {

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -36,6 +36,7 @@ func NewTFModel(ctx context.Context, projectID string, apiResp *admin.StreamsPri
 		State:                 types.StringPointerValue(apiResp.State),
 		Vendor:                types.StringPointerValue(apiResp.Vendor),
 		Arn:                   types.StringPointerValue(apiResp.Arn),
+		AuthenticationScheme:  types.StringPointerValue(apiResp.AuthenticationScheme),
 	}
 
 	subdomain, diags := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
@@ -82,6 +83,9 @@ func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.StreamsPrivateLinkC
 		if plan.Region.ValueString() != "" {
 			diags.AddError(fmt.Sprintf("region cannot be set for vendor %s", VendorMSK), "")
 		}
+		if plan.AuthenticationScheme.IsNull() || plan.AuthenticationScheme.ValueString() == "" {
+			diags.AddError(fmt.Sprintf("authentication_scheme is required for vendor %s", VendorMSK), "Valid values are TLS and IAM")
+		}
 	}
 
 	if plan.Vendor.ValueString() == VendorS3 {
@@ -117,13 +121,14 @@ func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.StreamsPrivateLinkC
 	}
 
 	result := &admin.StreamsPrivateLinkConnection{
-		DnsDomain:         conversion.StringPtr(plan.DnsDomain.ValueString()),
-		Provider:          plan.Provider.ValueString(),
-		Region:            plan.Region.ValueStringPointer(),
-		ServiceEndpointId: plan.ServiceEndpointId.ValueStringPointer(),
-		State:             plan.State.ValueStringPointer(),
-		Vendor:            plan.Vendor.ValueStringPointer(),
-		Arn:               plan.Arn.ValueStringPointer(),
+		DnsDomain:            conversion.StringPtr(plan.DnsDomain.ValueString()),
+		Provider:             plan.Provider.ValueString(),
+		Region:               plan.Region.ValueStringPointer(),
+		ServiceEndpointId:    plan.ServiceEndpointId.ValueStringPointer(),
+		State:                plan.State.ValueStringPointer(),
+		Vendor:               plan.Vendor.ValueStringPointer(),
+		Arn:                  plan.Arn.ValueStringPointer(),
+		AuthenticationScheme: plan.AuthenticationScheme.ValueStringPointer(),
 	}
 
 	if !plan.DnsSubDomain.IsNull() {

--- a/internal/service/streamprivatelinkendpoint/model_test.go
+++ b/internal/service/streamprivatelinkendpoint/model_test.go
@@ -35,6 +35,10 @@ var (
 	vendorPubSub               = "PUBSUB"
 	vendorS3                   = "S3"
 	vendorAzureBlobStorage     = "AZURE_BLOB_STORAGE"
+	vendorMSK                  = "MSK"
+	mskArn                     = "arn:aws:kafka:us-east-1:123456789012:cluster/demo/abc"
+	authSchemeIAM              = "IAM"
+	authSchemeTLS              = "TLS"
 	azureRegion                = "eastus2"
 	azureBlobDNSDomain         = "mystorageaccount.blob.core.windows.net"
 	azureBlobServiceEndpointID = "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorageaccount"
@@ -134,6 +138,30 @@ func TestStreamPrivatelinkEndpointSDKToTFModel(t *testing.T) {
 				ServiceAttachmentUris: types.ListNull(types.StringType),
 				State:                 types.StringValue(state),
 				Vendor:                types.StringValue(vendorConfluent),
+			},
+		},
+		"SDK response with vendor MSK and IAM authentication scheme": {
+			SDKResp: &admin.StreamsPrivateLinkConnection{
+				Id:                   &id,
+				Arn:                  &mskArn,
+				Provider:             constant.AWS,
+				Vendor:               &vendorMSK,
+				Region:               &region,
+				State:                &state,
+				AuthenticationScheme: &authSchemeIAM,
+			},
+			projectID: projectID,
+			expectedTFModel: &streamprivatelinkendpoint.TFModel{
+				Id:                    types.StringValue(id),
+				Arn:                   types.StringValue(mskArn),
+				Provider:              types.StringValue(constant.AWS),
+				Vendor:                types.StringValue(vendorMSK),
+				Region:                types.StringValue(region),
+				State:                 types.StringValue(state),
+				AuthenticationScheme:  types.StringValue(authSchemeIAM),
+				ProjectId:             types.StringValue(projectID),
+				DnsSubDomain:          types.ListNull(types.StringType),
+				ServiceAttachmentUris: types.ListNull(types.StringType),
 			},
 		},
 		"SDK response with vendor S3": {
@@ -343,6 +371,22 @@ func TestStreamPrivatelinkEndpointTFModelToSDK(t *testing.T) {
 				Vendor:            &vendorConfluent,
 			},
 		},
+		"TF state with MSK vendor and TLS authentication scheme": {
+			tfModel: &streamprivatelinkendpoint.TFModel{
+				Id:                    types.StringValue(id),
+				Arn:                   types.StringValue(mskArn),
+				Provider:              types.StringValue(constant.AWS),
+				Vendor:                types.StringValue(vendorMSK),
+				AuthenticationScheme:  types.StringValue(authSchemeTLS),
+				ServiceAttachmentUris: types.ListNull(types.StringType),
+			},
+			expectedSDKReq: &admin.StreamsPrivateLinkConnection{
+				Arn:                  &mskArn,
+				Provider:             constant.AWS,
+				Vendor:               &vendorMSK,
+				AuthenticationScheme: &authSchemeTLS,
+			},
+		},
 		"TF state with s3 vendor": {
 			tfModel: &streamprivatelinkendpoint.TFModel{
 				Id:                    types.StringValue(id),
@@ -539,6 +583,33 @@ func TestStreamPrivatelinkEndpointValidation(t *testing.T) {
 			},
 			expectError: true,
 			errorCount:  1,
+		},
+		"AWS MSK with authentication_scheme": {
+			tfModel: &streamprivatelinkendpoint.TFModel{
+				Provider:             types.StringValue(constant.AWS),
+				Vendor:               types.StringValue(streamprivatelinkendpoint.VendorMSK),
+				Arn:                  types.StringValue(mskArn),
+				AuthenticationScheme: types.StringValue(authSchemeIAM),
+			},
+			expectError: false,
+			errorCount:  0,
+		},
+		"AWS MSK missing authentication_scheme": {
+			tfModel: &streamprivatelinkendpoint.TFModel{
+				Provider: types.StringValue(constant.AWS),
+				Vendor:   types.StringValue(streamprivatelinkendpoint.VendorMSK),
+				Arn:      types.StringValue(mskArn),
+			},
+			expectError: true,
+			errorCount:  1,
+		},
+		"AWS MSK missing arn and authentication_scheme": {
+			tfModel: &streamprivatelinkendpoint.TFModel{
+				Provider: types.StringValue(constant.AWS),
+				Vendor:   types.StringValue(streamprivatelinkendpoint.VendorMSK),
+			},
+			expectError: true,
+			errorCount:  2,
 		},
 		"GCP PubSub with all required fields": {
 			tfModel: &streamprivatelinkendpoint.TFModel{

--- a/internal/service/streamprivatelinkendpoint/model_test.go
+++ b/internal/service/streamprivatelinkendpoint/model_test.go
@@ -387,6 +387,21 @@ func TestStreamPrivatelinkEndpointTFModelToSDK(t *testing.T) {
 				AuthenticationScheme: &authSchemeTLS,
 			},
 		},
+		"TF state with MSK vendor and no authentication scheme defaults to SASL/SCRAM": {
+			tfModel: &streamprivatelinkendpoint.TFModel{
+				Id:                    types.StringValue(id),
+				Arn:                   types.StringValue(mskArn),
+				Provider:              types.StringValue(constant.AWS),
+				Vendor:                types.StringValue(vendorMSK),
+				ServiceAttachmentUris: types.ListNull(types.StringType),
+			},
+			expectedSDKReq: &admin.StreamsPrivateLinkConnection{
+				Arn:                  &mskArn,
+				Provider:             constant.AWS,
+				Vendor:               &vendorMSK,
+				AuthenticationScheme: admin.PtrString(streamprivatelinkendpoint.AuthenticationSchemeSaslScram),
+			},
+		},
 		"TF state with s3 vendor": {
 			tfModel: &streamprivatelinkendpoint.TFModel{
 				Id:                    types.StringValue(id),
@@ -594,22 +609,32 @@ func TestStreamPrivatelinkEndpointValidation(t *testing.T) {
 			expectError: false,
 			errorCount:  0,
 		},
-		"AWS MSK missing authentication_scheme": {
+		"AWS MSK missing authentication_scheme defaults to SASL/SCRAM": {
 			tfModel: &streamprivatelinkendpoint.TFModel{
 				Provider: types.StringValue(constant.AWS),
 				Vendor:   types.StringValue(streamprivatelinkendpoint.VendorMSK),
 				Arn:      types.StringValue(mskArn),
 			},
-			expectError: true,
-			errorCount:  1,
+			expectError: false,
+			errorCount:  0,
 		},
-		"AWS MSK missing arn and authentication_scheme": {
+		"AWS MSK with SASL/SCRAM authentication_scheme": {
+			tfModel: &streamprivatelinkendpoint.TFModel{
+				Provider:             types.StringValue(constant.AWS),
+				Vendor:               types.StringValue(streamprivatelinkendpoint.VendorMSK),
+				Arn:                  types.StringValue(mskArn),
+				AuthenticationScheme: types.StringValue(streamprivatelinkendpoint.AuthenticationSchemeSaslScram),
+			},
+			expectError: false,
+			errorCount:  0,
+		},
+		"AWS MSK missing arn still errors": {
 			tfModel: &streamprivatelinkendpoint.TFModel{
 				Provider: types.StringValue(constant.AWS),
 				Vendor:   types.StringValue(streamprivatelinkendpoint.VendorMSK),
 			},
 			expectError: true,
-			errorCount:  2,
+			errorCount:  1,
 		},
 		"GCP PubSub with all required fields": {
 			tfModel: &streamprivatelinkendpoint.TFModel{

--- a/internal/service/streamprivatelinkendpoint/resource_schema.go
+++ b/internal/service/streamprivatelinkendpoint/resource_schema.go
@@ -123,6 +123,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"authentication_scheme": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.",
+			},
 		},
 	}
 }
@@ -143,6 +148,7 @@ type TFModel struct {
 	State                 types.String `tfsdk:"state"`
 	Vendor                types.String `tfsdk:"vendor"`
 	Arn                   types.String `tfsdk:"arn"`
+	AuthenticationScheme  types.String `tfsdk:"authentication_scheme"`
 }
 
 type TFModelDSP struct {

--- a/internal/service/streamprivatelinkendpoint/resource_schema.go
+++ b/internal/service/streamprivatelinkendpoint/resource_schema.go
@@ -3,10 +3,12 @@ package streamprivatelinkendpoint
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -126,7 +128,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"authentication_scheme": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "Authentication mechanism to use with this private link connection. Required when the vendor is `MSK`. Valid values are `TLS` and `IAM`.",
+				MarkdownDescription: "Authentication mechanism to use with this private link connection. Only applies when the vendor is `MSK`. Valid values are `SASL/SCRAM`, `TLS`, and `IAM`. Defaults to `SASL/SCRAM` when not specified.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(AuthenticationSchemeSaslScram, AuthenticationSchemeTLS, AuthenticationSchemeIAM),
+				},
 			},
 		},
 	}

--- a/internal/service/streamprivatelinkendpoint/resource_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_test.go
@@ -119,15 +119,16 @@ func TestAccStreamPrivatelinkEndpointMsk_fields(t *testing.T) {
 			expectedError: regexp.MustCompile(`(?s)^.*?region cannot be set for vendor MSK.*?$`),
 		},
 		{
-			name: "missing authentication_scheme",
+			name: "invalid authentication_scheme",
 			config: fmt.Sprintf(`
 			resource "mongodbatlas_stream_privatelink_endpoint" "test" {
-				project_id          = %[1]q
-				provider_name       = %[2]q
-				vendor              = %[3]q
-				arn                 = "an:arn:that:does:not:matter"
+				project_id            = %[1]q
+				provider_name         = %[2]q
+				vendor                = %[3]q
+				arn                   = "an:arn:that:does:not:matter"
+				authentication_scheme = "INVALID"
 			}`, projectID, provider, vendor),
-			expectedError: regexp.MustCompile(`(?s)^.*?authentication_scheme is required for vendor MSK.*?$`),
+			expectedError: regexp.MustCompile(`(?s)^.*?Attribute authentication_scheme value must be one of.*?$`),
 		},
 	}
 

--- a/internal/service/streamprivatelinkendpoint/resource_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_test.go
@@ -118,6 +118,17 @@ func TestAccStreamPrivatelinkEndpointMsk_fields(t *testing.T) {
 			}`, projectID, provider, vendor),
 			expectedError: regexp.MustCompile(`(?s)^.*?region cannot be set for vendor MSK.*?$`),
 		},
+		{
+			name: "missing authentication_scheme",
+			config: fmt.Sprintf(`
+			resource "mongodbatlas_stream_privatelink_endpoint" "test" {
+				project_id          = %[1]q
+				provider_name       = %[2]q
+				vendor              = %[3]q
+				arn                 = "an:arn:that:does:not:matter"
+			}`, projectID, provider, vendor),
+			expectedError: regexp.MustCompile(`(?s)^.*?authentication_scheme is required for vendor MSK.*?$`),
+		},
 	}
 
 	for _, tc := range tests {
@@ -354,10 +365,11 @@ func basicMskTestCase(t *testing.T) *resource.TestCase {
 	t.Helper()
 
 	var (
-		projectID = acc.ProjectIDExecution(t)
-		provider  = "AWS"
-		vendor    = "MSK"
-		arn       = os.Getenv("AWS_MSK_ARN")
+		projectID  = acc.ProjectIDExecution(t)
+		provider   = "AWS"
+		vendor     = "MSK"
+		arn        = os.Getenv("AWS_MSK_ARN")
+		authScheme = "IAM"
 	)
 
 	return &resource.TestCase{
@@ -367,8 +379,8 @@ func basicMskTestCase(t *testing.T) *resource.TestCase {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.GetCompleteMskConfig(projectID, arn),
-				Check:  checksStreamPrivatelinkEndpointMsk(projectID, provider, vendor, arn),
+				Config: acc.GetCompleteMskConfig(projectID, arn, authScheme),
+				Check:  checksStreamPrivatelinkEndpointMsk(projectID, provider, vendor, arn, authScheme),
 			},
 			{
 				ResourceName:      resourceName,
@@ -380,13 +392,14 @@ func basicMskTestCase(t *testing.T) *resource.TestCase {
 	}
 }
 
-func checksStreamPrivatelinkEndpointMsk(projectID, provider, vendor, arn string) resource.TestCheckFunc {
+func checksStreamPrivatelinkEndpointMsk(projectID, provider, vendor, arn, authScheme string) resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{checkExists()}
 	attrMap := map[string]string{
-		"project_id":    projectID,
-		"provider_name": provider,
-		"vendor":        vendor,
-		"arn":           arn,
+		"project_id":            projectID,
+		"provider_name":         provider,
+		"vendor":                vendor,
+		"arn":                   arn,
+		"authentication_scheme": authScheme,
 	}
 	pluralMap := map[string]string{
 		"project_id": projectID,

--- a/internal/testutil/acc/stream_privatelink_endpoint.go
+++ b/internal/testutil/acc/stream_privatelink_endpoint.go
@@ -182,13 +182,14 @@ func GetConfluentEnterpriseConfigForDNSDomainUpdate(withDNSDomain bool, projectI
 	}`, projectID, provider, region, vendor, dnsDomainConfig, connectionID, serviceEndpointID)
 }
 
-func GetCompleteMskConfig(projectID, clusterArn string) string {
+func GetCompleteMskConfig(projectID, clusterArn, authenticationScheme string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_stream_privatelink_endpoint" "test" {
-		project_id          = %[1]q
-		provider_name       = "AWS"
-		vendor              = "MSK"
-		arn                 = %[2]q
+		project_id            = %[1]q
+		provider_name         = "AWS"
+		vendor                = "MSK"
+		arn                   = %[2]q
+		authentication_scheme = %[3]q
 	}
 
 	data "mongodbatlas_stream_privatelink_endpoint" "test" {
@@ -204,7 +205,7 @@ func GetCompleteMskConfig(projectID, clusterArn string) string {
 		depends_on = [
 			mongodbatlas_stream_privatelink_endpoint.test
 		]
-	}`, projectID, clusterArn)
+	}`, projectID, clusterArn, authenticationScheme)
 }
 
 func GetCompleteAzureBlobStorageConfig(projectID, clusterName, subscriptionID, clientID, clientSecret, tenantID, resourceGroupName, storageAccountName string) string {


### PR DESCRIPTION
## Summary
Adds authentication enhancements for MongoDB Atlas Streams:

- **`mongodbatlas_stream_connection` (Kafka)**: IAM (`AWS_MSK_IAM`) auth via the new `authentication.aws.role_arn` field.
- **`mongodbatlas_stream_privatelink_endpoint` (MSK)**: new `authentication_scheme` attribute (`TLS`/`IAM`), required for the `MSK` vendor.

## ⚠️ Blocked on SDK bump (draft)
The new API fields are **not yet in the vendored Atlas Go SDK** (`v20250312021`). This branch intentionally does **not compile** until the SDK is bumped to a version exposing:
- `StreamsKafkaAuthentication.Aws`
- `StreamsPrivateLinkConnection.AuthenticationScheme`

Field/enum names inferred from the OpenAPI spec must be re-verified against the generated SDK once available (notably the `AuthenticationScheme` enum, which reads `SASL/SCAM` [sic] in the spec).

## Changes
- Schema + TF↔SDK model conversion for both resources (and derived data sources).
- `authentication.aws` always represented as a typed-null object when unset (no runtime attribute-mismatch).
- MSK per-vendor validation requiring `authentication_scheme`.
- Unit tests: IAM round-trip, typed-null `aws` regression guard, MSK scheme mapping + validation.
- Acceptance tests: Kafka IAM, no-`aws` empty-plan regression, MSK scheme.
- Docs, examples, changelog.

## Testing
`go build`/tests cannot pass until the SDK bump lands (see above). All non-SDK code compiles; the only build errors are the two new SDK fields.

CLOUDP-417873
