### PR TITLE
chore: Migrate SilkBomb workflows to DevProd Platforms ECR

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -14,6 +14,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  # TEMPORARY: validates ECR access for SilkBomb, remove before merge.
+  silkbomb-ecr-access:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
+      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
+    steps:
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
+      - name: Verify SilkBomb image is executable
+        run: docker run --rm "${SILKBOMB_IMG}" --help
   build:
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -14,28 +14,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # TEMPORARY: validates ECR access for SilkBomb, remove before merge.
-  silkbomb-ecr-access:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    env:
-      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
-      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
-      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
-    steps:
-      - name: Configure AWS credentials for DevProd Platforms ECR
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
-        with:
-          role-to-assume: ${{ env.ECR_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Authenticate Docker to DevProd Platforms ECR
-        run: |
-          aws ecr get-login-password --region us-east-1 |
-            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
-          docker pull "${SILKBOMB_IMG}"
-      - name: Verify SilkBomb image is executable
-        run: docker run --rm "${SILKBOMB_IMG}" --help
   build:
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/generate-augmented-sbom.yml
+++ b/.github/workflows/generate-augmented-sbom.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
       KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
       KONDUKTO_REPO: ${{ vars.KONDUKTO_REPO }}
       KONDUKTO_BRANCH_PREFIX: ${{ vars.KONDUKTO_BRANCH_PREFIX }}
@@ -24,6 +26,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,18 +221,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     needs: [ release-config, release ]
     if: >-
       !cancelled()
       && needs.release.result == 'success'
       && needs.release-config.outputs.is_official_release == 'true'
     env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
       SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ inputs.version_number }}
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
       - name: Generate SBOM
         run: make gen-purls generate-sbom
       - name: Upload SBOM to Kondukto


### PR DESCRIPTION
## Summary
- The Artifactory-hosted SilkBomb registry is retired and its TLS certificate expired, breaking the release `compliance` job ([failed run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/31710003862/job/94486457829)).
- Authenticate to the DevProd Platforms ECR registry via the shared read-only OIDC role before pulling the SilkBomb image, in both `release.yml` (compliance job) and `generate-augmented-sbom.yml`.
- Mirrors https://github.com/mongodb/atlas-sdk-go/pull/840.
- Repository variables `ECR_REGISTRY`, `ECR_ROLE_ARN` set and `SILKBOMB_IMG` repointed to the digest-pinned ECR image.

## Testing
- `actionlint` on all modified workflows.
- A temporary `silkbomb-ecr-access` job https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/31725936180/job/94534195710