### PR TITLE
fix: Caches Service Account tokens per client_id

### DIFF
--- a/.changelog/4597.txt
+++ b/.changelog/4597.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_organization: Fixes create with `service_account` when the provider is authenticated with a Service Account by caching OAuth tokens per `client_id`
+```

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -30,7 +30,7 @@ func ResetRevokeTokenForTest() {
 func ResetSAInfoForTest() {
 	saTokenSourceCache.mu.Lock()
 	defer saTokenSourceCache.mu.Unlock()
-	saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
+	saTokenSourceCache.sources = nil
 	saTokenSourceCache.closed = false
 }
 

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -30,7 +30,7 @@ func ResetRevokeTokenForTest() {
 func ResetSAInfoForTest() {
 	saTokenSourceCache.mu.Lock()
 	defer saTokenSourceCache.mu.Unlock()
-	saTokenSourceCache.sources = nil
+	saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
 	saTokenSourceCache.closed = false
 }
 

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -16,15 +16,26 @@ func ResetCreateTokenSourceForTest() {
 	createTokenSourceFn = defaultCreateTokenSource
 }
 
+// SetRevokeTokenForTest records which clientIDs get revoked without hitting the network.
+func SetRevokeTokenForTest(fn func(clientID string)) {
+	revokeTokenFn = func(clientID string, _ *saTokenSourceEntry) {
+		fn(clientID)
+	}
+}
+
+func ResetRevokeTokenForTest() {
+	revokeTokenFn = defaultRevokeToken
+}
+
 func ResetSAInfoForTest() {
-	saInfo.mu.Lock()
-	defer saInfo.mu.Unlock()
-	saInfo.sources = nil
-	saInfo.closed = false
+	saTokenSourceCache.mu.Lock()
+	defer saTokenSourceCache.mu.Unlock()
+	saTokenSourceCache.sources = nil
+	saTokenSourceCache.closed = false
 }
 
 func SetSAInfoClosedForTest(closed bool) {
-	saInfo.mu.Lock()
-	defer saInfo.mu.Unlock()
-	saInfo.closed = closed
+	saTokenSourceCache.mu.Lock()
+	defer saTokenSourceCache.mu.Unlock()
+	saTokenSourceCache.closed = closed
 }

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -27,14 +27,16 @@ func ResetRevokeTokenForTest() {
 	revokeTokenFn = defaultRevokeToken
 }
 
-func ResetSAInfoForTest() {
+func ResetSATokenSourceCacheForTest() {
 	saTokenSourceCache.mu.Lock()
 	defer saTokenSourceCache.mu.Unlock()
 	saTokenSourceCache.sources = nil
+	saTokenSourceCache.baseURL = ""
+	saTokenSourceCache.terraformVersion = ""
 	saTokenSourceCache.closed = false
 }
 
-func SetSAInfoClosedForTest(closed bool) {
+func SetSATokenSourceCacheClosedForTest(closed bool) {
 	saTokenSourceCache.mu.Lock()
 	defer saTokenSourceCache.mu.Unlock()
 	saTokenSourceCache.closed = closed

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -1,0 +1,30 @@
+package config
+
+import "github.com/mongodb/atlas-sdk-go/auth"
+
+// Test helpers exported only for package config_test (see service_account_test.go).
+
+func GetTokenSourceForTest(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+	return getTokenSource(clientID, clientSecret, baseURL, terraformVersion)
+}
+
+func SetCreateTokenSourceForTest(fn func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error)) {
+	createTokenSourceFn = fn
+}
+
+func ResetCreateTokenSourceForTest() {
+	createTokenSourceFn = defaultCreateTokenSource
+}
+
+func ResetSAInfoForTest() {
+	saInfo.mu.Lock()
+	defer saInfo.mu.Unlock()
+	saInfo.sources = nil
+	saInfo.closed = false
+}
+
+func SetSAInfoClosedForTest(closed bool) {
+	saInfo.mu.Lock()
+	defer saInfo.mu.Unlock()
+	saInfo.closed = closed
+}

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -30,7 +30,7 @@ func ResetRevokeTokenForTest() {
 func ResetSATokenSourceCacheForTest() {
 	saTokenSourceCache.mu.Lock()
 	defer saTokenSourceCache.mu.Unlock()
-	saTokenSourceCache.sources = nil
+	saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
 	saTokenSourceCache.baseURL = ""
 	saTokenSourceCache.terraformVersion = ""
 	saTokenSourceCache.closed = false

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -30,7 +30,7 @@ var saTokenSourceCache = struct {
 	terraformVersion string
 	mu               sync.Mutex
 	closed           bool
-}{}
+}{sources: make(map[string]*saTokenSourceEntry)}
 
 // createTokenSourceFn is the OAuth token-source factory; overridden in unit tests.
 var createTokenSourceFn = defaultCreateTokenSource
@@ -60,10 +60,10 @@ func defaultRevokeToken(clientID string, entry *saTokenSourceEntry) {
 }
 
 func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
-	// Hold the cache lock through token creation so concurrent callers with the same
-	// client_id cannot create duplicate, untracked tokens. This serializes SA init
-	// across client_ids (e.g. concurrent org creates with nested SAs); that path is
-	// rare enough that we prefer this over a finer-grained lock.
+	// Hold the cache lock through token creation so map updates stay synchronous when
+	// concurrent callers use different client_ids (multi-org create with nested SAs).
+	// That is the only path impacted by locking across the network call; we accept that
+	// serialization over a finer-grained lock.
 	saTokenSourceCache.mu.Lock()
 	defer saTokenSourceCache.mu.Unlock()
 
@@ -72,9 +72,6 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 	}
 
 	baseURL = NormalizeBaseURL(baseURL)
-	if saTokenSourceCache.sources == nil {
-		saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
-	}
 	if len(saTokenSourceCache.sources) > 0 && saTokenSourceCache.baseURL != baseURL {
 		return nil, fmt.Errorf("service account credentials changed")
 	}

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -16,19 +16,20 @@ import (
 const saTokenExpiryBuffer = 10 * time.Minute
 
 type saTokenSourceEntry struct {
-	tokenSource      auth.TokenSource
-	clientSecret     string
-	baseURL          string
-	terraformVersion string
+	tokenSource  auth.TokenSource
+	clientSecret string
 }
 
 // saTokenSourceCache caches token sources per service account (keyed by clientID) so a single
 // provider process can authenticate as more than one SA (e.g. org-creator SA, then the SA
-// created with a new org).
+// created with a new org). baseURL and terraformVersion are process-wide: provider config and
+// nested SA clients share them.
 var saTokenSourceCache = struct {
-	sources map[string]*saTokenSourceEntry
-	mu      sync.Mutex
-	closed  bool
+	sources          map[string]*saTokenSourceEntry
+	baseURL          string
+	terraformVersion string
+	mu               sync.Mutex
+	closed           bool
 }{}
 
 // createTokenSourceFn is the OAuth token-source factory; overridden in unit tests.
@@ -53,8 +54,8 @@ func defaultRevokeToken(clientID string, entry *saTokenSourceEntry) {
 	if err != nil {
 		return // Best-effort, no need to do anything if the token can't be retrieved.
 	}
-	conf := GetServiceAccountConfig(clientID, entry.clientSecret, entry.baseURL)
-	ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(entry.terraformVersion))
+	conf := GetServiceAccountConfig(clientID, entry.clientSecret, saTokenSourceCache.baseURL)
+	ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(saTokenSourceCache.terraformVersion))
 	_ = conf.RevokeToken(ctx, token) // Best-effort, no need to do anything if it fails.
 }
 
@@ -74,8 +75,11 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 	if saTokenSourceCache.sources == nil {
 		saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
 	}
+	if len(saTokenSourceCache.sources) > 0 && saTokenSourceCache.baseURL != baseURL {
+		return nil, fmt.Errorf("service account credentials changed")
+	}
 	if entry, ok := saTokenSourceCache.sources[clientID]; ok {
-		if entry.clientSecret != clientSecret || entry.baseURL != baseURL {
+		if entry.clientSecret != clientSecret {
 			return nil, fmt.Errorf("service account credentials changed")
 		}
 		return entry.tokenSource, nil
@@ -86,11 +90,11 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 		return nil, err
 	}
 	saTokenSourceCache.sources[clientID] = &saTokenSourceEntry{
-		tokenSource:      tokenSource,
-		clientSecret:     clientSecret,
-		baseURL:          baseURL,
-		terraformVersion: terraformVersion,
+		tokenSource:  tokenSource,
+		clientSecret: clientSecret,
 	}
+	saTokenSourceCache.baseURL = baseURL
+	saTokenSourceCache.terraformVersion = terraformVersion
 	return tokenSource, nil
 }
 

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -29,7 +29,7 @@ var saTokenSourceCache = struct {
 	sources map[string]*saTokenSourceEntry
 	mu      sync.Mutex
 	closed  bool
-}{sources: make(map[string]*saTokenSourceEntry)}
+}{}
 
 // createTokenSourceFn is the OAuth token-source factory; overridden in unit tests.
 var createTokenSourceFn = defaultCreateTokenSource
@@ -59,32 +59,28 @@ func defaultRevokeToken(clientID string, entry *saTokenSourceEntry) {
 }
 
 func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
-	baseURL = NormalizeBaseURL(baseURL)
-
-	// Read from cache.
 	saTokenSourceCache.mu.Lock()
-	ts, err := getCachedTokenSource(clientID, clientSecret, baseURL)
-	saTokenSourceCache.mu.Unlock()
-	if ts != nil || err != nil {
-		return ts, err
+	defer saTokenSourceCache.mu.Unlock()
+
+	if saTokenSourceCache.closed {
+		return nil, fmt.Errorf("service account token source already closed")
 	}
 
-	// Cache miss, fetch token.
+	baseURL = NormalizeBaseURL(baseURL)
+	if saTokenSourceCache.sources == nil {
+		saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
+	}
+	if entry, ok := saTokenSourceCache.sources[clientID]; ok {
+		if entry.clientSecret != clientSecret || entry.baseURL != baseURL {
+			return nil, fmt.Errorf("service account credentials changed")
+		}
+		return entry.tokenSource, nil
+	}
+
 	tokenSource, err := createTokenSourceFn(clientID, clientSecret, baseURL, terraformVersion)
 	if err != nil {
 		return nil, err
 	}
-
-	// Re-acquire lock.
-	saTokenSourceCache.mu.Lock()
-	defer saTokenSourceCache.mu.Unlock()
-
-	// Re-check cache.
-	if ts, err = getCachedTokenSource(clientID, clientSecret, baseURL); ts != nil || err != nil {
-		return ts, err
-	}
-
-	// Write to cache.
 	saTokenSourceCache.sources[clientID] = &saTokenSourceEntry{
 		tokenSource:      tokenSource,
 		clientSecret:     clientSecret,
@@ -92,21 +88,6 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 		terraformVersion: terraformVersion,
 	}
 	return tokenSource, nil
-}
-
-// getCachedTokenSource checks the closed flag and reads from the sources map. Callers must hold a lock on saTokenSourceCache.mu.
-func getCachedTokenSource(clientID, clientSecret, baseURL string) (auth.TokenSource, error) {
-	if saTokenSourceCache.closed {
-		return nil, fmt.Errorf("service account token source already closed")
-	}
-	entry, ok := saTokenSourceCache.sources[clientID]
-	if !ok {
-		return nil, nil
-	}
-	if entry.clientSecret != clientSecret || entry.baseURL != baseURL {
-		return nil, fmt.Errorf("service account credentials changed")
-	}
-	return entry.tokenSource, nil
 }
 
 func NormalizeBaseURL(baseURL string) string {

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -92,7 +92,7 @@ func GetServiceAccountConfig(clientID, clientSecret, baseURL string) *clientcred
 }
 
 // CloseTokenSource is called just before the provider finishes, it does a best-effort try to revoke all cached Service Account tokens.
-// It sets saInfo.closed = true to avoid future calls to getTokenSource, that should't happen as the provider is exiting.
+// It sets saInfo.closed = true to avoid future calls to getTokenSource, that shouldn't happen as the provider is exiting.
 func CloseTokenSource() {
 	saInfo.mu.Lock()
 	defer saInfo.mu.Unlock()

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -59,6 +59,10 @@ func defaultRevokeToken(clientID string, entry *saTokenSourceEntry) {
 }
 
 func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+	// Hold the cache lock through token creation so concurrent callers with the same
+	// client_id cannot create duplicate, untracked tokens. This serializes SA init
+	// across client_ids (e.g. concurrent org creates with nested SAs); that path is
+	// rare enough that we prefer this over a finer-grained lock.
 	saTokenSourceCache.mu.Lock()
 	defer saTokenSourceCache.mu.Unlock()
 

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -15,24 +15,27 @@ import (
 // Renew token if it expires within 10 minutes to avoid authentication errors during Atlas API calls.
 const saTokenExpiryBuffer = 10 * time.Minute
 
-type saCacheEntry struct {
+type saTokenSourceEntry struct {
 	tokenSource      auth.TokenSource
-	clientID         string
 	clientSecret     string
 	baseURL          string
 	terraformVersion string
 }
 
-// saInfo caches token sources per service account so a single provider process can
-// authenticate as more than one SA (e.g. org-creator SA, then the SA created with a new org).
-var saInfo = struct {
-	sources map[string]*saCacheEntry
+// saTokenSourceCache caches token sources per service account (keyed by clientID) so a single
+// provider process can authenticate as more than one SA (e.g. org-creator SA, then the SA
+// created with a new org).
+var saTokenSourceCache = struct {
+	sources map[string]*saTokenSourceEntry
 	mu      sync.Mutex
 	closed  bool
 }{}
 
 // createTokenSourceFn is the OAuth token-source factory; overridden in unit tests.
 var createTokenSourceFn = defaultCreateTokenSource
+
+// revokeTokenFn revokes a single Service Account token; overridden in unit tests.
+var revokeTokenFn = defaultRevokeToken
 
 func defaultCreateTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
 	// Use a new context to avoid "context canceled" errors as the token source is reused and can outlast the callee context.
@@ -45,19 +48,29 @@ func defaultCreateTokenSource(clientID, clientSecret, baseURL, terraformVersion 
 	return tokenSource, nil
 }
 
-func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
-	saInfo.mu.Lock()
-	defer saInfo.mu.Unlock()
+func defaultRevokeToken(clientID string, entry *saTokenSourceEntry) {
+	token, err := entry.tokenSource.Token()
+	if err != nil {
+		return // Best-effort, no need to do anything if the token can't be retrieved.
+	}
+	conf := GetServiceAccountConfig(clientID, entry.clientSecret, entry.baseURL)
+	ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(entry.terraformVersion))
+	_ = conf.RevokeToken(ctx, token) // Best-effort, no need to do anything if it fails.
+}
 
-	if saInfo.closed {
+func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+	saTokenSourceCache.mu.Lock()
+	defer saTokenSourceCache.mu.Unlock()
+
+	if saTokenSourceCache.closed {
 		return nil, fmt.Errorf("service account token source already closed")
 	}
 
 	baseURL = NormalizeBaseURL(baseURL)
-	if saInfo.sources == nil {
-		saInfo.sources = make(map[string]*saCacheEntry)
+	if saTokenSourceCache.sources == nil {
+		saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
 	}
-	if entry, ok := saInfo.sources[clientID]; ok {
+	if entry, ok := saTokenSourceCache.sources[clientID]; ok {
 		if entry.clientSecret != clientSecret || entry.baseURL != baseURL {
 			return nil, fmt.Errorf("service account credentials changed")
 		}
@@ -68,9 +81,8 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 	if err != nil {
 		return nil, err
 	}
-	saInfo.sources[clientID] = &saCacheEntry{
+	saTokenSourceCache.sources[clientID] = &saTokenSourceEntry{
 		tokenSource:      tokenSource,
-		clientID:         clientID,
 		clientSecret:     clientSecret,
 		baseURL:          baseURL,
 		terraformVersion: terraformVersion,
@@ -92,19 +104,15 @@ func GetServiceAccountConfig(clientID, clientSecret, baseURL string) *clientcred
 }
 
 // CloseTokenSource is called just before the provider finishes, it does a best-effort try to revoke all cached Service Account tokens.
-// It sets saInfo.closed = true to avoid future calls to getTokenSource, that shouldn't happen as the provider is exiting.
+// It sets saTokenSourceCache.closed = true to avoid future calls to getTokenSource, that shouldn't happen as the provider is exiting.
 func CloseTokenSource() {
-	saInfo.mu.Lock()
-	defer saInfo.mu.Unlock()
-	if saInfo.closed {
+	saTokenSourceCache.mu.Lock()
+	defer saTokenSourceCache.mu.Unlock()
+	if saTokenSourceCache.closed {
 		return
 	}
-	saInfo.closed = true
-	for _, entry := range saInfo.sources {
-		if token, err := entry.tokenSource.Token(); err == nil {
-			conf := GetServiceAccountConfig(entry.clientID, entry.clientSecret, entry.baseURL)
-			ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(entry.terraformVersion))
-			_ = conf.RevokeToken(ctx, token) // Best-effort, no need to do anything if it fails.
-		}
+	saTokenSourceCache.closed = true
+	for clientID, entry := range saTokenSourceCache.sources {
+		revokeTokenFn(clientID, entry)
 	}
 }

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -34,10 +34,6 @@ var saInfo = struct {
 // createTokenSourceFn is the OAuth token-source factory; overridden in unit tests.
 var createTokenSourceFn = defaultCreateTokenSource
 
-func saCacheKey(clientID, baseURL string) string {
-	return clientID + "\x00" + NormalizeBaseURL(baseURL)
-}
-
 func defaultCreateTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
 	// Use a new context to avoid "context canceled" errors as the token source is reused and can outlast the callee context.
 	ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(terraformVersion))
@@ -58,12 +54,11 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 	}
 
 	baseURL = NormalizeBaseURL(baseURL)
-	key := saCacheKey(clientID, baseURL)
 	if saInfo.sources == nil {
 		saInfo.sources = make(map[string]*saCacheEntry)
 	}
-	if entry, ok := saInfo.sources[key]; ok {
-		if entry.clientSecret != clientSecret {
+	if entry, ok := saInfo.sources[clientID]; ok {
+		if entry.clientSecret != clientSecret || entry.baseURL != baseURL {
 			return nil, fmt.Errorf("service account credentials changed")
 		}
 		return entry.tokenSource, nil
@@ -73,7 +68,7 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 	if err != nil {
 		return nil, err
 	}
-	saInfo.sources[key] = &saCacheEntry{
+	saInfo.sources[clientID] = &saCacheEntry{
 		tokenSource:      tokenSource,
 		clientID:         clientID,
 		clientSecret:     clientSecret,

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -15,15 +15,39 @@ import (
 // Renew token if it expires within 10 minutes to avoid authentication errors during Atlas API calls.
 const saTokenExpiryBuffer = 10 * time.Minute
 
-var saInfo = struct {
+type saCacheEntry struct {
 	tokenSource      auth.TokenSource
 	clientID         string
 	clientSecret     string
 	baseURL          string
 	terraformVersion string
-	mu               sync.Mutex
-	closed           bool
+}
+
+// saInfo caches token sources per service account so a single provider process can
+// authenticate as more than one SA (e.g. org-creator SA, then the SA created with a new org).
+var saInfo = struct {
+	sources map[string]*saCacheEntry
+	mu      sync.Mutex
+	closed  bool
 }{}
+
+// createTokenSourceFn is the OAuth token-source factory; overridden in unit tests.
+var createTokenSourceFn = defaultCreateTokenSource
+
+func saCacheKey(clientID, baseURL string) string {
+	return clientID + "\x00" + NormalizeBaseURL(baseURL)
+}
+
+func defaultCreateTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+	// Use a new context to avoid "context canceled" errors as the token source is reused and can outlast the callee context.
+	ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(terraformVersion))
+	conf := GetServiceAccountConfig(clientID, clientSecret, baseURL)
+	tokenSource := oauth2.ReuseTokenSourceWithExpiry(nil, conf.TokenSource(ctx), saTokenExpiryBuffer)
+	if _, err := tokenSource.Token(); err != nil { // Retrieve token to fail-fast if credentials are invalid.
+		return nil, err
+	}
+	return tokenSource, nil
+}
 
 func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
 	saInfo.mu.Lock()
@@ -34,26 +58,29 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 	}
 
 	baseURL = NormalizeBaseURL(baseURL)
-	if saInfo.tokenSource != nil { // Token source in cache.
-		if saInfo.clientID != clientID || saInfo.clientSecret != clientSecret || saInfo.baseURL != baseURL {
+	key := saCacheKey(clientID, baseURL)
+	if saInfo.sources == nil {
+		saInfo.sources = make(map[string]*saCacheEntry)
+	}
+	if entry, ok := saInfo.sources[key]; ok {
+		if entry.clientSecret != clientSecret {
 			return nil, fmt.Errorf("service account credentials changed")
 		}
-		return saInfo.tokenSource, nil
+		return entry.tokenSource, nil
 	}
 
-	// Use a new context to avoid "context canceled" errors as the token source is reused and can outlast the callee context.
-	ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(terraformVersion))
-	conf := GetServiceAccountConfig(clientID, clientSecret, baseURL)
-	tokenSource := oauth2.ReuseTokenSourceWithExpiry(nil, conf.TokenSource(ctx), saTokenExpiryBuffer)
-	if _, err := tokenSource.Token(); err != nil { // Retrieve token to fail-fast if credentials are invalid.
+	tokenSource, err := createTokenSourceFn(clientID, clientSecret, baseURL, terraformVersion)
+	if err != nil {
 		return nil, err
 	}
-	saInfo.clientID = clientID
-	saInfo.clientSecret = clientSecret
-	saInfo.baseURL = baseURL
-	saInfo.terraformVersion = terraformVersion
-	saInfo.tokenSource = tokenSource
-	return saInfo.tokenSource, nil
+	saInfo.sources[key] = &saCacheEntry{
+		tokenSource:      tokenSource,
+		clientID:         clientID,
+		clientSecret:     clientSecret,
+		baseURL:          baseURL,
+		terraformVersion: terraformVersion,
+	}
+	return tokenSource, nil
 }
 
 func NormalizeBaseURL(baseURL string) string {
@@ -69,7 +96,7 @@ func GetServiceAccountConfig(clientID, clientSecret, baseURL string) *clientcred
 	return config
 }
 
-// CloseTokenSource is called just before the provider finishes, it does a best-effort try to revoke the Service Access token.
+// CloseTokenSource is called just before the provider finishes, it does a best-effort try to revoke all cached Service Account tokens.
 // It sets saInfo.closed = true to avoid future calls to getTokenSource, that should't happen as the provider is exiting.
 func CloseTokenSource() {
 	saInfo.mu.Lock()
@@ -78,12 +105,11 @@ func CloseTokenSource() {
 		return
 	}
 	saInfo.closed = true
-	if saInfo.tokenSource == nil { // No need to do anything if SA was not initialized.
-		return
-	}
-	if token, err := saInfo.tokenSource.Token(); err == nil {
-		conf := GetServiceAccountConfig(saInfo.clientID, saInfo.clientSecret, saInfo.baseURL)
-		ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(saInfo.terraformVersion))
-		_ = conf.RevokeToken(ctx, token) // Best-effort, no need to do anything if it fails.
+	for _, entry := range saInfo.sources {
+		if token, err := entry.tokenSource.Token(); err == nil {
+			conf := GetServiceAccountConfig(entry.clientID, entry.clientSecret, entry.baseURL)
+			ctx := context.WithValue(context.Background(), auth.HTTPClient, NewOAuthHTTPClient(entry.terraformVersion))
+			_ = conf.RevokeToken(ctx, token) // Best-effort, no need to do anything if it fails.
+		}
 	}
 }

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -29,7 +29,7 @@ var saTokenSourceCache = struct {
 	sources map[string]*saTokenSourceEntry
 	mu      sync.Mutex
 	closed  bool
-}{}
+}{sources: make(map[string]*saTokenSourceEntry)}
 
 // createTokenSourceFn is the OAuth token-source factory; overridden in unit tests.
 var createTokenSourceFn = defaultCreateTokenSource
@@ -59,28 +59,32 @@ func defaultRevokeToken(clientID string, entry *saTokenSourceEntry) {
 }
 
 func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
-	saTokenSourceCache.mu.Lock()
-	defer saTokenSourceCache.mu.Unlock()
-
-	if saTokenSourceCache.closed {
-		return nil, fmt.Errorf("service account token source already closed")
-	}
-
 	baseURL = NormalizeBaseURL(baseURL)
-	if saTokenSourceCache.sources == nil {
-		saTokenSourceCache.sources = make(map[string]*saTokenSourceEntry)
-	}
-	if entry, ok := saTokenSourceCache.sources[clientID]; ok {
-		if entry.clientSecret != clientSecret || entry.baseURL != baseURL {
-			return nil, fmt.Errorf("service account credentials changed")
-		}
-		return entry.tokenSource, nil
+
+	// Read from cache.
+	saTokenSourceCache.mu.Lock()
+	ts, err := getCachedTokenSource(clientID, clientSecret, baseURL)
+	saTokenSourceCache.mu.Unlock()
+	if ts != nil || err != nil {
+		return ts, err
 	}
 
+	// Cache miss, fetch token.
 	tokenSource, err := createTokenSourceFn(clientID, clientSecret, baseURL, terraformVersion)
 	if err != nil {
 		return nil, err
 	}
+
+	// Re-acquire lock.
+	saTokenSourceCache.mu.Lock()
+	defer saTokenSourceCache.mu.Unlock()
+
+	// Re-check cache.
+	if ts, err = getCachedTokenSource(clientID, clientSecret, baseURL); ts != nil || err != nil {
+		return ts, err
+	}
+
+	// Write to cache.
 	saTokenSourceCache.sources[clientID] = &saTokenSourceEntry{
 		tokenSource:      tokenSource,
 		clientSecret:     clientSecret,
@@ -88,6 +92,21 @@ func getTokenSource(clientID, clientSecret, baseURL, terraformVersion string) (a
 		terraformVersion: terraformVersion,
 	}
 	return tokenSource, nil
+}
+
+// getCachedTokenSource checks the closed flag and reads from the sources map. Callers must hold a lock on saTokenSourceCache.mu.
+func getCachedTokenSource(clientID, clientSecret, baseURL string) (auth.TokenSource, error) {
+	if saTokenSourceCache.closed {
+		return nil, fmt.Errorf("service account token source already closed")
+	}
+	entry, ok := saTokenSourceCache.sources[clientID]
+	if !ok {
+		return nil, nil
+	}
+	if entry.clientSecret != clientSecret || entry.baseURL != baseURL {
+		return nil, fmt.Errorf("service account credentials changed")
+	}
+	return entry.tokenSource, nil
 }
 
 func NormalizeBaseURL(baseURL string) string {

--- a/internal/config/service_account_test.go
+++ b/internal/config/service_account_test.go
@@ -24,18 +24,18 @@ func (s staticTokenSource) Token() (*oauth2.Token, error) {
 	return s.token, nil
 }
 
-func resetSAInfo(t *testing.T) {
+func resetSATokenSourceCache(t *testing.T) {
 	t.Helper()
-	config.ResetSAInfoForTest()
+	config.ResetSATokenSourceCacheForTest()
 	t.Cleanup(func() {
-		config.ResetSAInfoForTest()
+		config.ResetSATokenSourceCacheForTest()
 		config.ResetCreateTokenSourceForTest()
 		config.ResetRevokeTokenForTest()
 	})
 }
 
 func TestGetTokenSource_AllowsDifferentClientIDs(t *testing.T) {
-	resetSAInfo(t)
+	resetSATokenSourceCache(t)
 
 	var mu sync.Mutex
 	created := make([]string, 0, 2)
@@ -61,7 +61,7 @@ func TestGetTokenSource_AllowsDifferentClientIDs(t *testing.T) {
 }
 
 func TestGetTokenSource_ReusesCacheForSameClientID(t *testing.T) {
-	resetSAInfo(t)
+	resetSATokenSourceCache(t)
 
 	calls := 0
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
@@ -77,7 +77,7 @@ func TestGetTokenSource_ReusesCacheForSameClientID(t *testing.T) {
 }
 
 func TestGetTokenSource_RejectsSecretChangeForSameClientID(t *testing.T) {
-	resetSAInfo(t)
+	resetSATokenSourceCache(t)
 
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
 		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok", TokenType: "Bearer"}}, nil
@@ -90,8 +90,8 @@ func TestGetTokenSource_RejectsSecretChangeForSameClientID(t *testing.T) {
 	assert.Contains(t, err.Error(), "service account credentials changed")
 }
 
-func TestGetTokenSource_RejectsBaseURLChangeForSameClientID(t *testing.T) {
-	resetSAInfo(t)
+func TestGetTokenSource_RejectsBaseURLChange(t *testing.T) {
+	resetSATokenSourceCache(t)
 
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
 		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok", TokenType: "Bearer"}}, nil
@@ -102,10 +102,14 @@ func TestGetTokenSource_RejectsBaseURLChangeForSameClientID(t *testing.T) {
 	_, err = config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud.mongodb.com", "1.0.0")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "service account credentials changed")
+
+	_, err = config.GetTokenSourceForTest("client-b", "secret-b", "https://cloud.mongodb.com", "1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service account credentials changed")
 }
 
 func TestGetTokenSource_ReusesCacheWhenBaseURLDiffersOnlyByTrailingSlash(t *testing.T) {
-	resetSAInfo(t)
+	resetSATokenSourceCache(t)
 
 	calls := 0
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
@@ -121,7 +125,7 @@ func TestGetTokenSource_ReusesCacheWhenBaseURLDiffersOnlyByTrailingSlash(t *test
 }
 
 func TestCloseTokenSource_RevokesAllCachedSources(t *testing.T) {
-	resetSAInfo(t)
+	resetSATokenSourceCache(t)
 
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
 		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok-" + clientID, TokenType: "Bearer"}}, nil
@@ -145,11 +149,11 @@ func TestCloseTokenSource_RevokesAllCachedSources(t *testing.T) {
 }
 
 func TestGetTokenSource_ErrorsWhenClosed(t *testing.T) {
-	resetSAInfo(t)
+	resetSATokenSourceCache(t)
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
 		return nil, errors.New("should not be called")
 	})
-	config.SetSAInfoClosedForTest(true)
+	config.SetSATokenSourceCacheClosedForTest(true)
 
 	_, err := config.GetTokenSourceForTest("client-a", "secret-a", "", "1.0.0")
 	require.Error(t, err)

--- a/internal/config/service_account_test.go
+++ b/internal/config/service_account_test.go
@@ -30,6 +30,7 @@ func resetSAInfo(t *testing.T) {
 	t.Cleanup(func() {
 		config.ResetSAInfoForTest()
 		config.ResetCreateTokenSourceForTest()
+		config.ResetRevokeTokenForTest()
 	})
 }
 
@@ -117,6 +118,30 @@ func TestGetTokenSource_ReusesCacheWhenBaseURLDiffersOnlyByTrailingSlash(t *test
 	_, err = config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com/", "1.0.0")
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
+}
+
+func TestCloseTokenSource_RevokesAllCachedSources(t *testing.T) {
+	resetSAInfo(t)
+
+	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok-" + clientID, TokenType: "Bearer"}}, nil
+	})
+
+	var mu sync.Mutex
+	revoked := make([]string, 0, 2)
+	config.SetRevokeTokenForTest(func(clientID string) {
+		mu.Lock()
+		revoked = append(revoked, clientID)
+		mu.Unlock()
+	})
+
+	_, err := config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+	_, err = config.GetTokenSourceForTest("client-b", "secret-b", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+
+	config.CloseTokenSource()
+	assert.ElementsMatch(t, []string{"client-a", "client-b"}, revoked)
 }
 
 func TestGetTokenSource_ErrorsWhenClosed(t *testing.T) {

--- a/internal/config/service_account_test.go
+++ b/internal/config/service_account_test.go
@@ -1,0 +1,102 @@
+package config_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/mongodb/atlas-sdk-go/auth"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type staticTokenSource struct {
+	token *oauth2.Token
+	err   error
+}
+
+func (s staticTokenSource) Token() (*oauth2.Token, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.token, nil
+}
+
+func resetSAInfo(t *testing.T) {
+	t.Helper()
+	config.ResetSAInfoForTest()
+	t.Cleanup(func() {
+		config.ResetSAInfoForTest()
+		config.ResetCreateTokenSourceForTest()
+	})
+}
+
+func TestGetTokenSource_AllowsDifferentClientIDs(t *testing.T) {
+	resetSAInfo(t)
+
+	var mu sync.Mutex
+	created := make([]string, 0, 2)
+	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+		mu.Lock()
+		created = append(created, clientID)
+		mu.Unlock()
+		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok-" + clientID, TokenType: "Bearer"}}, nil
+	})
+
+	ts1, err := config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+	ts2, err := config.GetTokenSourceForTest("client-b", "secret-b", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+
+	tok1, err := ts1.Token()
+	require.NoError(t, err)
+	tok2, err := ts2.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "tok-client-a", tok1.AccessToken)
+	assert.Equal(t, "tok-client-b", tok2.AccessToken)
+	assert.Equal(t, []string{"client-a", "client-b"}, created)
+}
+
+func TestGetTokenSource_ReusesCacheForSameClientID(t *testing.T) {
+	resetSAInfo(t)
+
+	calls := 0
+	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+		calls++
+		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok", TokenType: "Bearer"}}, nil
+	})
+
+	_, err := config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+	_, err = config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestGetTokenSource_RejectsSecretChangeForSameClientID(t *testing.T) {
+	resetSAInfo(t)
+
+	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok", TokenType: "Bearer"}}, nil
+	})
+
+	_, err := config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+	_, err = config.GetTokenSourceForTest("client-a", "secret-b", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service account credentials changed")
+}
+
+func TestGetTokenSource_ErrorsWhenClosed(t *testing.T) {
+	resetSAInfo(t)
+	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+		return nil, errors.New("should not be called")
+	})
+	config.SetSAInfoClosedForTest(true)
+
+	_, err := config.GetTokenSourceForTest("client-a", "secret-a", "", "1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already closed")
+}

--- a/internal/config/service_account_test.go
+++ b/internal/config/service_account_test.go
@@ -103,6 +103,22 @@ func TestGetTokenSource_RejectsBaseURLChangeForSameClientID(t *testing.T) {
 	assert.Contains(t, err.Error(), "service account credentials changed")
 }
 
+func TestGetTokenSource_ReusesCacheWhenBaseURLDiffersOnlyByTrailingSlash(t *testing.T) {
+	resetSAInfo(t)
+
+	calls := 0
+	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+		calls++
+		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok", TokenType: "Bearer"}}, nil
+	})
+
+	_, err := config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+	_, err = config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com/", "1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
 func TestGetTokenSource_ErrorsWhenClosed(t *testing.T) {
 	resetSAInfo(t)
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {

--- a/internal/config/service_account_test.go
+++ b/internal/config/service_account_test.go
@@ -89,6 +89,20 @@ func TestGetTokenSource_RejectsSecretChangeForSameClientID(t *testing.T) {
 	assert.Contains(t, err.Error(), "service account credentials changed")
 }
 
+func TestGetTokenSource_RejectsBaseURLChangeForSameClientID(t *testing.T) {
+	resetSAInfo(t)
+
+	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {
+		return staticTokenSource{token: &oauth2.Token{AccessToken: "tok", TokenType: "Bearer"}}, nil
+	})
+
+	_, err := config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud-qa.mongodb.com", "1.0.0")
+	require.NoError(t, err)
+	_, err = config.GetTokenSourceForTest("client-a", "secret-a", "https://cloud.mongodb.com", "1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service account credentials changed")
+}
+
 func TestGetTokenSource_ErrorsWhenClosed(t *testing.T) {
 	resetSAInfo(t)
 	config.SetCreateTokenSourceForTest(func(clientID, clientSecret, baseURL, terraformVersion string) (auth.TokenSource, error) {


### PR DESCRIPTION
## Description

Fixes org create with a nested `service_account` block when the provider is itself authenticated with a Service Account.

**Before:** `getTokenSource` kept a single process-wide SA token source. After `CreateOrg` returned the new org SA, switching credentials failed with `service account credentials changed`. `newSAClient` swallowed that error and fell back to the org-creator client, so the post-create settings `PATCH` returned `USER_CANNOT_ACCESS_ORG` and rollback `DELETE` failed the same way (dangling org).

**After:** Token sources are cached per `client_id`, so one provider process can hold both the org-creator SA and the newly created org SA. Same `client_id` with a different secret or `base_url` still errors. `CloseTokenSource` revokes all cached sources.

Link to related issue(s): [CLOUDP-428116](https://jira.mongodb.org/browse/CLOUDP-428116)

Test run: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/30368242613

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Required Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have run `make fix` / lint and verified my code
- [x] I have added a changelog entry (`.changelog/4597.txt`) for this bug fix