### PR TITLE
doc: Add example for mongodbatlas_search_index

### DIFF
--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -140,6 +140,9 @@ resource "mongodbatlas_search_index" "conf-dynamic" {
 }
 ```
 
+### Further Examples
+- [Search Index Examples](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.15.0/examples/mongodbatlas_search_index)
+
 ## Argument Reference
 
 * `type` - (Optional) Type of index: `search` or `vectorSearch`. Default type is `search`.

--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -141,7 +141,7 @@ resource "mongodbatlas_search_index" "conf-dynamic" {
 ```
 
 ### Further Examples
-- [Search Index Examples](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v2.15.0/examples/mongodbatlas_search_index)
+- [Search Index Examples](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_search_index)
 
 ## Argument Reference
 

--- a/examples/mongodbatlas_search_index/README.md
+++ b/examples/mongodbatlas_search_index/README.md
@@ -1,6 +1,6 @@
 # MongoDB Atlas Provider - Search Indexes on a Cluster
 
-This example shows how to create the different `mongodbatlas_search_index` types on an Atlas cluster. A project and cluster are created as a prerequisite, and then three indexes on the same collection:
+This example shows how to create the different `mongodbatlas_search_index` types on a MongoDB Atlas cluster, three indexes on the same collection:
 
 - A text `search` index with dynamic mappings.
 - A `vector` index, for embeddings you generate and store yourself.
@@ -10,7 +10,8 @@ Variables required to be set:
 
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID.
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret.
-- `org_id`: Organization ID where the project and cluster are created.
+- `project_id`: MongoDB Atlas project (groupId) that holds the cluster.
+- `cluster_name`: MongoDB Atlas cluster with the collection to index.
 - `database`: Database that holds the collection to index.
 - `collection_name`: Collection to index.
 

--- a/examples/mongodbatlas_search_index/README.md
+++ b/examples/mongodbatlas_search_index/README.md
@@ -1,6 +1,6 @@
 # MongoDB Atlas Provider - Search Indexes on a Cluster
 
-This example shows how to create the different `mongodbatlas_search_index` types on a MongoDB Atlas cluster, three indexes on the same collection:
+This example shows how to create different `mongodbatlas_search_index` types on a MongoDB Atlas cluster, three indexes on the same collection:
 
 - A text `search` index with dynamic mappings.
 - A `vector` index, for embeddings you generate and store yourself.
@@ -10,7 +10,7 @@ Variables required to be set:
 
 - `atlas_client_id`: MongoDB Atlas Service Account Client ID.
 - `atlas_client_secret`: MongoDB Atlas Service Account Client Secret.
-- `project_id`: MongoDB Atlas project (groupId) that holds the cluster.
+- `project_id`: MongoDB Atlas project ID that holds the cluster.
 - `cluster_name`: MongoDB Atlas cluster with the collection to index.
 - `database`: Database that holds the collection to index.
 - `collection_name`: Collection to index.

--- a/examples/mongodbatlas_search_index/README.md
+++ b/examples/mongodbatlas_search_index/README.md
@@ -1,0 +1,19 @@
+# MongoDB Atlas Provider - Search Indexes on a Cluster
+
+This example shows how to create the different `mongodbatlas_search_index` types on an Atlas cluster. A project and cluster are created as a prerequisite, and then three indexes on the same collection:
+
+- A text `search` index with dynamic mappings.
+- A `vector` index, for embeddings you generate and store yourself.
+- An `autoEmbed` (Automated Embedding) index, where Atlas generates the embeddings from a text field using a Voyage model.
+
+Variables required to be set:
+
+- `atlas_client_id`: MongoDB Atlas Service Account Client ID.
+- `atlas_client_secret`: MongoDB Atlas Service Account Client Secret.
+- `org_id`: Organization ID where the project and cluster are created.
+- `database`: Database that holds the collection to index.
+- `collection_name`: Collection to index.
+
+Adjust the field paths in `main.tf` to match your collection.
+
+For the Automated Embedding (`autoEmbed`) index, see [Automated Embedding](https://www.mongodb.com/docs/vector-search/crud-embeddings/automated-embedding/) for supported models and requirements. For additional information on search index field types, see [Vector Search Types](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/).

--- a/examples/mongodbatlas_search_index/main.tf
+++ b/examples/mongodbatlas_search_index/main.tf
@@ -1,0 +1,86 @@
+resource "mongodbatlas_project" "example" {
+  name   = "search-index-example"
+  org_id = var.org_id
+}
+
+resource "mongodbatlas_advanced_cluster" "example" {
+  project_id   = mongodbatlas_project.example.id
+  name         = "ClusterExample"
+  cluster_type = "REPLICASET"
+
+  replication_specs = [{
+    region_configs = [{
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }]
+  }]
+}
+
+# Text search index with dynamic mappings.
+resource "mongodbatlas_search_index" "search" {
+  project_id       = mongodbatlas_project.example.id
+  cluster_name     = mongodbatlas_advanced_cluster.example.name
+  database         = var.database
+  collection_name  = var.collection_name
+  name             = "search-index"
+  type             = "search"
+  mappings_dynamic = true
+}
+
+# Vector search index with embeddings you generate and store yourself.
+resource "mongodbatlas_search_index" "vector" {
+  project_id      = mongodbatlas_project.example.id
+  cluster_name    = mongodbatlas_advanced_cluster.example.name
+  database        = var.database
+  collection_name = var.collection_name
+  name            = "vector-index"
+  type            = "vectorSearch"
+  fields          = <<-EOF
+[{
+  "type": "vector",
+  "path": "plot_embedding",
+  "numDimensions": 1536,
+  "similarity": "euclidean"
+}]
+EOF
+}
+
+# Vector search index with Automated Embedding: Atlas generates the embeddings
+# from a text field using the specified Voyage model.
+resource "mongodbatlas_search_index" "auto_embed" {
+  project_id      = mongodbatlas_project.example.id
+  cluster_name    = mongodbatlas_advanced_cluster.example.name
+  database        = var.database
+  collection_name = var.collection_name
+  name            = "auto-embed-index"
+  type            = "vectorSearch"
+  fields          = <<-EOF
+[{
+  "type": "autoEmbed",
+  "path": "plot",
+  "model": "voyage-4-lite",
+  "modality": "text"
+},
+{
+  "type": "filter",
+  "path": "genres"
+}]
+EOF
+}
+
+output "search_index_id" {
+  value = mongodbatlas_search_index.search.index_id
+}
+
+output "vector_index_id" {
+  value = mongodbatlas_search_index.vector.index_id
+}
+
+output "auto_embed_index_id" {
+  value = mongodbatlas_search_index.auto_embed.index_id
+}

--- a/examples/mongodbatlas_search_index/main.tf
+++ b/examples/mongodbatlas_search_index/main.tf
@@ -1,30 +1,7 @@
-resource "mongodbatlas_project" "example" {
-  name   = "search-index-example"
-  org_id = var.org_id
-}
-
-resource "mongodbatlas_advanced_cluster" "example" {
-  project_id   = mongodbatlas_project.example.id
-  name         = "ClusterExample"
-  cluster_type = "REPLICASET"
-
-  replication_specs = [{
-    region_configs = [{
-      electable_specs = {
-        instance_size = "M10"
-        node_count    = 3
-      }
-      provider_name = "AWS"
-      priority      = 7
-      region_name   = "US_EAST_1"
-    }]
-  }]
-}
-
 # Text search index with dynamic mappings.
 resource "mongodbatlas_search_index" "search" {
-  project_id       = mongodbatlas_project.example.id
-  cluster_name     = mongodbatlas_advanced_cluster.example.name
+  project_id       = var.project_id
+  cluster_name     = var.cluster_name
   database         = var.database
   collection_name  = var.collection_name
   name             = "search-index"
@@ -34,8 +11,8 @@ resource "mongodbatlas_search_index" "search" {
 
 # Vector search index with embeddings you generate and store yourself.
 resource "mongodbatlas_search_index" "vector" {
-  project_id      = mongodbatlas_project.example.id
-  cluster_name    = mongodbatlas_advanced_cluster.example.name
+  project_id      = var.project_id
+  cluster_name    = var.cluster_name
   database        = var.database
   collection_name = var.collection_name
   name            = "vector-index"
@@ -53,8 +30,8 @@ EOF
 # Vector search index with Automated Embedding: Atlas generates the embeddings
 # from a text field using the specified Voyage model.
 resource "mongodbatlas_search_index" "auto_embed" {
-  project_id      = mongodbatlas_project.example.id
-  cluster_name    = mongodbatlas_advanced_cluster.example.name
+  project_id      = var.project_id
+  cluster_name    = var.cluster_name
   database        = var.database
   collection_name = var.collection_name
   name            = "auto-embed-index"

--- a/examples/mongodbatlas_search_index/provider.tf
+++ b/examples/mongodbatlas_search_index/provider.tf
@@ -1,0 +1,4 @@
+provider "mongodbatlas" {
+  client_id     = var.atlas_client_id
+  client_secret = var.atlas_client_secret
+}

--- a/examples/mongodbatlas_search_index/variables.tf
+++ b/examples/mongodbatlas_search_index/variables.tf
@@ -11,8 +11,13 @@ variable "atlas_client_secret" {
   default     = ""
 }
 
-variable "org_id" {
-  description = "Atlas Organization ID where the project is created"
+variable "project_id" {
+  description = "MongoDB Atlas project (groupId) that holds the cluster"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "MongoDB Atlas cluster with the collection to index"
   type        = string
 }
 

--- a/examples/mongodbatlas_search_index/variables.tf
+++ b/examples/mongodbatlas_search_index/variables.tf
@@ -12,7 +12,7 @@ variable "atlas_client_secret" {
 }
 
 variable "project_id" {
-  description = "MongoDB Atlas project (groupId) that holds the cluster"
+  description = "MongoDB Atlas project ID that holds the cluster"
   type        = string
 }
 
@@ -27,6 +27,6 @@ variable "database" {
 }
 
 variable "collection_name" {
-  description = "Collection to index. Must contain the fields referenced by each index below"
+  description = "Collection to index."
   type        = string
 }

--- a/examples/mongodbatlas_search_index/variables.tf
+++ b/examples/mongodbatlas_search_index/variables.tf
@@ -1,0 +1,27 @@
+variable "atlas_client_id" {
+  description = "MongoDB Atlas Service Account Client ID"
+  type        = string
+  default     = ""
+}
+
+variable "atlas_client_secret" {
+  description = "MongoDB Atlas Service Account Client Secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "org_id" {
+  description = "Atlas Organization ID where the project is created"
+  type        = string
+}
+
+variable "database" {
+  description = "Database that holds the collection to index"
+  type        = string
+}
+
+variable "collection_name" {
+  description = "Collection to index. Must contain the fields referenced by each index below"
+  type        = string
+}

--- a/examples/mongodbatlas_search_index/versions.tf
+++ b/examples/mongodbatlas_search_index/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 1.10"
+}


### PR DESCRIPTION
## Description

Adds an example for the `mongodbatlas_search_index` resource demonstrating the three index types (text `search`, `vector`, and `autoEmbed` / Automated Embedding) on a MongoDB Atlas cluster, and links it from the resource docs under "Further Examples".

Link to any related issue(s): CLOUDP-429776

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments