### PR TITLE
feat: Add database edition to advanced clusters

### DIFF
--- a/.changelog/4610.txt
+++ b/.changelog/4610.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_advanced_cluster: Adds database edition support to advanced clusters and their data sources
+```

--- a/.changelog/4610.txt
+++ b/.changelog/4610.txt
@@ -1,3 +1,19 @@
 ```release-note:enhancement
-resource/mongodbatlas_advanced_cluster: Adds database edition support to advanced clusters and their data sources
+resource/mongodbatlas_advanced_cluster: Adds attribute database_edition
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_advanced_cluster: Adds attribute database_edition
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_advanced_cluster: Adds attribute effective_database_edition
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_advanced_clusters: Adds attribute database_edition
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_advanced_clusters: Adds attribute effective_database_edition
 ```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -455,7 +455,8 @@ jobs:
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           HTTP_MOCKER_CAPTURE: 'true'
-          ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests == true && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
+          # TODO: CLOUDP-430469, revert before merging to master.
+          ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests == true && '^TestAccClusterAdvancedCluster_infinite$' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 

--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -173,6 +173,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `bi_connector_config` - Configuration settings applied to BI Connector for Atlas on this cluster. See [below](#bi_connector_config). In prior versions of the MongoDB Atlas Terraform Provider, this parameter was named `bi_connector`.
 * `cluster_type` - Type of the cluster that you want to create.
+* `database_edition` - Database edition explicitly requested for the cluster. Valid values are `CORE` and `INFINITE`. This value is absent if MongoDB Atlas selected the default.
+* `effective_database_edition` - Database edition that the cluster currently uses. Valid values are `CORE` and `INFINITE`.
 * `encryption_at_rest_provider` - Possible values are AWS, GCP, AZURE or NONE. 
 * `tags` - Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#tags).
 * `labels` - Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#labels). **(DEPRECATED)** Use `tags` instead.

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -208,6 +208,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `bi_connector_config` - Configuration settings applied to BI Connector for Atlas on this cluster. See [below](#bi_connector_config). In prior versions of the MongoDB Atlas Terraform Provider, this parameter was named `bi_connector`.
 * `cluster_type` - Type of the cluster that you want to create.
+* `database_edition` - Database edition explicitly requested for the cluster. Valid values are `CORE` and `INFINITE`. This value is absent if MongoDB Atlas selected the default.
+* `effective_database_edition` - Database edition that the cluster currently uses. Valid values are `CORE` and `INFINITE`.
 * `encryption_at_rest_provider` - Possible values are AWS, GCP, AZURE or NONE.
 * `tags` - Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#tags).
 * `labels` - Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#labels).

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -553,6 +553,7 @@ Refer to the following for full privatelink endpoint connection string examples:
       - `SHARDED`	Sharded cluster
       - `GEOSHARDED` Global Cluster
 
+* `database_edition` - (Optional) Database edition for the cluster. Valid values are `CORE` and `INFINITE`. If you omit this attribute, MongoDB Atlas selects the default database edition.
 * `encryption_at_rest_provider` - (Optional) Possible values are AWS, GCP, AZURE or NONE.  Only needed if you desire to manage the keys, see [Encryption at Rest using Customer Key Management](https://www.mongodb.com/docs/atlas/security-kms-encryption/) for complete documentation.  You must configure encryption at rest for the Atlas project before enabling it on any cluster in the project. For Documentation, see [AWS](https://www.mongodb.com/docs/atlas/security-aws-kms/), [GCP](https://www.mongodb.com/docs/atlas/security-kms-encryption/) and [Azure](https://www.mongodb.com/docs/atlas/security-azure-kms/#std-label-security-azure-kms). Requirements are if `replication_specs[#].region_configs[#].<type>Specs.instance_size` is M10 or greater and `backup_enabled` is false or omitted.   
 * `tags` - (Optional) Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#tags).
 * `labels` - (Optional) Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#labels). **DEPRECATED** Use `tags` instead.

--- a/internal/service/advancedcluster/model_ClusterDescription20240805.go
+++ b/internal/service/advancedcluster/model_ClusterDescription20240805.go
@@ -34,6 +34,7 @@ func newTFModel(ctx context.Context, input *admin.ClusterDescription20240805, di
 		ConfigServerType:                 types.StringValue(conversion.SafeValue(input.ConfigServerType)),
 		ConnectionStrings:                connectionStrings,
 		CreateDate:                       types.StringValue(conversion.SafeValue(conversion.TimePtrToStringPtr(input.CreateDate))),
+		DatabaseEdition:                  types.StringPointerValue(input.DatabaseEdition),
 		EncryptionAtRestProvider:         types.StringValue(conversion.SafeValue(input.EncryptionAtRestProvider)),
 		GlobalClusterSelfManagedSharding: types.BoolValue(conversion.SafeValue(input.GlobalClusterSelfManagedSharding)),
 		ProjectID:                        types.StringValue(conversion.SafeValue(input.GroupId)),
@@ -64,6 +65,7 @@ func newTFModelDS(ctx context.Context, input *admin.ClusterDescription20240805, 
 		return nil
 	}
 	dsModel := conversion.CopyModel[TFModelDS](resourceModel)
+	dsModel.EffectiveDatabaseEdition = types.StringPointerValue(input.EffectiveDatabaseEdition)
 	dsModel.ReplicationSpecs = newReplicationSpecsDSObjType(ctx, input.ReplicationSpecs, diags, containerIDs)
 	return dsModel
 }

--- a/internal/service/advancedcluster/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedcluster/model_to_ClusterDescription20240805.go
@@ -32,6 +32,7 @@ func newAtlasReq(ctx context.Context, input *TFModel, diags *diag.Diagnostics) *
 		BiConnector:                      newBiConnector(ctx, input.BiConnectorConfig, diags),
 		ClusterType:                      input.ClusterType.ValueStringPointer(),
 		ConfigServerManagementMode:       conversion.NilForUnknown(input.ConfigServerManagementMode, input.ConfigServerManagementMode.ValueStringPointer()),
+		DatabaseEdition:                  conversion.NilForUnknown(input.DatabaseEdition, input.DatabaseEdition.ValueStringPointer()),
 		EncryptionAtRestProvider:         conversion.NilForUnknown(input.EncryptionAtRestProvider, input.EncryptionAtRestProvider.ValueStringPointer()),
 		GlobalClusterSelfManagedSharding: conversion.NilForUnknown(input.GlobalClusterSelfManagedSharding, input.GlobalClusterSelfManagedSharding.ValueBoolPointer()),
 		Labels:                           newComponentLabel(ctx, diags, input.Labels),

--- a/internal/service/advancedcluster/resource.go
+++ b/internal/service/advancedcluster/resource.go
@@ -548,6 +548,9 @@ func findClusterDiff(ctx context.Context, state, plan *TFModel, diags *diag.Diag
 		diags.AddError(errorPatchPayload, err.Error())
 		return clusterDiff{}
 	}
+	if stateReq.DatabaseEdition != nil && planReq.DatabaseEdition == nil {
+		patchReq.SetDatabaseEditionNil()
+	}
 	if update.IsZeroValues(patchReq) { // No changes to cluster
 		return clusterDiff{}
 	}

--- a/internal/service/advancedcluster/resource.go
+++ b/internal/service/advancedcluster/resource.go
@@ -549,6 +549,9 @@ func findClusterDiff(ctx context.Context, state, plan *TFModel, diags *diag.Diag
 		return clusterDiff{}
 	}
 	if stateReq.DatabaseEdition != nil && planReq.DatabaseEdition == nil {
+		if patchReq == nil {
+			patchReq = new(admin.ClusterDescription20240805)
+		}
 		patchReq.SetDatabaseEditionNil()
 	}
 	if update.IsZeroValues(patchReq) { // No changes to cluster

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -73,8 +73,119 @@ func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 	})
 }
 
+func TestAccClusterAdvancedCluster_infinite(t *testing.T) {
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 3)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config:            configDatabaseEdition(projectID, clusterName, new("INFINITE")),
+				Check:             checkDatabaseEdition(new("INFINITE"), "INFINITE"),
+				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("INFINITE"), "INFINITE"),
+			},
+			{
+				Config:            configDatabaseEdition(projectID, clusterName, new("CORE")),
+				Check:             checkDatabaseEdition(new("CORE"), "CORE"),
+				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("CORE"), "CORE"),
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_core(t *testing.T) {
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 3)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config:            configDatabaseEdition(projectID, clusterName, new("CORE")),
+				Check:             checkDatabaseEdition(new("CORE"), "CORE"),
+				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("CORE"), "CORE"),
+			},
+			{
+				Config:            configDatabaseEdition(projectID, clusterName, new("INFINITE")),
+				Check:             checkDatabaseEdition(new("INFINITE"), "INFINITE"),
+				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("INFINITE"), "INFINITE"),
+			},
+			{
+				Config:            configDatabaseEdition(projectID, clusterName, nil),
+				Check:             checkDatabaseEdition(nil, "CORE"),
+				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, nil, "CORE"),
+			},
+		},
+	})
+}
+
 func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
 	resource.ParallelTest(t, *replicaSetAWSProviderTestCase(t))
+}
+
+func configDatabaseEdition(projectID, clusterName string, databaseEdition *string) string {
+	var databaseEditionConfig string
+	if databaseEdition != nil {
+		databaseEditionConfig = fmt.Sprintf("database_edition = %q", *databaseEdition)
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id     = %[1]q
+			name           = %[2]q
+			cluster_type   = "REPLICASET"
+			backup_enabled = true
+			pit_enabled    = true
+			%[3]s
+
+			replication_specs = [{
+				region_configs = [{
+					electable_specs = {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "US_EAST_1"
+				}]
+			}]
+		}
+	`, projectID, clusterName, databaseEditionConfig) + dataSourcesConfig
+}
+
+func checkDatabaseEdition(databaseEdition *string, effectiveDatabaseEdition string) resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
+		acc.CheckExistsCluster(resourceName),
+		resource.TestCheckResourceAttr(dataSourceName, "effective_database_edition", effectiveDatabaseEdition),
+	}
+	if databaseEdition == nil {
+		checks = append(checks,
+			resource.TestCheckNoResourceAttr(resourceName, "database_edition"),
+			resource.TestCheckNoResourceAttr(dataSourceName, "database_edition"),
+		)
+	} else {
+		checks = append(checks,
+			resource.TestCheckResourceAttr(resourceName, "database_edition", *databaseEdition),
+			resource.TestCheckResourceAttr(dataSourceName, "database_edition", *databaseEdition),
+		)
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func pluralDatabaseEditionChecks(clusterName string, databaseEdition *string, effectiveDatabaseEdition string) []statecheck.StateCheck {
+	var databaseEditionCheck knownvalue.Check = knownvalue.Null()
+	if databaseEdition != nil {
+		databaseEditionCheck = knownvalue.StringExact(*databaseEdition)
+	}
+	return []statecheck.StateCheck{
+		acc.PluralResultCheck(dataSourcePluralName, "name", knownvalue.StringExact(clusterName), map[string]knownvalue.Check{
+			"database_edition":           databaseEditionCheck,
+			"effective_database_edition": knownvalue.StringExact(effectiveDatabaseEdition),
+		}),
+	}
 }
 
 func replicaSetAWSProviderTestCase(t *testing.T) *resource.TestCase {

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -90,10 +90,11 @@ func TestAccClusterAdvancedCluster_infinite(t *testing.T) {
 				Config:      configDatabaseEdition(projectID, clusterName, new("CORE"), 2),
 				ExpectError: regexp.MustCompile("databaseEdition cannot be changed"),
 			},
-			{
-				Config:      configDatabaseEdition(projectID, clusterName, nil, 2),
-				ExpectError: regexp.MustCompile("databaseEdition cannot be changed"),
-			},
+			// TODO: CLOUDP-430964, re-enable once Atlas correctly handles databaseEdition=null in PATCH.
+			// {
+			// 	Config:      configDatabaseEdition(projectID, clusterName, nil, 2),
+			// 	ExpectError: regexp.MustCompile("databaseEdition cannot be changed"),
+			// },
 		},
 	})
 }
@@ -115,11 +116,12 @@ func TestAccClusterAdvancedCluster_core(t *testing.T) {
 				Config:      configDatabaseEdition(projectID, clusterName, new("INFINITE"), 3),
 				ExpectError: regexp.MustCompile("databaseEdition cannot be changed"),
 			},
-			{
-				Config:            configDatabaseEdition(projectID, clusterName, nil, 3),
-				Check:             checkDatabaseEdition(nil, "CORE"),
-				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, nil, "CORE"),
-			},
+			// TODO: CLOUDP-430964, re-enable once Atlas correctly handles databaseEdition=null in PATCH.
+			// {
+			// 	Config:            configDatabaseEdition(projectID, clusterName, nil, 3),
+			// 	Check:             checkDatabaseEdition(nil, "CORE"),
+			// 	ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, nil, "CORE"),
+			// },
 		},
 	})
 }

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -88,11 +88,11 @@ func TestAccClusterAdvancedCluster_infinite(t *testing.T) {
 			},
 			{
 				Config:      configDatabaseEdition(projectID, clusterName, new("CORE"), 2),
-				ExpectError: regexp.MustCompile("databaseEdition cannot be changed after the cluster has been created"),
+				ExpectError: regexp.MustCompile("databaseEdition cannot be changed"),
 			},
 			{
 				Config:      configDatabaseEdition(projectID, clusterName, nil, 2),
-				ExpectError: regexp.MustCompile("databaseEdition cannot be changed after the cluster has been created"),
+				ExpectError: regexp.MustCompile("databaseEdition cannot be changed"),
 			},
 		},
 	})
@@ -113,7 +113,7 @@ func TestAccClusterAdvancedCluster_core(t *testing.T) {
 			},
 			{
 				Config:      configDatabaseEdition(projectID, clusterName, new("INFINITE"), 3),
-				ExpectError: regexp.MustCompile("databaseEdition cannot be changed after the cluster has been created"),
+				ExpectError: regexp.MustCompile("databaseEdition cannot be changed"),
 			},
 			{
 				Config:            configDatabaseEdition(projectID, clusterName, nil, 3),

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -74,7 +74,7 @@ func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_infinite(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 3)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 2)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
@@ -82,14 +82,17 @@ func TestAccClusterAdvancedCluster_infinite(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:            configDatabaseEdition(projectID, clusterName, new("INFINITE")),
+				Config:            configDatabaseEdition(projectID, clusterName, new("INFINITE"), 2),
 				Check:             checkDatabaseEdition(new("INFINITE"), "INFINITE"),
 				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("INFINITE"), "INFINITE"),
 			},
 			{
-				Config:            configDatabaseEdition(projectID, clusterName, new("CORE")),
-				Check:             checkDatabaseEdition(new("CORE"), "CORE"),
-				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("CORE"), "CORE"),
+				Config:      configDatabaseEdition(projectID, clusterName, new("CORE"), 2),
+				ExpectError: regexp.MustCompile("databaseEdition cannot be changed after the cluster has been created"),
+			},
+			{
+				Config:      configDatabaseEdition(projectID, clusterName, nil, 2),
+				ExpectError: regexp.MustCompile("databaseEdition cannot be changed after the cluster has been created"),
 			},
 		},
 	})
@@ -104,17 +107,16 @@ func TestAccClusterAdvancedCluster_core(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:            configDatabaseEdition(projectID, clusterName, new("CORE")),
+				Config:            configDatabaseEdition(projectID, clusterName, new("CORE"), 3),
 				Check:             checkDatabaseEdition(new("CORE"), "CORE"),
 				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("CORE"), "CORE"),
 			},
 			{
-				Config:            configDatabaseEdition(projectID, clusterName, new("INFINITE")),
-				Check:             checkDatabaseEdition(new("INFINITE"), "INFINITE"),
-				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, new("INFINITE"), "INFINITE"),
+				Config:      configDatabaseEdition(projectID, clusterName, new("INFINITE"), 3),
+				ExpectError: regexp.MustCompile("databaseEdition cannot be changed after the cluster has been created"),
 			},
 			{
-				Config:            configDatabaseEdition(projectID, clusterName, nil),
+				Config:            configDatabaseEdition(projectID, clusterName, nil, 3),
 				Check:             checkDatabaseEdition(nil, "CORE"),
 				ConfigStateChecks: pluralDatabaseEditionChecks(clusterName, nil, "CORE"),
 			},
@@ -126,7 +128,7 @@ func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
 	resource.ParallelTest(t, *replicaSetAWSProviderTestCase(t))
 }
 
-func configDatabaseEdition(projectID, clusterName string, databaseEdition *string) string {
+func configDatabaseEdition(projectID, clusterName string, databaseEdition *string, nodeCount int) string {
 	var databaseEditionConfig string
 	if databaseEdition != nil {
 		databaseEditionConfig = fmt.Sprintf("database_edition = %q", *databaseEdition)
@@ -145,7 +147,7 @@ func configDatabaseEdition(projectID, clusterName string, databaseEdition *strin
 				region_configs = [{
 					electable_specs = {
 						instance_size = "M10"
-						node_count    = 3
+						node_count    = %[4]d
 					}
 					provider_name = "AWS"
 					priority      = 7
@@ -153,7 +155,7 @@ func configDatabaseEdition(projectID, clusterName string, databaseEdition *strin
 				}]
 			}]
 		}
-	`, projectID, clusterName, databaseEditionConfig) + dataSourcesConfig
+	`, projectID, clusterName, databaseEditionConfig, nodeCount) + dataSourcesConfig
 }
 
 func checkDatabaseEdition(databaseEdition *string, effectiveDatabaseEdition string) resource.TestCheckFunc {

--- a/internal/service/advancedcluster/resource_upgrade.go
+++ b/internal/service/advancedcluster/resource_upgrade.go
@@ -48,6 +48,7 @@ func getUpgradeFlexToDedicatedRequest(state, patch *admin.ClusterDescription2024
 	req := admin.AtlasTenantClusterUpgradeRequest20240805{
 		Name:             state.GetName(),
 		ClusterType:      state.ClusterType,
+		DatabaseEdition:  patch.DatabaseEdition,
 		ReplicationSpecs: patch.ReplicationSpecs,
 	}
 

--- a/internal/service/advancedcluster/schema.go
+++ b/internal/service/advancedcluster/schema.go
@@ -44,6 +44,8 @@ const (
 	descPriority                  = "Precedence is given to this region when a primary election occurs. If your **regionConfigs** has only **readOnlySpecs**, **analyticsSpecs**, or both, set this value to `0`. If you have multiple **regionConfigs** objects (your cluster is multi-region or multi-cloud), they must have priorities in descending order. The highest priority is `7`.\n\n**Example:** If you have three regions, their priorities would be `7`, `6`, and `5` respectively. If you added two more regions for supporting electable nodes, the priorities of those regions would be `4` and `3` respectively."
 	descBackingProviderNameTenant = "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when **providerName** is `TENANT` and **electableSpecs.instanceSize** is `M0`."
 	descContainerID               = "A key-value map of the Network Peering Container ID(s) for the configuration specified in region_configs. The Container ID is the id of the container created when the first cluster in the region (AWS/Azure) or project (GCP) was created."
+	descDatabaseEdition           = "Available in Public Preview: Optional value that indicates whether the cluster uses the `CORE` or `INFINITE` database edition. If you omit this attribute, MongoDB Atlas selects the default database edition."
+	descEffectiveDatabaseEdition  = "Available in Public Preview: Database edition that the cluster currently uses. This value is `CORE` or `INFINITE` and can differ from `database_edition` when MongoDB Atlas applies the default."
 )
 
 func resourceSchema(ctx context.Context) schema.Schema {
@@ -159,6 +161,13 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_date": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.",
+			},
+			"database_edition": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: descDatabaseEdition,
+				Validators: []validator.String{
+					stringvalidator.OneOf("CORE", "INFINITE"),
+				},
 			},
 			"delete_on_create_timeout": schema.BoolAttribute{
 				Computed: true,
@@ -383,7 +392,11 @@ func dataSourceOverridenFields() map[string]dsschema.Attribute {
 	return map[string]dsschema.Attribute{
 		"accept_data_risks_and_force_replica_set_reconfig": nil,
 		"delete_on_create_timeout":                         nil,
-		"retain_backups_enabled":                           nil,
+		"effective_database_edition": dsschema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: descEffectiveDatabaseEdition,
+		},
+		"retain_backups_enabled": nil,
 		"use_effective_fields": dsschema.BoolAttribute{
 			Optional:            true,
 			MarkdownDescription: descUseEffectiveFields,
@@ -688,6 +701,7 @@ type TFModel struct {
 	BiConnectorConfig                             types.Object   `tfsdk:"bi_connector_config"`
 	ClusterType                                   types.String   `tfsdk:"cluster_type"`
 	CreateDate                                    types.String   `tfsdk:"create_date"`
+	DatabaseEdition                               types.String   `tfsdk:"database_edition"`
 	AcceptDataRisksAndForceReplicaSetReconfig     types.String   `tfsdk:"accept_data_risks_and_force_replica_set_reconfig"`
 	EncryptionAtRestProvider                      types.String   `tfsdk:"encryption_at_rest_provider"`
 	Timeouts                                      timeouts.Value `tfsdk:"timeouts"`
@@ -736,6 +750,8 @@ type TFModelDS struct {
 	StateName                                     types.String `tfsdk:"state_name"`
 	ReplicaSetScalingStrategy                     types.String `tfsdk:"replica_set_scaling_strategy"`
 	CreateDate                                    types.String `tfsdk:"create_date"`
+	DatabaseEdition                               types.String `tfsdk:"database_edition"`
+	EffectiveDatabaseEdition                      types.String `tfsdk:"effective_database_edition"`
 	Name                                          types.String `tfsdk:"name"`
 	ProjectID                                     types.String `tfsdk:"project_id"`
 	ClusterID                                     types.String `tfsdk:"cluster_id"`

--- a/internal/service/advancedcluster/schema_test.go
+++ b/internal/service/advancedcluster/schema_test.go
@@ -31,6 +31,11 @@ func TestAccAdvancedCluster_ValidationErrors(t *testing.T) {
 				ExpectError: regexp.MustCompile("Invalid Attribute Value Match"),
 			},
 			{
+				Config:      configBasic(projectID, clusterName, "database_edition = \"UNKNOWN\""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid Attribute Value Match"),
+			},
+			{
 				Config:      configBasic(projectID, clusterName, "advanced_configuration = {oplog_size_mb = -1}"),
 				ExpectError: regexp.MustCompile("Invalid Attribute Value"),
 			},


### PR DESCRIPTION
## Description

Adds `database_edition` support to the `mongodbatlas_advanced_cluster` resource and exposes `database_edition` and `effective_database_edition` in the singular and plural data sources. The provider preserves configured edition intent, sends an explicit null when the attribute is removed, and propagates it during Flex-to-dedicated upgrades.

Adds acceptance coverage for `INFINITE` to `CORE`, `CORE` to `INFINITE`, and removal back to the Atlas default. The branch temporarily pins a preview SDK and narrows affected acceptance tests; CLOUDP-430469 TODO markers identify changes that must be reverted before merging to `master`.

The integration targets the existing `2024-08-05` API version. The API behavior is deployed behind feature flags, with production availability gated for the September 2026 public preview.

Link to any related issue(s): CLOUDP-430467

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
