### PR TITLE
chore: Serialize project ip access list DELETEs

### DIFF
--- a/internal/service/projectipaccesslist/resource_project_ip_access_list.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list.go
@@ -29,7 +29,11 @@ const (
 	minTimeoutCreate      = 10 * time.Second
 )
 
-var createAccessListEntryMutex = concurrency.NewMutexKV()
+// Each access list entry is its own resource, which leads to concurrent calls within a single execution unless explicitly serialized by the user.
+// From API docs: "This endpoint doesn't support concurrent POST requests. You must submit multiple POST requests synchronously."
+// Locking both POSTs and DELETEs at the project level to avoid race conditions within a single execution.
+// Still, we verify that the entry was added/removed to/from the access list and retry otherwise in case of an external action.
+var accessListEntryMutex = concurrency.NewMutexKV()
 
 type projectIPAccessListRS struct {
 	config.RSCommon
@@ -162,7 +166,10 @@ func (r *projectIPAccessListRS) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		accessListEntryMutex.Lock(projectID)
 		httpResponse, err := connV2.ProjectIPAccessListAPI.DeleteAccessListEntry(ctx, projectID, entry).Execute()
+		// Unlock immediately to allow parallel reads (intentionally not deferring).
+		accessListEntryMutex.Unlock(projectID)
 		if err != nil {
 			if validate.StatusInternalServerError(httpResponse) {
 				return retry.RetryableError(err)
@@ -220,13 +227,10 @@ func createEntry(ctx context.Context, connV2 *admin.APIClient, projectIPAccessLi
 		Pending: []string{"pending"},
 		Target:  []string{"created", "failed"},
 		Refresh: func() (any, string, error) {
-			// Each access list entry is its own resource, which leads to concurrent calls within a single apply unless explicitly handled by the user.
-			// From API docs: "This endpoint doesn't support concurrent POST requests. You must submit multiple POST requests synchronously."
-			// Locking on a project level to avoid race conditions within a single apply. Still, we verify that the entry was added to the access list and retry otherwise in case of an external update.
-			createAccessListEntryMutex.Lock(projectID)
+			accessListEntryMutex.Lock(projectID)
 			_, httpResponse, err := connV2.ProjectIPAccessListAPI.CreateAccessListEntry(ctx, projectID, NewMongoDBProjectIPAccessList(projectIPAccessListModel)).Execute()
-			// Unlock immediately after create to allow parallel reads (intentionally not deferring).
-			createAccessListEntryMutex.Unlock(projectID)
+			// Unlock immediately to allow parallel reads (intentionally not deferring).
+			accessListEntryMutex.Unlock(projectID)
 			if err != nil {
 				if validate.StatusInternalServerError(httpResponse) {
 					return nil, "pending", nil

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -113,8 +113,6 @@ func TestAccProjectIPAccessList_settingAWSSecurityGroup(t *testing.T) {
 }
 
 func TestAccProjectIPAccessList_settingMultiple(t *testing.T) {
-	// Concurrent access list deletes get spurious 401 replay rejections under digest auth, related ticket: CLOUDP-432227
-	acc.SkipInPAK(t, "concurrent deletes fail with 401 under digest auth, see CLOUDP-432227")
 	var (
 		projectID        = acc.ProjectIDExecution(t)
 		resourceFmt      = "mongodbatlas_project_ip_access_list.test_%d"


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4623 
Atlas does not support concurrent operations for project ip access lists.
We were previously serializing POSTs only (see https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4108), but as we observed in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4623, DELETEs also play into the same issue.
We are only seeing error for PAKs due to a difference in the API behavior that causes 401s instead of retry-able errors, owner team to work on a fix. 
In regards to Terraform, we avoid retries altogether by serializing these calls.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-433170

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
