### PR TITLE
chore: Adds monthly-test-suite-summary skill

### DIFF
--- a/.agents/skills/monthly-test-suite-summary/SKILL.md
+++ b/.agents/skills/monthly-test-suite-summary/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: monthly-test-suite-summary
+description: Build the monthly test-stability summary for the OpEx document (Test stability → Overall metrics section) for the mongodb/terraform-provider-mongodbatlas repo. Aggregates the daily summarize-test-suite verdicts of one calendar month into a paste-ready markdown table plus a short narrative. Use when asked for the monthly OpEx test summary, monthly test stability metrics, or to update the Overall metrics section.
+---
+
+# Monthly Test Suite Summary (OpEx)
+
+## Purpose
+
+Produce the monthly replacement for the OpEx doc's *Test stability → Overall metrics* table. The old metric counted raw run conclusions (a run with only `OUT_OF_CAPACITY` flakes counted as "Fail"), which made the suite look permanently broken. This skill counts a run as a regression only when its daily summary verdict was `:red_circle:` — i.e., the daily `summarize-test-suite` classification found at least one code regression.
+
+## Determinism contract
+
+All data collection and aggregation is done by `scripts/monthly_summary.py`. The script's numbers are authoritative — **never alter, recompute, or "correct" them**. The agent's only reasoning work is Step 2 (sanity checks and narrative).
+
+Per-run verdicts come from the daily `summarize-test-suite` skill's output (the `summary` artifact uploaded by every scheduled Test Suite run). This skill never re-classifies failures and never reads raw job logs.
+
+## Inputs
+
+Optional: an anchor date `YYYY-MM-DD`. "Last month" is the calendar month before the anchor's month. Default anchor is today; pass `--date` when the skill was not run on time (e.g. `--date 2026-08-01` on August 20 still yields July).
+
+## Workflow
+
+### Step 1: Run the aggregation script
+
+```bash
+python3 .agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py [--date YYYY-MM-DD]
+```
+
+Requires `gh` authenticated against `mongodb/terraform-provider-mongodbatlas`. The script writes two artefacts (paths printed on stderr):
+
+- `monthly-summary-<anchor-date>.md` in the current working directory — the metrics table plus exclusion footnote. This is the final output file.
+- A JSON report (default `$TMPDIR/monthly-test-suite-summary/<month>-result.json`). Read it for the narrative step.
+
+### Step 2: Sanity checks and narrative (the only agent reasoning)
+
+1. **Sanity checks.** Flag in the narrative, with likely cause, when:
+   - The month has far fewer runs than days (scheduled runs may have been skipped or the workflow renamed).
+   - `no_summary_runs` is non-empty — the summary job failed or the artifact expired. These runs are excluded from the percentage; say so.
+   - `unknown_verdict_runs` is non-empty — a summary artifact existed but no verdict emoji was found; suggest a manual look.
+2. **Repeat offenders.** `recurring_tests` lists tests named in daily failing lists on ≥2 distinct days (a lower bound — daily summaries cap the list at 10 names plus `, and N more`). For each of the top recurring tests, read the cached daily summaries (`$TMPDIR/monthly-test-suite-summary/<run_id>/summary.md`) for those dates and determine whether it failed with the **same root cause every time** (persistent broken or flaky test — a ticket candidate; say which category, e.g. always `OUT_OF_CAPACITY` vs always a timeout) or **alternating causes** (general infra noise). Keep this to the handful of flagged tests.
+3. **Red days.** For each run with verdict `red` in the JSON report, give one line with the run number, date, linked run URL, and the regression cause from its `regressions` entries. Group repeats (e.g. "3 of 4 red days were the same `config_server_type` regression").
+4. **Category trends.** Summarize `category_totals` in one sentence (e.g. "capacity noise dominated: 340 failures across 22 days").
+
+### Step 3: Append the narrative to the output file
+
+Append a short `**Notes:**` bullet list to `monthly-summary-<anchor-date>.md`, below the script's table and footnote (never modify anything the script wrote): red days, repeat offenders with root-cause verdicts, category trend, and any sanity-check caveats. Keep it under ~10 bullets; this replaces the old table-plus-graph, not the whole section.
+
+The finished file is **GitHub-flavored markdown** (standard `**bold**`, tables, `[label](url)` links — **not** Slack mrkdwn), paste-ready for the OpEx doc's *Test stability → Overall metrics* section. End your response by telling the user the file path; also show the file's full content so it can be reviewed without opening it.
+
+Do not include internal ticket IDs or artefact names (same rule as the daily skill).
+
+## Caveats
+
+- **Artifact retention.** The daily `summary` artifact uses the repo's default retention. The skill is designed to run for last month only; older months will surface as "no summary available" runs.
+- **Recurring-test counts are a lower bound.** Daily summaries truncate failing-test lists (first 10 + `, and N more`), so a test failing every day but ranked below the cut-off won't appear in `recurring_tests`.
+- **Verdicts are only as good as the daily classification.** If a daily summary was wrong, this skill inherits the error by design — fix the daily skill's rules instead of overriding numbers here.

--- a/.agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py
+++ b/.agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py
@@ -39,6 +39,9 @@ REPO = "mongodb/terraform-provider-mongodbatlas"
 WORKFLOW = "test-suite.yml"
 CACHE_ROOT = os.path.join(tempfile.gettempdir(), "monthly-test-suite-summary")
 
+# Format coupling: these regexes parse the output format owned by the daily
+# summarize-test-suite skill (.agents/skills/summarize-test-suite/SKILL.md).
+# Reflect any template change there here.
 # The leading emoji is the daily verdict; first occurrence wins.
 VERDICT_RE = re.compile(r":(red|yellow|green)_circle:")
 

--- a/.agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py
+++ b/.agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py
@@ -25,7 +25,6 @@ Usage:
 """
 
 import argparse
-import calendar
 import datetime
 import io
 import json
@@ -40,12 +39,8 @@ REPO = "mongodb/terraform-provider-mongodbatlas"
 WORKFLOW = "test-suite.yml"
 CACHE_ROOT = os.path.join(tempfile.gettempdir(), "monthly-test-suite-summary")
 
-VERDICT_TOKENS = (":red_circle:", ":yellow_circle:", ":green_circle:")
-VERDICT_MAP = {
-    ":red_circle:": "red",
-    ":yellow_circle:": "yellow",
-    ":green_circle:": "green",
-}
+# The leading emoji is the daily verdict; first occurrence wins.
+VERDICT_RE = re.compile(r":(red|yellow|green)_circle:")
 
 # Bullet form: "• Cloud capacity: 5 tests (e.g., ...)"
 CATEGORY_BULLET_RE = re.compile(r"^\s*•\s*([A-Za-z /]+?):\s*(\d+)\s+tests?\b")
@@ -62,33 +57,19 @@ KNOWN_CATEGORIES = (
 
 FAILING_TESTS_LINE_RE = re.compile(r"\*Failing tests\*[^:]*:\s*(.+)$")
 BACKTICK_RE = re.compile(r"`([^`]+)`")
-AND_N_MORE_RE = re.compile(r",?\s*(?:…|,)?\s*and\s+\d+\s+more\.?\s*$")
 SUBTEST_COUNT_SUFFIX_RE = re.compile(r"\s*\(×\d+\s+subtests\)\s*$")
 
 REGRESSION_HEADER_RE = re.compile(r"^\*\d+ code regressions?\*")
 REGRESSION_BULLET_RE = re.compile(r"^\s*•\s*(.+)$")
 
 
-def gh_api(endpoint):
-    """Run `gh api` and return parsed JSON."""
-    result = subprocess.run(
-        ["gh", "api", endpoint],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"gh api {endpoint} failed: {result.stderr.strip()}")
-    return json.loads(result.stdout)
-
-
-def gh_api_bytes(endpoint):
-    """Run `gh api` and return raw bytes (for artifact zip download)."""
+def gh_api(endpoint, raw=False):
+    """Run `gh api`; return parsed JSON, or raw bytes when raw=True."""
     result = subprocess.run(["gh", "api", endpoint], capture_output=True)
     if result.returncode != 0:
-        raise RuntimeError(
-            f"gh api {endpoint} failed: {result.stderr.decode(errors='replace').strip()}"
-        )
-    return result.stdout
+        err = result.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"gh api {endpoint} failed: {err}")
+    return result.stdout if raw else json.loads(result.stdout)
 
 
 def last_month_range(anchor):
@@ -126,7 +107,9 @@ def fetch_summary(run_id):
     if summary_artifact is None:
         return None
 
-    blob = gh_api_bytes(f"repos/{REPO}/actions/artifacts/{summary_artifact['id']}/zip")
+    blob = gh_api(
+        f"repos/{REPO}/actions/artifacts/{summary_artifact['id']}/zip", raw=True
+    )
     with zipfile.ZipFile(io.BytesIO(blob)) as zf:
         names = [n for n in zf.namelist() if n.endswith("summary.md")]
         if not names:
@@ -140,13 +123,8 @@ def fetch_summary(run_id):
 
 
 def parse_verdict(text):
-    """The leading emoji is the verdict; pick the earliest-occurring token."""
-    best_pos, best = None, None
-    for token in VERDICT_TOKENS:
-        pos = text.find(token)
-        if pos != -1 and (best_pos is None or pos < best_pos):
-            best_pos, best = pos, VERDICT_MAP[token]
-    return best
+    m = VERDICT_RE.search(text)
+    return m.group(1) if m else None
 
 
 def parse_categories(text):
@@ -173,23 +151,18 @@ def normalize_test_name(name):
 
 
 def parse_failing_tests(text):
-    """Test names from the '*Failing tests*' line. Lower bound: the daily
-    summary caps this list (first 10, then ', and N more')."""
+    """Backticked test names from the '*Failing tests*' line. Lower bound: the
+    daily summary caps this list (first 10, then ', and N more')."""
     for line in text.splitlines():
         m = FAILING_TESTS_LINE_RE.search(line)
-        if not m:
-            continue
-        rest = m.group(1)
-        names = [normalize_test_name(n) for n in BACKTICK_RE.findall(rest)]
-        if not names:
-            rest = AND_N_MORE_RE.sub("", rest)
-            names = [normalize_test_name(p) for p in rest.split(",") if p.strip()]
-        return [n for n in names if n]
+        if m:
+            names = BACKTICK_RE.findall(m.group(1))
+            return [normalize_test_name(n) for n in names]
     return []
 
 
 def parse_regressions(text):
-    """Regression bullets from a red-run summary: [{test, line}]."""
+    """Regression bullet lines from a red-run summary (for the narrative)."""
     regressions = []
     in_section = False
     for line in text.splitlines():
@@ -199,21 +172,10 @@ def parse_regressions(text):
         if in_section:
             bullet = REGRESSION_BULLET_RE.match(line)
             if bullet:
-                content = bullet.group(1)
-                names = BACKTICK_RE.findall(content)
-                regressions.append(
-                    {
-                        "test": normalize_test_name(names[0]) if names else content,
-                        "line": content,
-                    }
-                )
+                regressions.append(bullet.group(1))
             elif line.strip() == "":
                 in_section = False
     return regressions
-
-
-def month_label(start):
-    return f"{start.strftime('%b')}/{start.strftime('%y')}"
 
 
 def main():
@@ -230,7 +192,7 @@ def main():
         datetime.date.fromisoformat(args.date) if args.date else datetime.date.today()
     )
     start, end = last_month_range(anchor)
-    label = month_label(start)
+    label = start.strftime("%b/%y")  # e.g. Jul/26
     month_id = start.strftime("%Y-%m")
 
     runs = list_scheduled_runs(start, end)
@@ -318,7 +280,7 @@ def main():
     }
 
     json_out = args.json_out or os.path.join(CACHE_ROOT, f"{month_id}-result.json")
-    os.makedirs(os.path.dirname(json_out), exist_ok=True)
+    os.makedirs(os.path.dirname(json_out) or ".", exist_ok=True)
     with open(json_out, "w", encoding="utf-8") as f:
         json.dump(report, f, indent=2)
 
@@ -331,21 +293,19 @@ def main():
         f"| **% without regression** | {pct} |",
     ]
     if no_summary_runs or unknown_runs:
-        notes = []
+
+        def refs(runs):
+            return ", ".join(
+                f"[#{r['run_number']} ({r['date']})]({r['url']})" for r in runs
+            )
+
+        exclusions = []
         if no_summary_runs:
-            refs = ", ".join(
-                f"[#{r['run_number']} ({r['date']})]({r['url']})" for r in no_summary_runs
-            )
-            notes.append(f"no summary available: {refs}")
+            exclusions.append(f"no summary available: {refs(no_summary_runs)}")
         if unknown_runs:
-            refs = ", ".join(
-                f"[#{r['run_number']} ({r['date']})]({r['url']})" for r in unknown_runs
-            )
-            notes.append(f"unparseable summary verdict: {refs}")
+            exclusions.append(f"unparseable summary verdict: {refs(unknown_runs)}")
         lines.append("")
-        lines.append(
-            "*Excluded from the percentage: " + "; ".join(notes) + ".*"
-        )
+        lines.append("*Excluded from the percentage: " + "; ".join(exclusions) + ".*")
 
     # Write the metrics section to monthly-summary-<anchor-date>.md in the cwd.
     # The agent appends the **Notes:** narrative section to this file (Step 3 of

--- a/.agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py
+++ b/.agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Monthly test-suite stability summary for the OpEx doc.
+
+Deterministic aggregator: it never classifies failures itself. It reuses the
+per-run verdicts produced by the daily `summarize-test-suite` skill, which are
+uploaded as a `summary` artifact (summary.md) on every scheduled Test Suite run.
+
+For each scheduled run of the target month it:
+  - downloads the summary artifact (cached under $TMPDIR),
+  - parses the leading verdict emoji (red/yellow/green),
+  - parses per-category failure counts,
+  - parses named failing tests (lower bound: daily summaries cap the list),
+
+then writes a paste-ready GitHub-flavored markdown table to
+monthly-summary-<anchor-date>.md (in the current working directory) and a JSON
+report for the agent's narrative step.
+
+Usage:
+    monthly_summary.py [--date YYYY-MM-DD] [--json-out PATH]
+
+    --date      Anchor date; "last month" is computed relative to this date
+                instead of today (use when the skill was not run on time).
+    --json-out  Where to write the JSON report
+                (default: $TMPDIR/monthly-test-suite-summary/<month>-result.json).
+"""
+
+import argparse
+import calendar
+import datetime
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+REPO = "mongodb/terraform-provider-mongodbatlas"
+WORKFLOW = "test-suite.yml"
+CACHE_ROOT = os.path.join(tempfile.gettempdir(), "monthly-test-suite-summary")
+
+VERDICT_TOKENS = (":red_circle:", ":yellow_circle:", ":green_circle:")
+VERDICT_MAP = {
+    ":red_circle:": "red",
+    ":yellow_circle:": "yellow",
+    ":green_circle:": "green",
+}
+
+# Bullet form: "• Cloud capacity: 5 tests (e.g., ...)"
+CATEGORY_BULLET_RE = re.compile(r"^\s*•\s*([A-Za-z /]+?):\s*(\d+)\s+tests?\b")
+# Compressed form: "*Other failures*: Cloud capacity 5, Timeout 12, Cleanup 3"
+CATEGORY_COMPRESSED_LINE_RE = re.compile(r"\*Other failures\*:\s*(.+)$")
+CATEGORY_COMPRESSED_ITEM_RE = re.compile(r"([A-Za-z /]+?)\s+(\d+)(?:,|$)")
+KNOWN_CATEGORIES = (
+    "cloud capacity",
+    "api errors",
+    "api contract",
+    "timeout",
+    "cleanup",
+)
+
+FAILING_TESTS_LINE_RE = re.compile(r"\*Failing tests\*[^:]*:\s*(.+)$")
+BACKTICK_RE = re.compile(r"`([^`]+)`")
+AND_N_MORE_RE = re.compile(r",?\s*(?:…|,)?\s*and\s+\d+\s+more\.?\s*$")
+SUBTEST_COUNT_SUFFIX_RE = re.compile(r"\s*\(×\d+\s+subtests\)\s*$")
+
+REGRESSION_HEADER_RE = re.compile(r"^\*\d+ code regressions?\*")
+REGRESSION_BULLET_RE = re.compile(r"^\s*•\s*(.+)$")
+
+
+def gh_api(endpoint):
+    """Run `gh api` and return parsed JSON."""
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh api {endpoint} failed: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def gh_api_bytes(endpoint):
+    """Run `gh api` and return raw bytes (for artifact zip download)."""
+    result = subprocess.run(["gh", "api", endpoint], capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh api {endpoint} failed: {result.stderr.decode(errors='replace').strip()}"
+        )
+    return result.stdout
+
+
+def last_month_range(anchor):
+    """Return (first_day, last_day) of the calendar month before the anchor's month."""
+    first_of_anchor_month = anchor.replace(day=1)
+    last_of_prev = first_of_anchor_month - datetime.timedelta(days=1)
+    first_of_prev = last_of_prev.replace(day=1)
+    return first_of_prev, last_of_prev
+
+
+def list_scheduled_runs(start, end):
+    created = f"{start.isoformat()}..{end.isoformat()}"
+    data = gh_api(
+        f"repos/{REPO}/actions/workflows/{WORKFLOW}/runs"
+        f"?event=schedule&created={created}&per_page=100"
+    )
+    return data.get("workflow_runs", [])
+
+
+def fetch_summary(run_id):
+    """Return the summary.md text for a run, or None if unavailable. Cached."""
+    cache_dir = os.path.join(CACHE_ROOT, str(run_id))
+    cache_file = os.path.join(cache_dir, "summary.md")
+    if os.path.exists(cache_file):
+        with open(cache_file, encoding="utf-8") as f:
+            return f.read()
+
+    artifacts = gh_api(f"repos/{REPO}/actions/runs/{run_id}/artifacts").get(
+        "artifacts", []
+    )
+    summary_artifact = next(
+        (a for a in artifacts if a.get("name") == "summary" and not a.get("expired")),
+        None,
+    )
+    if summary_artifact is None:
+        return None
+
+    blob = gh_api_bytes(f"repos/{REPO}/actions/artifacts/{summary_artifact['id']}/zip")
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        names = [n for n in zf.namelist() if n.endswith("summary.md")]
+        if not names:
+            return None
+        text = zf.read(names[0]).decode("utf-8", errors="replace")
+
+    os.makedirs(cache_dir, exist_ok=True)
+    with open(cache_file, "w", encoding="utf-8") as f:
+        f.write(text)
+    return text
+
+
+def parse_verdict(text):
+    """The leading emoji is the verdict; pick the earliest-occurring token."""
+    best_pos, best = None, None
+    for token in VERDICT_TOKENS:
+        pos = text.find(token)
+        if pos != -1 and (best_pos is None or pos < best_pos):
+            best_pos, best = pos, VERDICT_MAP[token]
+    return best
+
+
+def parse_categories(text):
+    """Per-category failure counts from a daily summary. Returns {name: count}."""
+    counts = {}
+    for line in text.splitlines():
+        m = CATEGORY_BULLET_RE.match(line)
+        if m:
+            name = m.group(1).strip().lower()
+            if name in KNOWN_CATEGORIES:
+                counts[name] = counts.get(name, 0) + int(m.group(2))
+            continue
+        m = CATEGORY_COMPRESSED_LINE_RE.search(line)
+        if m:
+            for item in CATEGORY_COMPRESSED_ITEM_RE.finditer(m.group(1)):
+                name = item.group(1).strip().lower()
+                if name in KNOWN_CATEGORIES:
+                    counts[name] = counts.get(name, 0) + int(item.group(2))
+    return counts
+
+
+def normalize_test_name(name):
+    return SUBTEST_COUNT_SUFFIX_RE.sub("", name).strip()
+
+
+def parse_failing_tests(text):
+    """Test names from the '*Failing tests*' line. Lower bound: the daily
+    summary caps this list (first 10, then ', and N more')."""
+    for line in text.splitlines():
+        m = FAILING_TESTS_LINE_RE.search(line)
+        if not m:
+            continue
+        rest = m.group(1)
+        names = [normalize_test_name(n) for n in BACKTICK_RE.findall(rest)]
+        if not names:
+            rest = AND_N_MORE_RE.sub("", rest)
+            names = [normalize_test_name(p) for p in rest.split(",") if p.strip()]
+        return [n for n in names if n]
+    return []
+
+
+def parse_regressions(text):
+    """Regression bullets from a red-run summary: [{test, line}]."""
+    regressions = []
+    in_section = False
+    for line in text.splitlines():
+        if REGRESSION_HEADER_RE.match(line):
+            in_section = True
+            continue
+        if in_section:
+            bullet = REGRESSION_BULLET_RE.match(line)
+            if bullet:
+                content = bullet.group(1)
+                names = BACKTICK_RE.findall(content)
+                regressions.append(
+                    {
+                        "test": normalize_test_name(names[0]) if names else content,
+                        "line": content,
+                    }
+                )
+            elif line.strip() == "":
+                in_section = False
+    return regressions
+
+
+def month_label(start):
+    return f"{start.strftime('%b')}/{start.strftime('%y')}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--date",
+        help="Anchor date YYYY-MM-DD; 'last month' is computed relative to it "
+        "instead of today.",
+    )
+    parser.add_argument("--json-out", help="Path for the JSON report.")
+    args = parser.parse_args()
+
+    anchor = (
+        datetime.date.fromisoformat(args.date) if args.date else datetime.date.today()
+    )
+    start, end = last_month_range(anchor)
+    label = month_label(start)
+    month_id = start.strftime("%Y-%m")
+
+    runs = list_scheduled_runs(start, end)
+    runs.sort(key=lambda r: r.get("run_started_at") or r.get("created_at", ""))
+
+    report_runs = []
+    category_totals = {}
+    test_days = {}  # test name -> set of ISO dates
+
+    for run in runs:
+        run_id = run["id"]
+        date = (run.get("run_started_at") or run.get("created_at", ""))[:10]
+        entry = {
+            "run_id": run_id,
+            "run_number": run.get("run_number"),
+            "date": date,
+            "url": run.get("html_url"),
+            "conclusion": run.get("conclusion"),
+            "verdict": None,
+            "categories": {},
+            "failing_tests": [],
+            "regressions": [],
+        }
+        try:
+            text = fetch_summary(run_id)
+        except RuntimeError as e:
+            print(f"warning: run {run_id}: {e}", file=sys.stderr)
+            text = None
+
+        if text is not None:
+            entry["verdict"] = parse_verdict(text) or "unknown"
+            entry["categories"] = parse_categories(text)
+            entry["failing_tests"] = parse_failing_tests(text)
+            entry["regressions"] = parse_regressions(text)
+            for name, count in entry["categories"].items():
+                category_totals[name] = category_totals.get(name, 0) + count
+            for test in entry["failing_tests"]:
+                test_days.setdefault(test, set()).add(date)
+        report_runs.append(entry)
+
+    red = sum(1 for r in report_runs if r["verdict"] == "red")
+    no_summary = sum(1 for r in report_runs if r["verdict"] is None)
+    unknown = sum(1 for r in report_runs if r["verdict"] == "unknown")
+    without_regression = sum(
+        1 for r in report_runs if r["verdict"] in ("yellow", "green")
+    )
+    classified = red + without_regression
+    pct = f"{(without_regression / classified * 100):.2f}%" if classified else "n/a"
+
+    recurring = [
+        {"test": t, "days": len(dates), "dates": sorted(dates)}
+        for t, dates in test_days.items()
+        if len(dates) >= 2
+    ]
+    recurring.sort(key=lambda x: (-x["days"], x["test"]))
+
+    no_summary_runs = [
+        {"run_number": r["run_number"], "date": r["date"], "url": r["url"]}
+        for r in report_runs
+        if r["verdict"] is None
+    ]
+    unknown_runs = [
+        {"run_number": r["run_number"], "date": r["date"], "url": r["url"]}
+        for r in report_runs
+        if r["verdict"] == "unknown"
+    ]
+
+    report = {
+        "month": month_id,
+        "label": label,
+        "anchor_date": anchor.isoformat(),
+        "totals": {
+            "runs": len(report_runs),
+            "red": red,
+            "without_regression": without_regression,
+            "no_summary": no_summary,
+            "unknown_verdict": unknown,
+            "pct_without_regression": pct,
+        },
+        "category_totals": category_totals,
+        "recurring_tests": recurring,
+        "no_summary_runs": no_summary_runs,
+        "unknown_verdict_runs": unknown_runs,
+        "runs": report_runs,
+    }
+
+    json_out = args.json_out or os.path.join(CACHE_ROOT, f"{month_id}-result.json")
+    os.makedirs(os.path.dirname(json_out), exist_ok=True)
+    with open(json_out, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    # Markdown table (paste-ready for the OpEx doc).
+    lines = [
+        f"| TF Provider Test Suite Runs | {label} |",
+        "| --- | --- |",
+        f"| **Runs with code regression** | {red} |",
+        f"| **Runs without code regression** (pass or infra noise only) | {without_regression} |",
+        f"| **% without regression** | {pct} |",
+    ]
+    if no_summary_runs or unknown_runs:
+        notes = []
+        if no_summary_runs:
+            refs = ", ".join(
+                f"[#{r['run_number']} ({r['date']})]({r['url']})" for r in no_summary_runs
+            )
+            notes.append(f"no summary available: {refs}")
+        if unknown_runs:
+            refs = ", ".join(
+                f"[#{r['run_number']} ({r['date']})]({r['url']})" for r in unknown_runs
+            )
+            notes.append(f"unparseable summary verdict: {refs}")
+        lines.append("")
+        lines.append(
+            "*Excluded from the percentage: " + "; ".join(notes) + ".*"
+        )
+
+    # Write the metrics section to monthly-summary-<anchor-date>.md in the cwd.
+    # The agent appends the **Notes:** narrative section to this file (Step 3 of
+    # the skill); it must not alter anything above that section.
+    md_out = f"monthly-summary-{anchor.isoformat()}.md"
+    with open(md_out, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print("\n".join(lines))
+    print(f"\nMarkdown file: {md_out}", file=sys.stderr)
+    print(f"JSON report: {json_out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/summarize-test-suite/SKILL.md
+++ b/.agents/skills/summarize-test-suite/SKILL.md
@@ -161,6 +161,8 @@ Assign each failing test (or aggregated subtest group) to exactly one category, 
 
 Build the summary in Slack mrkdwn from the templates below and return it. Never emit GitHub-flavoured markdown — `**bold**`, `# heading`, `[label](url)` will not render correctly. The TL;DR line appears only in the red template; green and yellow have no TL;DR (the header and categorisation say everything).
 
+**Format coupling**: the monthly-test-suite-summary skill parses this output format. Reflect any template change in `.agents/skills/monthly-test-suite-summary/scripts/monthly_summary.py`.
+
 #### Template — code regression detected
 
 Use this when at least one failure is category 1.


### PR DESCRIPTION
Adds a new `monthly-test-suite-summary` skill that builds the monthly test stability summary.

The old Passes/Fails metric counts was not clear indicator of the health of the test suite, because a run with only infra noise (e.g. `OUT_OF_CAPACITY`) reads as a failure and the suite looks broken even if no issue is present in the API/TF code. This skill instead reuses the daily `summarize-test-suite` verdicts uploaded as `summary` artifacts: a run only counts as a regression when the daily verdict was red.

Determinism split:

- `scripts/monthly_summary.py` does all data collection, verdict parsing, and aggregation. The agent never classifies anything.
- The agent only does sanity checks and writes a short narrative (red days, repeat offenders, category trends), appended to the output file.

Default scope is the previous calendar month, with a `--date` anchor override for missed runs. Output is written to `monthly-summary-<anchor-date>.md` (generated artefact, not to be committed).

Example output (July 2026):

```markdown
| TF Provider Test Suite Runs | Jul/26 |
| --- | --- |
| **Runs with code regression** | 5 |
| **Runs without code regression** (pass or infra noise only) | 25 |
| **% without regression** | 83.33% |

*Excluded from the percentage: no summary available: [#1095 (2026-07-20)](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29709878272).*

**Notes:**

- **Red days (5 runs, 3 distinct regressions):**
  - [#1076 (Jul 1)](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/28486204382) and [#1077 (Jul 2)](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/28557958982): same root cause, `Provider produced inconsistent result after apply` on `mongodbatlas_database_user` / `mongodbatlas_database_user_api` (`.description` populated server-side on PAK-authed create, state diverges from plan).
  - [#1078 (Jul 3)](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/28630942076): `TestAccMockableAdvancedCluster_tenantUpgrade` inconsistent result (`provider_name` AWS → TENANT and related attrs), plus a migration test schema mismatch on `mongodbatlas_project`.
  - [#1089 (Jul 14)](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29296414867) and [#1093 (Jul 18)](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/29623495404): same root cause, `TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema` `INVALID_ATTRIBUTE` on Disk IOPS PATCH outside M30/M30_GEN_2 tier limits. Recurred across 4 days before being fixed.
- **Noise was dominated by cloud-dev instability, not provider issues:** of 1400 total categorized failures, 1321 were API errors, mostly repeated `HTTP 500 UNEXPECTED_ERROR` on `POST /groups` (project creation) outage waves in cloud-dev (Jul 4, 14, 18, 23) and their `MAX_GROUPS_PER_ORG_EXCEEDED` cascades (Jul 9, 21). Remaining: 47 API contract, 28 timeout, 3 capacity, 1 cleanup.
- **Repeat offenders (tests named in failing lists on ≥4 days):**
  - LDAP suite (`TestAccLDAPConfiguration_basic`, `TestAccLDAPConfiguration_withVerify_CACertificateComplete`, `TestAccLDAPVerify_*`, `TestMigLDAP*`, 6 tests failing together on 4+ days): same root cause almost every time, `LDAP_HOSTNAME_NOT_ALLOWED` (Atlas rejecting the configured test LDAP hostname in dev/qa). Persistent env/allowlist issue, ticket candidate.
  - `TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema` (5 days): 2 days the real Disk IOPS regression above; 3 days (Jul 25, 28, 30) `HTTP 401` from the internal test-utils `independentShardScalingMode` endpoint under SA auth, also hit by `TestAccCluster_basic_RedactClientLogData`. Persistent SA-auth test-util issue, ticket candidate.
  - `TestAccSearchDeploymentAPI_basic` (5 days): alternating causes, mostly 1h state-wait timeouts (3 days) and one cleanup failure. Slow/flaky search deployment, watch item.
  - `TestAccAdvancedCluster_gen1ProvisionedDiskIops` (4 days): `HOURLY_BILLING_LIMIT_EXCEEDED` (QA billing quota) on at least 2 days, breaking its `ExpectError` assertion. Quota issue, not a provider bug.
  - `TestAccAdvancedCluster_effectiveBasic` (5 days): no test-specific root cause; it appears in the truncated failing lists of the mass-outage days. General infra noise.
- **Coverage:** 31 of 31 days had a scheduled run; one run (Jul 20) has no summary artifact and is excluded from the percentage.
```

CLOUDP-411248
