### PR TITLE
feat: Support in-place updates for alert_configuration severity_override

### DIFF
--- a/.changelog/4598.txt
+++ b/.changelog/4598.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_alert_configuration: Supports in-place updates for `severity_override`
+```

--- a/internal/service/alertconfiguration/resource.go
+++ b/internal/service/alertconfiguration/resource.go
@@ -155,9 +155,6 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 			},
 			"severity_override": schema.StringAttribute{
 				Optional: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 		},
 		Blocks: map[string]schema.Block{

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -683,7 +684,9 @@ func TestAccConfigRSAlertConfiguration_updateNotificationTypeFromTeamsToPagerDut
 
 func TestAccConfigRSAlertConfiguration_withSeverityOverride(t *testing.T) {
 	var (
-		projectID = acc.ProjectIDExecution(t)
+		projectID  = acc.ProjectIDExecution(t)
+		errorStr   = "ERROR"
+		warningStr = "WARNING"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -692,26 +695,22 @@ func TestAccConfigRSAlertConfiguration_withSeverityOverride(t *testing.T) {
 		CheckDestroy:             checkDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: configWithSeverityOverride(projectID, conversion.StringPtr("ERROR")),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "severity_override", "ERROR"),
-					// Data source checks
-					checkExists(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "severity_override", "ERROR"),
-				),
+				Config: configWithSeverityOverride(projectID, &errorStr),
+				Check:  checkSeverityOverride(&errorStr),
 			},
-			// TODO: Should check for no attr once CLOUDP-353933 is fixed.
-			// {
-			// 	Config: configWithSeverityOverride(projectID, nil),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		checkExists(resourceName),
-			// 		resource.TestCheckNoResourceAttr(resourceName, "severity_override"),
-			// 		// Data source checks
-			// 		checkExists(dataSourceName),
-			// 		resource.TestCheckNoResourceAttr(resourceName, "severity_override"),
-			// 	),
-			// },
+			{
+				Config: configWithSeverityOverride(projectID, &warningStr),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: checkSeverityOverride(&warningStr),
+			},
+			{
+				Config: configWithSeverityOverride(projectID, nil),
+				Check:  checkSeverityOverride(nil),
+			},
 		},
 	})
 }
@@ -732,6 +731,22 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+func checkSeverityOverride(severity *string) resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{checkExists(resourceName), checkExists(dataSourceName)}
+	if severity == nil {
+		checks = append(checks,
+			resource.TestCheckNoResourceAttr(resourceName, "severity_override"),
+			resource.TestCheckNoResourceAttr(dataSourceName, "severity_override"),
+		)
+	} else {
+		checks = append(checks,
+			resource.TestCheckResourceAttr(resourceName, "severity_override", *severity),
+			resource.TestCheckResourceAttr(dataSourceName, "severity_override", *severity),
+		)
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
 func checkDestroy() resource.TestCheckFunc {

--- a/internal/serviceapi/alertconfigurationapi/resource_test.go
+++ b/internal/serviceapi/alertconfigurationapi/resource_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -386,9 +385,11 @@ func TestAccAlertConfigurationAPI_withVictorOps(t *testing.T) {
 	})
 }
 
-func TestAccAlertConfigurationAPI_withSeverityOverride(t *testing.T) {
+func TestAccConfigRSAlertConfiguration_withSeverityOverride(t *testing.T) {
 	var (
-		projectID = acc.ProjectIDExecution(t)
+		projectID  = acc.ProjectIDExecution(t)
+		errorStr   = "ERROR"
+		warningStr = "WARNING"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -397,20 +398,22 @@ func TestAccAlertConfigurationAPI_withSeverityOverride(t *testing.T) {
 		CheckDestroy:             checkDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: configWithSeverityOverride(projectID, conversion.StringPtr("ERROR")),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "severity_override", "ERROR"),
-				),
+				Config: configWithSeverityOverride(projectID, &errorStr),
+				Check:  checkSeverityOverride(&errorStr),
 			},
-			// TODO: Should check for no attr once CLOUDP-353933 is fixed.
-			// {
-			// 	Config: configWithSeverityOverride(projectID, nil),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		checkExists(resourceName),
-			// 		resource.TestCheckNoResourceAttr(resourceName, "severity_override"),
-			// 	),
-			// },
+			{
+				Config: configWithSeverityOverride(projectID, &warningStr),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: checkSeverityOverride(&warningStr),
+			},
+			{
+				Config: configWithSeverityOverride(projectID, nil),
+				Check:  checkSeverityOverride(nil),
+			},
 		},
 	})
 }
@@ -431,6 +434,20 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+func checkSeverityOverride(severity *string) resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{checkExists(resourceName)}
+	if severity == nil {
+		checks = append(checks,
+			resource.TestCheckNoResourceAttr(resourceName, "severity_override"),
+		)
+	} else {
+		checks = append(checks,
+			resource.TestCheckResourceAttr(resourceName, "severity_override", *severity),
+		)
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
 func checkDestroy() resource.TestCheckFunc {

--- a/internal/serviceapi/alertconfigurationapi/resource_test.go
+++ b/internal/serviceapi/alertconfigurationapi/resource_test.go
@@ -385,7 +385,7 @@ func TestAccAlertConfigurationAPI_withVictorOps(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSAlertConfiguration_withSeverityOverride(t *testing.T) {
+func TestAccAlertConfigurationAPI_withSeverityOverride(t *testing.T) {
 	var (
 		projectID  = acc.ProjectIDExecution(t)
 		errorStr   = "ERROR"


### PR DESCRIPTION
## Description

The API now supports unsetting the `severity_override` attribute for `alert_configuration`.
The `RequiresReplace` plan modifier is no longer necessary, which means that we can now support in-place updates.

Link to any related issue(s): HELP-97508

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


