### PR TITLE
feat: Add write-only password support to mongodbatlas_database_user

### DIFF
--- a/.changelog/4621.txt
+++ b/.changelog/4621.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_database_user: Adds support for write-only `password_wo` and `password_wo_version` attributes so the password is not persisted in Terraform state
+```

--- a/internal/service/databaseuser/model_database_user.go
+++ b/internal/service/databaseuser/model_database_user.go
@@ -50,6 +50,7 @@ func NewMongoDBDatabaseUser(ctx context.Context, statePasswordValue, stateDescri
 			result.Password = plan.PasswordWo.ValueStringPointer()
 		}
 	} else if statePasswordValue != plan.Password {
+		// Password value has been modified or no previous state was present. Password is only updated if changed in the terraform configuration CLOUDP-235738
 		result.Password = plan.Password.ValueStringPointer()
 	}
 	if plan.Description.IsNull() && !stateDescriptionValue.Equal(plan.Description) {

--- a/internal/service/databaseuser/model_database_user.go
+++ b/internal/service/databaseuser/model_database_user.go
@@ -46,9 +46,7 @@ func NewMongoDBDatabaseUser(ctx context.Context, statePasswordValue, stateDescri
 	}
 
 	if !plan.PasswordWo.IsNull() {
-		if statePasswordWoVersion.IsNull() {
-			result.Password = plan.PasswordWo.ValueStringPointer()
-		} else if !plan.PasswordWoVersion.IsNull() && statePasswordWoVersion.ValueInt64() != plan.PasswordWoVersion.ValueInt64() {
+		if statePasswordWoVersion.IsNull() || statePasswordWoVersion.ValueInt64() != plan.PasswordWoVersion.ValueInt64() {
 			result.Password = plan.PasswordWo.ValueStringPointer()
 		}
 	} else if statePasswordValue != plan.Password {
@@ -99,18 +97,15 @@ func NewTfDatabaseUserModel(ctx context.Context, inModel *TfDatabaseUserModel, d
 		Scopes:           scopesSet,
 	}
 
-	if inModel != nil && inModel.Password.ValueString() != "" {
-		// The Password is not returned from the endpoint so we use the one provided in the model.
-		outModel.Password = inModel.Password
-	}
-	// password_wo is write-only, so it is never persisted to state.
-	outModel.PasswordWo = types.StringNull()
 	if inModel != nil {
+		if inModel.Password.ValueString() != "" {
+			// Password is not returned from the endpoint so we use the one provided in the model.
+			outModel.Password = inModel.Password
+		}
 		outModel.PasswordWoVersion = inModel.PasswordWoVersion
-	}
-	if inModel != nil && outModel.Description.Equal(types.StringValue("")) && inModel.Description.IsNull() {
-		// null != "" in TPF:  Error: Provider produced inconsistent result after apply. .description: was null, but now cty.StringVal("")
-		outModel.Description = types.StringNull()
+		if outModel.Description.Equal(types.StringValue("")) && inModel.Description.IsNull() {
+			outModel.Description = types.StringNull()
+		}
 	}
 	return outModel, nil
 }

--- a/internal/service/databaseuser/model_database_user.go
+++ b/internal/service/databaseuser/model_database_user.go
@@ -11,7 +11,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
-func NewMongoDBDatabaseUser(ctx context.Context, statePasswordValue, stateDescriptionValue types.String, plan *TfDatabaseUserModel) (*admin.CloudDatabaseUser, diag.Diagnostics) {
+func NewMongoDBDatabaseUser(ctx context.Context, statePasswordValue, stateDescriptionValue types.String, statePasswordWoVersion types.Int64, plan *TfDatabaseUserModel) (*admin.CloudDatabaseUser, diag.Diagnostics) {
 	var rolesModel []*TfRoleModel
 	var labelsModel []*TfLabelModel
 	var scopesModel []*TfScopeModel
@@ -45,7 +45,25 @@ func NewMongoDBDatabaseUser(ctx context.Context, statePasswordValue, stateDescri
 		Scopes:       NewMongoDBAtlasScopes(scopesModel),
 	}
 
-	if statePasswordValue != plan.Password {
+	// Handle password_wo (write-only): send if version is new or changed
+	if !plan.PasswordWo.IsNull() {
+		// For write-only passwords, send if:
+		// 1. State version is null (CREATE - new resource)
+		// 2. Version changed (UPDATE - password rotation)
+		// Only send if password_wo_version is also set (enforced in Create/Update before this function is called)
+		if statePasswordWoVersion.IsNull() {
+			// CREATE: state has no version, so this is a new resource → send password
+			result.Password = plan.PasswordWo.ValueStringPointer()
+		} else if !plan.PasswordWoVersion.IsNull() {
+			// UPDATE: both state and plan have versions, check if changed
+			planVersion := plan.PasswordWoVersion.ValueInt64()
+			stateVersion := statePasswordWoVersion.ValueInt64()
+			if stateVersion != planVersion {
+				result.Password = plan.PasswordWo.ValueStringPointer()
+			}
+		}
+	} else if statePasswordValue != plan.Password {
+		// Legacy password attribute: send if changed
 		// Password value has been modified or no previous state was present. Password is only updated if changed in the terraform configuration CLOUDP-235738
 		result.Password = plan.Password.ValueStringPointer()
 	}
@@ -95,8 +113,15 @@ func NewTfDatabaseUserModel(ctx context.Context, inModel *TfDatabaseUserModel, d
 	}
 
 	if inModel != nil && inModel.Password.ValueString() != "" {
-		// The Password is not retuned from the endpoint so we use the one provided in the model
+		// The Password is not returned from the endpoint so we use the one provided in the model.
 		outModel.Password = inModel.Password
+	}
+	// password_wo is write-only: never stored in state, always null in read operations
+	outModel.PasswordWo = types.StringNull()
+	// password_wo_version is stored in state. On Create/Update inModel is the plan (user-specified value);
+	// on Read inModel is the prior state. In both cases we carry forward the value the user set.
+	if inModel != nil {
+		outModel.PasswordWoVersion = inModel.PasswordWoVersion
 	}
 	if inModel != nil && outModel.Description.Equal(types.StringValue("")) && inModel.Description.IsNull() {
 		// null != "" in TPF:  Error: Provider produced inconsistent result after apply. .description: was null, but now cty.StringVal("")

--- a/internal/service/databaseuser/model_database_user.go
+++ b/internal/service/databaseuser/model_database_user.go
@@ -45,26 +45,13 @@ func NewMongoDBDatabaseUser(ctx context.Context, statePasswordValue, stateDescri
 		Scopes:       NewMongoDBAtlasScopes(scopesModel),
 	}
 
-	// Handle password_wo (write-only): send if version is new or changed
 	if !plan.PasswordWo.IsNull() {
-		// For write-only passwords, send if:
-		// 1. State version is null (CREATE - new resource)
-		// 2. Version changed (UPDATE - password rotation)
-		// Only send if password_wo_version is also set (enforced in Create/Update before this function is called)
 		if statePasswordWoVersion.IsNull() {
-			// CREATE: state has no version, so this is a new resource → send password
 			result.Password = plan.PasswordWo.ValueStringPointer()
-		} else if !plan.PasswordWoVersion.IsNull() {
-			// UPDATE: both state and plan have versions, check if changed
-			planVersion := plan.PasswordWoVersion.ValueInt64()
-			stateVersion := statePasswordWoVersion.ValueInt64()
-			if stateVersion != planVersion {
-				result.Password = plan.PasswordWo.ValueStringPointer()
-			}
+		} else if !plan.PasswordWoVersion.IsNull() && statePasswordWoVersion.ValueInt64() != plan.PasswordWoVersion.ValueInt64() {
+			result.Password = plan.PasswordWo.ValueStringPointer()
 		}
 	} else if statePasswordValue != plan.Password {
-		// Legacy password attribute: send if changed
-		// Password value has been modified or no previous state was present. Password is only updated if changed in the terraform configuration CLOUDP-235738
 		result.Password = plan.Password.ValueStringPointer()
 	}
 	if plan.Description.IsNull() && !stateDescriptionValue.Equal(plan.Description) {
@@ -116,10 +103,8 @@ func NewTfDatabaseUserModel(ctx context.Context, inModel *TfDatabaseUserModel, d
 		// The Password is not returned from the endpoint so we use the one provided in the model.
 		outModel.Password = inModel.Password
 	}
-	// password_wo is write-only: never stored in state, always null in read operations
+	// password_wo is write-only, so it is never persisted to state.
 	outModel.PasswordWo = types.StringNull()
-	// password_wo_version is stored in state. On Create/Update inModel is the plan (user-specified value);
-	// on Read inModel is the prior state. In both cases we carry forward the value the user set.
 	if inModel != nil {
 		outModel.PasswordWoVersion = inModel.PasswordWoVersion
 	}

--- a/internal/service/databaseuser/model_database_user_test.go
+++ b/internal/service/databaseuser/model_database_user_test.go
@@ -92,10 +92,10 @@ var (
 
 func TestNewMongoDBDatabaseUser(t *testing.T) {
 	testCases := []struct {
-		tfDatabaseUserModel databaseuser.TfDatabaseUserModel
-		passwordStateValue  types.String
 		expectedResult      *admin.CloudDatabaseUser
+		passwordStateValue  types.String
 		name                string
+		tfDatabaseUserModel databaseuser.TfDatabaseUserModel
 		expectedError       bool
 	}{
 		{
@@ -145,9 +145,74 @@ func TestNewMongoDBDatabaseUser(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resultModel, err := databaseuser.NewMongoDBDatabaseUser(t.Context(), tc.passwordStateValue, types.StringValue(""), &testCases[i].tfDatabaseUserModel)
+			resultModel, err := databaseuser.NewMongoDBDatabaseUser(t.Context(), tc.passwordStateValue, types.StringValue(""), types.Int64Null(), &testCases[i].tfDatabaseUserModel)
 
 			if (err != nil) != tc.expectedError {
+				t.Errorf("Case %s: Received unexpected error: %v", tc.name, err)
+			}
+			assert.Equal(t, tc.expectedResult, resultModel, "created terraform model did not match expected output")
+		})
+	}
+}
+
+func newPasswordWoTestModel(passwordWo string, version int64) databaseuser.TfDatabaseUserModel {
+	return databaseuser.TfDatabaseUserModel{
+		ProjectID:         types.StringValue(projectID),
+		Username:          types.StringValue(username),
+		AuthDatabaseName:  types.StringValue(authDatabaseName),
+		PasswordWo:        types.StringValue(passwordWo),
+		PasswordWoVersion: types.Int64Value(version),
+		Roles:             rolesSet,
+		Labels:            labelsSet,
+		Scopes:            scopesSet,
+	}
+}
+
+func newPasswordWoExpectedResult(password *string) *admin.CloudDatabaseUser {
+	return &admin.CloudDatabaseUser{
+		GroupId:      projectID,
+		Username:     username,
+		DatabaseName: authDatabaseName,
+		Description:  new(""),
+		Password:     password,
+		Roles:        []admin.DatabaseUserRole{sdkRole},
+		Labels:       &[]admin.ComponentLabel{sdkLabel},
+		Scopes:       &[]admin.UserScope{sdkScope},
+	}
+}
+
+func TestNewMongoDBDatabaseUserPasswordWo(t *testing.T) {
+	testCases := []struct {
+		expectedResult       *admin.CloudDatabaseUser
+		name                 string
+		tfDatabaseUserModel  databaseuser.TfDatabaseUserModel
+		passwordWoStateValue types.Int64
+	}{
+		{
+			name:                 "password_wo sets result.Password on CREATE",
+			tfDatabaseUserModel:  newPasswordWoTestModel("write-only-password", 1),
+			passwordWoStateValue: types.Int64Null(),
+			expectedResult:       newPasswordWoExpectedResult(new("write-only-password")),
+		},
+		{
+			name:                 "password_wo sets password when version changes on UPDATE",
+			tfDatabaseUserModel:  newPasswordWoTestModel("updated-password", 2),
+			passwordWoStateValue: types.Int64Value(1),
+			expectedResult:       newPasswordWoExpectedResult(new("updated-password")),
+		},
+		{
+			name:                 "password_wo does NOT set password when version unchanged on UPDATE",
+			tfDatabaseUserModel:  newPasswordWoTestModel("same-password", 1),
+			passwordWoStateValue: types.Int64Value(1),
+			expectedResult:       newPasswordWoExpectedResult(nil),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resultModel, err := databaseuser.NewMongoDBDatabaseUser(t.Context(), types.StringNull(), types.StringValue(""), tc.passwordWoStateValue, &testCases[i].tfDatabaseUserModel)
+
+			if err != nil {
 				t.Errorf("Case %s: Received unexpected error: %v", tc.name, err)
 			}
 			assert.Equal(t, tc.expectedResult, resultModel, "created terraform model did not match expected output")
@@ -158,9 +223,9 @@ func TestNewMongoDBDatabaseUser(t *testing.T) {
 func TestNewTfDatabaseUserModel(t *testing.T) {
 	testCases := []struct {
 		expectedResult  *databaseuser.TfDatabaseUserModel
-		currentModel    databaseuser.TfDatabaseUserModel
 		sdkDatabaseUser *admin.CloudDatabaseUser
 		name            string
+		currentModel    databaseuser.TfDatabaseUserModel
 		expectedError   bool
 	}{
 		{
@@ -353,19 +418,21 @@ func getDatabaseUserModel(roles, labels, scopes basetypes.SetValue, password typ
 		"auth_database_name": authDatabaseName,
 	})
 	return &databaseuser.TfDatabaseUserModel{
-		ID:               types.StringValue(encodedID),
-		ProjectID:        types.StringValue(projectID),
-		AuthDatabaseName: types.StringValue(authDatabaseName),
-		Username:         types.StringValue(username),
-		Description:      types.StringValue(""),
-		Password:         password,
-		X509Type:         types.StringValue(x509Type),
-		OIDCAuthType:     types.StringValue(oidCAuthType),
-		LDAPAuthType:     types.StringValue(ldapAuthType),
-		AWSIAMType:       types.StringValue(awsIAMType),
-		Roles:            roles,
-		Labels:           labels,
-		Scopes:           scopes,
+		ID:                types.StringValue(encodedID),
+		ProjectID:         types.StringValue(projectID),
+		AuthDatabaseName:  types.StringValue(authDatabaseName),
+		Username:          types.StringValue(username),
+		Description:       types.StringValue(""),
+		Password:          password,
+		PasswordWo:        types.StringNull(),
+		PasswordWoVersion: types.Int64Null(),
+		X509Type:          types.StringValue(x509Type),
+		OIDCAuthType:      types.StringValue(oidCAuthType),
+		LDAPAuthType:      types.StringValue(ldapAuthType),
+		AWSIAMType:        types.StringValue(awsIAMType),
+		Roles:             roles,
+		Labels:            labels,
+		Scopes:            scopes,
 	}
 }
 

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -138,10 +139,18 @@ func (r *databaseUserRS) Schema(ctx context.Context, req resource.SchemaRequest,
 						path.MatchRelative().AtParent().AtName("ldap_auth_type"),
 						path.MatchRelative().AtParent().AtName("aws_iam_type"),
 					}...),
+					stringvalidator.AlsoRequires(
+						path.MatchRelative().AtParent().AtName("password_wo_version"),
+					),
 				},
 			},
 			"password_wo_version": schema.Int64Attribute{
 				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(
+						path.MatchRelative().AtParent().AtName("password_wo"),
+					),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
@@ -241,19 +250,9 @@ func (r *databaseUserRS) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// password_wo is nullified by the framework in the plan (write-only semantics), so read it from
-	// config instead. password_wo_version is non-write-only and remains in the plan unchanged.
+	// Write-only values are nullified in the plan, so password_wo must be read from config.
 	if !configModel.PasswordWo.IsNull() {
 		plan.PasswordWo = configModel.PasswordWo
-		// Validate: password_wo requires password_wo_version to be set for rotation detection
-		if configModel.PasswordWoVersion.IsNull() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("password_wo_version"),
-				"Missing Required Attribute",
-				"When 'password_wo' is set, 'password_wo_version' must also be specified to enable password rotation detection.",
-			)
-			return
-		}
 	}
 
 	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, types.StringNull(), types.StringNull(), types.Int64Null(), plan)
@@ -327,21 +326,9 @@ func (r *databaseUserRS) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	// Write-only attribute handling: The Terraform framework nullifies write-only values in the plan
-	// (to prevent them from being persisted in state), but they remain available in the config.
-	// We must read from config to access the original user-provided value, then the framework
-	// ensures it never appears in the resulting state.
+	// Write-only values are nullified in the plan, so password_wo must be read from config.
 	if !configModel.PasswordWo.IsNull() {
 		plan.PasswordWo = configModel.PasswordWo
-		// Validate: password_wo requires password_wo_version to be set for rotation detection
-		if configModel.PasswordWoVersion.IsNull() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("password_wo_version"),
-				"Missing Required Attribute",
-				"When 'password_wo' is set, 'password_wo_version' must also be specified to enable password rotation detection.",
-			)
-			return
-		}
 	}
 
 	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, state.Password, state.Description, state.PasswordWoVersion, plan)

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -251,9 +251,7 @@ func (r *databaseUserRS) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Write-only values are nullified in the plan, so password_wo must be read from config.
-	if !configModel.PasswordWo.IsNull() {
-		plan.PasswordWo = configModel.PasswordWo
-	}
+	plan.PasswordWo = configModel.PasswordWo
 
 	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, types.StringNull(), types.StringNull(), types.Int64Null(), plan)
 	resp.Diagnostics.Append(localDiags...)
@@ -327,9 +325,7 @@ func (r *databaseUserRS) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Write-only values are nullified in the plan, so password_wo must be read from config.
-	if !configModel.PasswordWo.IsNull() {
-		plan.PasswordWo = configModel.PasswordWo
-	}
+	plan.PasswordWo = configModel.PasswordWo
 
 	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, state.Password, state.Description, state.PasswordWoVersion, plan)
 	resp.Diagnostics.Append(localDiags...)

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -43,19 +43,21 @@ func Resource() resource.Resource {
 }
 
 type TfDatabaseUserModel struct {
-	ID               types.String `tfsdk:"id"`
-	ProjectID        types.String `tfsdk:"project_id"`
-	AuthDatabaseName types.String `tfsdk:"auth_database_name"`
-	Username         types.String `tfsdk:"username"`
-	Password         types.String `tfsdk:"password"`
-	X509Type         types.String `tfsdk:"x509_type"`
-	OIDCAuthType     types.String `tfsdk:"oidc_auth_type"`
-	LDAPAuthType     types.String `tfsdk:"ldap_auth_type"`
-	AWSIAMType       types.String `tfsdk:"aws_iam_type"`
-	Description      types.String `tfsdk:"description"`
-	Roles            types.Set    `tfsdk:"roles"`
-	Labels           types.Set    `tfsdk:"labels"`
-	Scopes           types.Set    `tfsdk:"scopes"`
+	ID                types.String `tfsdk:"id"`
+	ProjectID         types.String `tfsdk:"project_id"`
+	AuthDatabaseName  types.String `tfsdk:"auth_database_name"`
+	Username          types.String `tfsdk:"username"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWo        types.String `tfsdk:"password_wo"`
+	X509Type          types.String `tfsdk:"x509_type"`
+	OIDCAuthType      types.String `tfsdk:"oidc_auth_type"`
+	LDAPAuthType      types.String `tfsdk:"ldap_auth_type"`
+	AWSIAMType        types.String `tfsdk:"aws_iam_type"`
+	Description       types.String `tfsdk:"description"`
+	Roles             types.Set    `tfsdk:"roles"`
+	Labels            types.Set    `tfsdk:"labels"`
+	Scopes            types.Set    `tfsdk:"scopes"`
+	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
 }
 
 type TfRoleModel struct {
@@ -124,6 +126,22 @@ func (r *databaseUserRS) Schema(ctx context.Context, req resource.SchemaRequest,
 						path.MatchRelative().AtParent().AtName("aws_iam_type"),
 					}...),
 				},
+			},
+			"password_wo": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				WriteOnly: true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRelative().AtParent().AtName("password"),
+						path.MatchRelative().AtParent().AtName("x509_type"),
+						path.MatchRelative().AtParent().AtName("ldap_auth_type"),
+						path.MatchRelative().AtParent().AtName("aws_iam_type"),
+					}...),
+				},
+			},
+			"password_wo_version": schema.Int64Attribute{
+				Optional: true,
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
@@ -209,6 +227,7 @@ func (r *databaseUserRS) Schema(ctx context.Context, req resource.SchemaRequest,
 
 func (r *databaseUserRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan *TfDatabaseUserModel
+	var configModel *TfDatabaseUserModel
 
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -216,7 +235,28 @@ func (r *databaseUserRS) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, types.StringNull(), types.StringNull(), plan)
+	diagsConfig := req.Config.Get(ctx, &configModel)
+	resp.Diagnostics.Append(diagsConfig...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// password_wo is nullified by the framework in the plan (write-only semantics), so read it from
+	// config instead. password_wo_version is non-write-only and remains in the plan unchanged.
+	if !configModel.PasswordWo.IsNull() {
+		plan.PasswordWo = configModel.PasswordWo
+		// Validate: password_wo requires password_wo_version to be set for rotation detection
+		if configModel.PasswordWoVersion.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("password_wo_version"),
+				"Missing Required Attribute",
+				"When 'password_wo' is set, 'password_wo_version' must also be specified to enable password rotation detection.",
+			)
+			return
+		}
+	}
+
+	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, types.StringNull(), types.StringNull(), types.Int64Null(), plan)
 	resp.Diagnostics.Append(localDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -278,15 +318,33 @@ func (r *databaseUserRS) Read(ctx context.Context, req resource.ReadRequest, res
 }
 
 func (r *databaseUserRS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state *TfDatabaseUserModel
+	var plan, state, configModel *TfDatabaseUserModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, state.Password, state.Description, plan)
+	// Write-only attribute handling: The Terraform framework nullifies write-only values in the plan
+	// (to prevent them from being persisted in state), but they remain available in the config.
+	// We must read from config to access the original user-provided value, then the framework
+	// ensures it never appears in the resulting state.
+	if !configModel.PasswordWo.IsNull() {
+		plan.PasswordWo = configModel.PasswordWo
+		// Validate: password_wo requires password_wo_version to be set for rotation detection
+		if configModel.PasswordWoVersion.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("password_wo_version"),
+				"Missing Required Attribute",
+				"When 'password_wo' is set, 'password_wo_version' must also be specified to enable password rotation detection.",
+			)
+			return
+		}
+	}
+
+	dbUserReq, localDiags := NewMongoDBDatabaseUser(ctx, state.Password, state.Description, state.PasswordWoVersion, plan)
 	resp.Diagnostics.Append(localDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -298,7 +356,7 @@ func (r *databaseUserRS) Update(ctx context.Context, req resource.UpdateRequest,
 		plan.AuthDatabaseName.ValueString(),
 		plan.Username.ValueString(), dbUserReq).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("error during database user creation", err.Error())
+		resp.Diagnostics.AddError("error during database user update", err.Error())
 		return
 	}
 

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -35,7 +35,7 @@ var (
 		ImportStateIdFunc:       importStateIDFunc(resourceName),
 		ImportState:             true,
 		ImportStateVerify:       true,
-		ImportStateVerifyIgnore: []string{"password"},
+		ImportStateVerifyIgnore: []string{"password", "password_wo_version"},
 	}
 )
 
@@ -523,6 +523,85 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 
 		return fmt.Errorf("database user(%s-%s-%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["username"], rs.Primary.Attributes["auth_database_name"])
 	}
+}
+
+func TestAccDatabaseUser_withPasswordWo(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+		username  = acc.RandomName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: acc.ConfigDatabaseUserPasswordWo(projectID, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
+					// password_wo should not be stored in state
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+					// legacy password should not be set
+					resource.TestCheckNoResourceAttr(resourceName, "password"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabaseUser_withPasswordWoVersionUpdate(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+		username  = acc.RandomName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: acc.ConfigDatabaseUserPasswordWo(projectID, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
+				),
+			},
+			{
+				Config: acc.ConfigDatabaseUserPasswordWoVersionUpdate(projectID, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabaseUser_legacyPassword(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+		username  = acc.RandomName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: acc.ConfigDatabaseUserBasic(projectID, username, "atlasAdmin", "test-key", "test-value"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo_version"),
+				),
+			},
+		},
+	})
 }
 
 func checkDestroy(s *terraform.State) error {

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -574,6 +574,39 @@ func TestAccDatabaseUser_withPasswordWriteOnly(t *testing.T) {
 	})
 }
 
+func TestAccDatabaseUser_migrateToPasswordWriteOnly(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+		username  = acc.RandomName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acc.ConfigDatabaseUserBasic(projectID, username, "atlasAdmin", "key", "value"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo_version"),
+				),
+			},
+			{
+				Config: acc.ConfigDatabaseUserPasswordWo(projectID, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "password"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatabaseUser_writeOnlyValidation(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/databaseuser"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
@@ -47,6 +49,8 @@ func TestAccDatabaseUser_basic(t *testing.T) {
 			resource.TestCheckNoResourceAttr(resourceName, "description"),
 			resource.TestCheckNoResourceAttr(dataSourceName, "description"),
 			resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+			resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+			resource.TestCheckNoResourceAttr(resourceName, "password_wo_version"),
 		}
 	)
 
@@ -525,7 +529,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 	}
 }
 
-func TestAccDatabaseUser_withPasswordWo(t *testing.T) {
+func TestAccDatabaseUser_withPasswordWriteOnly(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
 		username  = acc.RandomName()
@@ -535,6 +539,9 @@ func TestAccDatabaseUser_withPasswordWo(t *testing.T) {
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0), // write-only attributes require Terraform 1.11+
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDatabaseUserPasswordWo(projectID, username),
@@ -543,17 +550,23 @@ func TestAccDatabaseUser_withPasswordWo(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
 					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
-					// password_wo should not be stored in state
 					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
-					// legacy password should not be set
 					resource.TestCheckNoResourceAttr(resourceName, "password"),
 				),
 			},
+			{
+				Config: acc.ConfigDatabaseUserPasswordWoVersionUpdate(projectID, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "2"),
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+				),
+			},
+			importStep,
 		},
 	})
 }
 
-func TestAccDatabaseUser_withPasswordWoVersionUpdate(t *testing.T) {
+func TestAccDatabaseUser_writeOnlyValidation(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
 		username  = acc.RandomName()
@@ -562,19 +575,24 @@ func TestAccDatabaseUser_withPasswordWoVersionUpdate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigDatabaseUserPasswordWo(projectID, username),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
-				),
+				Config:      configDatabaseUserPasswordAndPasswordWo(projectID, username),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Attribute "password_wo" cannot be specified when\s+"password" is\s+specified`),
 			},
 			{
-				Config: acc.ConfigDatabaseUserPasswordWoVersionUpdate(projectID, username),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "2"),
-				),
+				Config:      configDatabaseUserPasswordWoOnly(projectID, username),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Attribute "password_wo_version" must be specified when\s+"password_wo" is\s+specified`),
+			},
+			{
+				Config:      configDatabaseUserPasswordWoVersionOnly(projectID, username),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Attribute "password_wo" must be specified when\s+"password_wo_version" is\s+specified`),
 			},
 		},
 	})
@@ -633,4 +651,54 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		return fmt.Sprintf("%s-%s-%s", ids["project_id"], ids["username"], ids["auth_database_name"]), nil
 	}
+}
+
+func configDatabaseUserPasswordAndPasswordWo(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "test" {
+			project_id          = %[1]q
+			username            = %[2]q
+			password            = "test-acc-password"
+			password_wo         = "test-acc-password-wo"
+			password_wo_version = 1
+			auth_database_name  = "admin"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+	`, projectID, username)
+}
+
+func configDatabaseUserPasswordWoOnly(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "test" {
+			project_id         = %[1]q
+			username           = %[2]q
+			password_wo        = "test-acc-password-wo"
+			auth_database_name = "admin"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+	`, projectID, username)
+}
+
+func configDatabaseUserPasswordWoVersionOnly(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "test" {
+			project_id          = %[1]q
+			username            = %[2]q
+			password_wo_version = 1
+			auth_database_name  = "admin"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+	`, projectID, username)
 }

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -582,7 +582,7 @@ func TestAccDatabaseUser_writeOnlyValidation(t *testing.T) {
 			{
 				Config:      configDatabaseUserPasswordAndPasswordWo(projectID, username),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`Attribute "password_wo" cannot be specified when\s+"password" is\s+specified`),
+				ExpectError: regexp.MustCompile(`Attribute "password" cannot be specified when\s+"password_wo" is\s+specified`),
 			},
 			{
 				Config:      configDatabaseUserPasswordWoOnly(projectID, username),

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -37,6 +37,14 @@ var (
 		ImportStateIdFunc:       importStateIDFunc(resourceName),
 		ImportState:             true,
 		ImportStateVerify:       true,
+		ImportStateVerifyIgnore: []string{"password"},
+	}
+	// Atlas does not return password_wo_version, so it is null after import.
+	importStepWriteOnly = resource.TestStep{
+		ResourceName:            resourceName,
+		ImportStateIdFunc:       importStateIDFunc(resourceName),
+		ImportState:             true,
+		ImportStateVerify:       true,
 		ImportStateVerifyIgnore: []string{"password", "password_wo_version"},
 	}
 )
@@ -561,7 +569,7 @@ func TestAccDatabaseUser_withPasswordWriteOnly(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
 				),
 			},
-			importStep,
+			importStepWriteOnly,
 		},
 	})
 }

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -598,30 +598,6 @@ func TestAccDatabaseUser_writeOnlyValidation(t *testing.T) {
 	})
 }
 
-func TestAccDatabaseUser_legacyPassword(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		username  = acc.RandomName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: acc.ConfigDatabaseUserBasic(projectID, username, "atlasAdmin", "test-key", "test-value"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "username", username),
-					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
-					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
-					resource.TestCheckNoResourceAttr(resourceName, "password_wo_version"),
-				),
-			},
-		},
-	})
-}
-
 func checkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_database_user" {

--- a/internal/testutil/acc/database_user.go
+++ b/internal/testutil/acc/database_user.go
@@ -201,3 +201,37 @@ func ConfigDataBaseUserWithOIDCAuthType(projectID, username, authType, databaseN
 	}
 `, projectID, username, authType, databaseName, roleName)
 }
+
+func ConfigDatabaseUserPasswordWo(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "test" {
+			project_id          = %[1]q
+			username            = %[2]q
+			password_wo         = "test-acc-password-wo"
+			password_wo_version = 1
+			auth_database_name  = "admin"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+	`, projectID, username)
+}
+
+func ConfigDatabaseUserPasswordWoVersionUpdate(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "test" {
+			project_id          = %[1]q
+			username            = %[2]q
+			password_wo         = "test-acc-password-wo-updated"
+			password_wo_version = 2
+			auth_database_name  = "admin"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+	`, projectID, username)
+}


### PR DESCRIPTION
## Description

Adds write-only password support to `mongodbatlas_database_user` so the password is never persisted to Terraform plan or state.

Two new optional attributes are added:

- `password_wo` : Sent to Atlas on create and update, never written to state.
- `password_wo_version`: rotation trigger. 

Link to any related issue(s): CLOUDP-431741

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Resource documentation and example migrations are tracked separately (CLOUDP-431743 and CLOUDP-431744), which is why the documentation checkbox above is unticked.