### PR TITLE
chore: Skips TestAccProjectIPAccessList_settingMultiple when using PAK credentials

### DIFF
--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -113,6 +113,8 @@ func TestAccProjectIPAccessList_settingAWSSecurityGroup(t *testing.T) {
 }
 
 func TestAccProjectIPAccessList_settingMultiple(t *testing.T) {
+	// Concurrent access list deletes get spurious 401 replay rejections under digest auth, related ticket: CLOUDP-432227
+	acc.SkipInPAK(t, "concurrent deletes fail with 401 under digest auth, see CLOUDP-432227")
 	var (
 		projectID        = acc.ProjectIDExecution(t)
 		resourceFmt      = "mongodbatlas_project_ip_access_list.test_%d"


### PR DESCRIPTION
## Description

Skips `TestAccProjectIPAccessList_settingMultiple` when the acceptance suite runs with programmatic API key credentials.

The test manages 20 access list entries and deletes them concurrently. Under digest auth those concurrent deletes intermittently return `401 Unauthorized` with a replay rejection, even though each nonce is sent exactly once.

This is not a non-prod artifact. PAK token exchange is off in all environments, so prod PAK traffic already authenticates with digest and is reachable by the same failure. The server behaviour did not change. CLOUDP-428083 disabled PAK token exchange in non-prod, moving non-prod PAK off bearer tokens and onto digest, which aligned non-prod with prod and exposed the failure to our nightly test runs. That is why the PAK nightly has failed on this test since 2026-07-29.

The upstream fix is tracked in CLOUDP-432227, owned by the IAM Workload Identity team. This PR only stops a known server-side failure from red-lining the PAK nightly. Remove the skip once that ticket is resolved. Service Account and access token runs are unaffected and continue to cover the test.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Test-only change, no changelog entry needed. Verified locally: with PAK credentials the test skips before any API call; with Service Account credentials it runs as before.

