### PR TITLE
chore: Use SDK SetAdaptiveCapacityNil for clearing adaptive_capacity in mongodbatlas_advanced_cluster

### DIFF
--- a/internal/service/advancedcluster/resource.go
+++ b/internal/service/advancedcluster/resource.go
@@ -397,25 +397,12 @@ func (r *rs) applyClusterChanges(ctx context.Context, diags *diag.Diagnostics, p
 	return result
 }
 
-// clearAdaptiveCapacity sends a PATCH with `adaptiveCapacity: null` via UntypedAPICall.
-// Needed because the SDK field is *string with omitempty, so a nil pointer would be omitted instead of serialized as null.
-// Once CLOUDP-315290 adds SDK-level null support in PATCH payloads, this special case can be removed.
+// clearAdaptiveCapacity sends a PATCH with `adaptiveCapacity: null` to clear the value.
+// SetAdaptiveCapacityNil is used so a nil pointer is serialized as null instead of omitted.
 func clearAdaptiveCapacity(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, waitParams *ClusterWaitParams) *admin.ClusterDescription20240805 {
-	body := []byte(`{"adaptiveCapacity":null}`)
-	_, err := client.UntypedAPICall(ctx, config.APICallParams{
-		VersionHeader: "application/vnd.atlas.2024-08-05+json",
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{name}",
-		PathParams: map[string]string{
-			"groupId": waitParams.ProjectID,
-			"name":    waitParams.ClusterName,
-		},
-		Method: "PATCH",
-	}, body)
-	if err != nil {
-		addErrorDiag(diags, operationUpdate, defaultAPIErrorDetails(waitParams.ClusterName, err))
-		return nil
-	}
-	return AwaitChanges(ctx, client, waitParams, operationUpdate, diags)
+	patchReq := &admin.ClusterDescription20240805{}
+	patchReq.SetAdaptiveCapacityNil()
+	return updateCluster(ctx, diags, client, patchReq, waitParams, operationUpdate)
 }
 
 func getBasicClusterModel(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, clusterResp *admin.ClusterDescription20240805, modelIn *TFModel) *TFModel {


### PR DESCRIPTION
## Description

Replaces the `UntypedAPICall` PATCH workaround in `clearAdaptiveCapacity` with the SDK's `SetAdaptiveCapacityNil()`, which serializes `adaptiveCapacity` as explicit JSON null. The workaround was needed because the SDK field had `omitempty`, but SDK-level null support (CLOUDP-315290) is now available. Behavior is unchanged.

Link to any related issue(s): CLOUDP-426882

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Covered by existing `TestAccAdvancedCluster_adaptiveCapacity` (steps removing `adaptive_capacity` from config), no new tests needed.