### PR TITLE
chore: Remove invalid disk iops test step

### DIFF
--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -3332,10 +3332,6 @@ func TestAccAdvancedCluster_gen2HighPerformanceDiskIops(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{pluralCheckGen2(clusterName, 3400, "HIGH_PERFORMANCE")},
 			},
 			{
-				Config:      configGen2(projectID, clusterName, "AF_SOUTH_1", "M30_GEN_2", "HIGH_PERFORMANCE", 100000, false),
-				ExpectError: regexp.MustCompile("INVALID_ATTRIBUTE"),
-			},
-			{
 				Config:      configGen2(projectID, clusterName, "AF_SOUTH_1", "M30_GEN_2", "HIGH_PERFORMANCE", 1, false),
 				ExpectError: regexp.MustCompile("INVALID_ATTRIBUTE"),
 			},
@@ -3370,10 +3366,6 @@ func TestAccAdvancedCluster_gen1ProvisionedDiskIops(t *testing.T) {
 				Config:            configGen2(projectID, clusterName, "US_EAST_1", "M30", "PROVISIONED", 1500, false),
 				Check:             checkGen2(1500, "PROVISIONED", false, false),
 				ConfigStateChecks: []statecheck.StateCheck{pluralCheckGen2(clusterName, 1500, "PROVISIONED")},
-			},
-			{
-				Config:      configGen2(projectID, clusterName, "US_EAST_1", "M30", "PROVISIONED", 1000000, false),
-				ExpectError: regexp.MustCompile("INVALID_ATTRIBUTE"),
 			},
 			{
 				Config:      configGen2(projectID, clusterName, "US_EAST_1", "M30", "PROVISIONED", 1, false),


### PR DESCRIPTION
## Description

This test step has been failing due to getting a `HOURLY_BILLING_LIMIT_EXCEEDED` error instead of `INVALID_ATTRIBUTE`.
Removing the step as discussed with the team - it makes little sense for us to be testing these API error cases in Terraform.
We already notified upstream of the change in behavior.

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
