### PR TITLE
chore: Make clean-atlas-org project prefixes configurable and add atlas-examples default prefix

### DIFF
--- a/.github/templates/clean-atlas-org/action.yaml
+++ b/.github/templates/clean-atlas-org/action.yaml
@@ -1,5 +1,5 @@
 name: clean-atlas-org
-description: 'Cleans up an Atlas organization bot projects'
+description: 'Cleans up test projects in an Atlas organization'
 
 inputs:
   repo-path:
@@ -12,7 +12,7 @@ inputs:
     description: 'Only projects with 0 clusters'
     default: 'false'
   project-prefixes:
-    description: 'Comma-separated project name prefixes to clean, defaults to the repo bot project prefixes'
+    description: 'Comma-separated project name prefixes to clean, defaults to the built-in project prefixes'
     default: ''
 
 runs:

--- a/.github/templates/clean-atlas-org/action.yaml
+++ b/.github/templates/clean-atlas-org/action.yaml
@@ -11,6 +11,9 @@ inputs:
   clean-only-when-no-clusters:
     description: 'Only projects with 0 clusters'
     default: 'false'
+  project-prefixes:
+    description: 'Comma-separated project name prefixes to clean, defaults to the repo bot project prefixes'
+    default: ''
 
 runs:
   using: 'composite'
@@ -25,3 +28,4 @@ runs:
         DRY_RUN: ${{ inputs.dry-run }}
         MONGODB_ATLAS_CLEAN_ORG: 'true'
         MONGODB_ATLAS_CLEAN_ONLY_WHEN_NO_CLUSTERS: ${{ inputs.clean-only-when-no-clusters }}
+        MONGODB_ATLAS_CLEAN_PROJECT_PREFIXES: ${{ inputs.project-prefixes }}

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ build: ## Compile the provider binary
 	go build -ldflags "$(LINKER_FLAGS)" -o $(DESTINATION)
 
 .PHONY: clean-atlas-org
-clean-atlas-org: ## Run a test to clean all projects and pending resources in an Atlas org, supports export DRY_RUN=false (default=true)
+clean-atlas-org: ## Run a test to clean all projects and pending resources in an Atlas org, supports export DRY_RUN=false (default=true), MONGODB_ATLAS_CLEAN_PROJECT_PREFIXES=prefix1,prefix2
 	@$(eval export MONGODB_ATLAS_CLEAN_ORG?=true)
 	@$(eval export DRY_RUN?=true)
 	go test -count=1 'github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/clean' -timeout 3600s -parallel=250 -run 'TestCleanProjectAndClusters' -v -ldflags="$(LINKER_FLAGS)"

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -32,10 +32,11 @@ const (
 )
 
 var (
-	botProjectPrefixes = []string{
+	defaultBotProjectPrefixes = []string{
 		"cfn-", // general CFN tests
 		"ct-",  // CFN contract tests
 		"test-acc-tf-p-",
+		"atlas-examples-e2e-", // terraform-mongodbatlas-modules/atlas-examples e2e tests
 	}
 	// keptPrefixes has the prefix of the projects that we want to delete their resources but keep the projects themselves.
 	// Useful when a feature flag or cloud provider is configured outside of the test
@@ -97,8 +98,9 @@ func TestCleanProjectAndClusters(t *testing.T) {
 	t.Logf("found %d projects (DRY_RUN=%t)", projectsBefore, dryRun)
 	projectsToClean := map[string]string{}
 	projectInfos := []string{}
+	prefixes := projectPrefixes()
 	for _, p := range projects {
-		skipReason := projectSkipReason(&p, skipProjectsAfter, onlyZeroClusters)
+		skipReason := projectSkipReason(&p, skipProjectsAfter, onlyZeroClusters, prefixes)
 		projectName := p.GetName()
 		projectID := p.GetId()
 		if skipReason != "" {
@@ -215,15 +217,31 @@ func removeProjectResources(ctx context.Context, t *testing.T, dryRun bool, clie
 	return strings.Join(changes, ", "), nil
 }
 
-func projectSkipReason(p *admin.Group, skipProjectsAfter time.Time, onlyEmpty bool) string {
-	usesBotPrefix := false
-	for _, botPrefix := range botProjectPrefixes {
-		if strings.HasPrefix(p.GetName(), botPrefix) {
-			usesBotPrefix = true
+func projectPrefixes() []string {
+	prefixesStr := os.Getenv("MONGODB_ATLAS_CLEAN_PROJECT_PREFIXES")
+	if prefixesStr != "" {
+		prefixes := []string{}
+		for prefix := range strings.SplitSeq(prefixesStr, ",") {
+			if trimmed := strings.TrimSpace(prefix); trimmed != "" {
+				prefixes = append(prefixes, trimmed)
+			}
+		}
+		if len(prefixes) > 0 {
+			return prefixes
+		}
+	}
+	return defaultBotProjectPrefixes
+}
+
+func projectSkipReason(p *admin.Group, skipProjectsAfter time.Time, onlyEmpty bool, prefixes []string) string {
+	matchesPrefix := false
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(p.GetName(), prefix) {
+			matchesPrefix = true
 			break
 		}
 	}
-	if !usesBotPrefix {
+	if !matchesPrefix {
 		return "not bot project"
 	}
 	if p.GetCreated().After(skipProjectsAfter) {

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	defaultBotProjectPrefixes = []string{
+	defaultProjectPrefixes = []string{
 		"cfn-", // general CFN tests
 		"ct-",  // CFN contract tests
 		"test-acc-tf-p-",
@@ -230,7 +230,7 @@ func projectPrefixes() []string {
 			return prefixes
 		}
 	}
-	return defaultBotProjectPrefixes
+	return defaultProjectPrefixes
 }
 
 func projectSkipReason(p *admin.Group, skipProjectsAfter time.Time, onlyEmpty bool, prefixes []string) string {
@@ -242,7 +242,7 @@ func projectSkipReason(p *admin.Group, skipProjectsAfter time.Time, onlyEmpty bo
 		}
 	}
 	if !matchesPrefix {
-		return "not bot project"
+		return "name does not match cleanup prefixes"
 	}
 	if p.GetCreated().After(skipProjectsAfter) {
 		return "created after " + skipProjectsAfter.Format("2006-01-02T15:04")


### PR DESCRIPTION
## Description

Makes the Atlas org cleanup (`make clean-atlas-org`, backed by `internal/testutil/clean/org_clean_test.go`) usable by other repos/orgs, specifically terraform-mongodbatlas-modules/atlas-examples:

- Adds `atlas-examples-e2e-` to the default bot project prefixes, so the existing scheduled cleanup also sweeps atlas-examples CI leftovers in the shared dev org.
- Makes the prefix list configurable via `MONGODB_ATLAS_CLEAN_PROJECT_PREFIXES` (comma-separated, whitespace-trimmed, falls back to defaults when unset/empty), so any caller can scope the cleanup to its own convention without future upstream PRs.
- Adds an optional `project-prefixes` input to the `clean-atlas-org` composite action.

Backward compatibility: with no new env vars set, behavior is identical to today, plus matching the new default prefix. `.github/workflows/cleanup-test-env.yml` is unchanged and its jobs keep current behavior through defaults.

No changelog entry: internal test tooling only.

Link to any related issue(s): CLOUDP-428615

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.
- [ ] Documentation fix/enhancement.