### PR TITLE
test: Use Admin API for independent shard scaling check

### DIFF
--- a/internal/service/advancedcluster/resource_migration_v1x_test.go
+++ b/internal/service/advancedcluster/resource_migration_v1x_test.go
@@ -130,18 +130,18 @@ func TestV1xMigAdvancedCluster_oldToNewSchemaWithAutoscalingEnabled(t *testing.T
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeTPFGARelease),
 				Config:            configShardedTransitionOldToNewSchema(t, !isSDKv2, projectID, clusterName, false, true, false),
-				Check:             acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER"),
+				Check:             acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING"),
 			},
 			mig.TestStepCheckEmptyPlan(configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, true, false)),
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, true, false),
-				Check:                    acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER"),
+				Check:                    acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING"),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, true, true),
-				Check:                    acc.CheckIndependentShardScalingMode(resourceName, clusterName, "SHARD"),
+				Check:                    acc.CheckIndependentShardScalingMode(resourceName, clusterName, "INDEPENDENT_SHARD_SCALING"),
 			},
 			mig.TestStepCheckEmptyPlan(configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, true, true)),
 		},
@@ -282,7 +282,7 @@ func TestV1xMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.
 				Config:            configGeoShardedTransitionOldToNewSchema(t, !isSDKv2, projectID, clusterName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkGeoShardedTransitionOldToNewSchema(false, false),
-					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
+					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING")),
 			},
 			mig.TestStepCheckEmptyPlan(configGeoShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true)),
 			{
@@ -290,7 +290,7 @@ func TestV1xMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.
 				Config:                   configGeoShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkGeoShardedTransitionOldToNewSchema(true, true),
-					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
+					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING")),
 			},
 			mig.TestStepCheckEmptyPlan(configGeoShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true)),
 		},

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -725,7 +725,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, useSDKv2 ...bool) resource
 				Config: configShardedNewSchema(t, orgID, projectName, clusterName, 50, "M30", "M40", new(2000), new(2500), false, false, isSDKv2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkShardedNewSchema(isTPF, 50, "M30", "M40", new(2000), new(2500), true, false),
-					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "SHARD")),
+					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "INDEPENDENT_SHARD_SCALING")),
 			},
 			acc.TestStepImportCluster(resourceName),
 		},

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1287,25 +1287,25 @@ func TestAccCluster_basic_RedactClientLogData(t *testing.T) {
 				Config: configRedactClientLogData(orgID, projectName, clusterName, nil),
 				Check: acc.CheckRSAndDS(resourceName, new(dataSourceName), new(dataSourcePluralName),
 					nil, map[string]string{"redact_client_log_data": "false"},
-					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
+					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING")),
 			},
 			{
 				Config: configRedactClientLogData(orgID, projectName, clusterName, new(false)),
 				Check: acc.CheckRSAndDS(resourceName, new(dataSourceName), new(dataSourcePluralName),
 					nil, map[string]string{"redact_client_log_data": "false"},
-					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
+					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING")),
 			},
 			{
 				Config: configRedactClientLogData(orgID, projectName, clusterName, new(true)),
 				Check: acc.CheckRSAndDS(resourceName, new(dataSourceName), new(dataSourcePluralName),
 					nil, map[string]string{"redact_client_log_data": "true"},
-					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")), // latest PATCH API is called, ensure autoscaling mode is not modified
+					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING")), // latest PATCH API is called, ensure autoscaling mode is not modified
 			},
 			{
 				Config: configRedactClientLogData(orgID, projectName, clusterName, new(false)),
 				Check: acc.CheckRSAndDS(resourceName, new(dataSourceName), new(dataSourcePluralName),
 					nil, map[string]string{"redact_client_log_data": "false"},
-					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
+					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER_WIDE_SCALING")),
 			},
 		},
 	})

--- a/internal/testutil/acc/independent_shard_scaling.go
+++ b/internal/testutil/acc/independent_shard_scaling.go
@@ -2,39 +2,14 @@ package acc
 
 import (
 	"context"
-	"io"
 	"net/http"
-	"os"
-
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func GetIndependentShardScalingMode(ctx context.Context, projectID, clusterName string) (*string, *http.Response, error) {
-	baseURL := config.NormalizeBaseURL(os.Getenv("MONGODB_ATLAS_BASE_URL"))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/test/utils/auth/groups/"+projectID+"/clusters/"+clusterName+"/independentShardScalingMode", http.NoBody)
-	if err != nil {
-		return nil, nil, err
-	}
-	req.Header.Add("Accept", "*/*")
-	resp, err := ConnV2().GetConfig().HTTPClient.Do(req)
-	if err != nil || resp == nil {
-		return nil, resp, err
-	}
-
-	var result *string
-	result, err = decode(resp.Body)
+	cfg, resp, err := ConnV2().ClustersAPI.AutoScalingConfiguration(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		return nil, resp, err
 	}
-
-	return result, resp, nil
-}
-
-func decode(body io.ReadCloser) (*string, error) {
-	buf, err := io.ReadAll(body)
-	_ = body.Close()
-	if err != nil {
-		return nil, err
-	}
-	return new(string(buf)), nil
+	mode := cfg.GetAutoScalingMode()
+	return &mode, resp, nil
 }

--- a/internal/testutil/acc/independent_shard_scaling.go
+++ b/internal/testutil/acc/independent_shard_scaling.go
@@ -2,6 +2,7 @@ package acc
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -9,6 +10,9 @@ func GetIndependentShardScalingMode(ctx context.Context, projectID, clusterName 
 	cfg, resp, err := ConnV2().ClustersAPI.AutoScalingConfiguration(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		return nil, resp, err
+	}
+	if cfg == nil {
+		return nil, resp, fmt.Errorf("auto scaling configuration is nil for cluster %s in project %s", clusterName, projectID)
 	}
 	mode := cfg.GetAutoScalingMode()
 	return &mode, resp, nil

--- a/internal/testutil/acc/independent_shard_scaling.go
+++ b/internal/testutil/acc/independent_shard_scaling.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 )
 
+// Deprecated AutoScalingConfiguration is the only Atlas API that returns autoScalingMode; used here
+// (test-only) to verify independent shard scaling—no supported replacement exists.
 func GetIndependentShardScalingMode(ctx context.Context, projectID, clusterName string) (*string, *http.Response, error) {
 	cfg, resp, err := ConnV2().ClustersAPI.AutoScalingConfiguration(ctx, projectID, clusterName).Execute()
 	if err != nil {


### PR DESCRIPTION
## Description

Fixes acceptance tests that use `CheckIndependentShardScalingMode` when CI runs with Service Account credentials.

**Before:** `GetIndependentShardScalingMode` called the cloud-dev MMS test-utils endpoint `/test/utils/auth/groups/{projectId}/clusters/{clusterName}/independentShardScalingMode`. That path accepts Digest (PAK) auth but returns Jetty HTML `401 Unauthorized` under SA Bearer auth. Cluster apply and `redact_client_log_data` checks still passed; only the ISS probe failed (for example `TestAccCluster_basic_RedactClientLogData` step 1 check 4).

**After:** The helper calls the public Admin API `GET .../autoScalingConfiguration` via `ConnV2().ClustersAPI.AutoScalingConfiguration`, which works for both PAK and SA. Expected mode strings at call sites now match the API enum: `CLUSTER_WIDE_SCALING` and `INDEPENDENT_SHARD_SCALING` (replacing test-utils plain-text `CLUSTER` / `SHARD`).

## Type of change

- [x] Test fix (acceptance test helper; no provider behavior change)

## Required Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have run `make fix` / lint and verified my code
- [ ] I have added a changelog entry (not required; test-only change)

## Test plan

- [x] `gofmt` and `go test -c` for `internal/testutil/acc`, `internal/service/cluster`, and `internal/service/advancedcluster`
- [x] SA acceptance: `cluster` job — `TestAccCluster_basic_RedactClientLogData` https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/30535400528 [sa run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/30610322973)
- [x] SA acceptance: `advanced_cluster` job — `TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema` and ISS checks in `resource_migration_v1x_test.go` https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/30535378433 [sa run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/30610377694)