### PR TITLE
chore: Clean up stale pending org users in test org cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build: ## Compile the provider binary
 clean-atlas-org: ## Run a test to clean all projects and pending resources in an Atlas org, supports export DRY_RUN=false (default=true), MONGODB_ATLAS_CLEAN_PROJECT_PREFIXES=prefix1,prefix2
 	@$(eval export MONGODB_ATLAS_CLEAN_ORG?=true)
 	@$(eval export DRY_RUN?=true)
-	go test -count=1 'github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/clean' -timeout 3600s -parallel=250 -run 'TestCleanProjectAndClusters' -v -ldflags="$(LINKER_FLAGS)"
+	go test -count=1 'github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/clean' -timeout 3600s -parallel=250 -run 'TestCleanProjectAndClusters|TestCleanOrgPendingUsers' -v -ldflags="$(LINKER_FLAGS)"
 
 .PHONY: test
 test: ## Run unit tests

--- a/internal/testutil/clean/org_clean.go
+++ b/internal/testutil/clean/org_clean.go
@@ -26,18 +26,12 @@ func SkipUnauthorizedErr(resp *http.Response, err error) error {
 	return err
 }
 
-// PendingOrgUser is a PENDING org membership that RemovePendingOrgUsers considers stale.
 type PendingOrgUser struct {
 	InvitedAt time.Time
 	ID        string
 	Username  string
 }
 
-// ListStalePendingOrgUsers returns PENDING org memberships whose username matches one of the
-// prefixes and whose invitation predates invitedBefore. Acceptance tests that assign a not-yet
-// existing username to a project or team leave the org membership behind on destroy, and those
-// pile up until the org hits MAX_USERS_PER_ORG_EXCEEDED. Both guards matter: the status filter
-// keeps active members out, and the prefix keeps a real person's open invitation out.
 func ListStalePendingOrgUsers(ctx context.Context, client *admin.APIClient, orgID string, prefixes []string, invitedBefore time.Time) ([]PendingOrgUser, error) {
 	users, err := dsschema.AllPages(ctx, func(ctx context.Context, pageNum int) (dsschema.PaginateResponse[admin.OrgUserResponse], *http.Response, error) {
 		return client.MongoDBCloudUsersAPI.ListOrgUsers(ctx, orgID).
@@ -49,31 +43,24 @@ func ListStalePendingOrgUsers(ctx context.Context, client *admin.APIClient, orgI
 	stale := []PendingOrgUser{}
 	for i := range users {
 		user := &users[i]
-		if !hasAnyPrefix(user.Username, prefixes) {
+		if !hasAnyPrefix(user.GetUsername(), prefixes) {
 			continue
 		}
-		// A membership without invitationCreatedAt has no age to judge, treat it as stale.
 		if invitedAt := user.GetInvitationCreatedAt(); !invitedAt.IsZero() && invitedAt.After(invitedBefore) {
 			continue
 		}
-		stale = append(stale, PendingOrgUser{ID: user.GetId(), Username: user.Username, InvitedAt: user.GetInvitationCreatedAt()})
+		stale = append(stale, PendingOrgUser{ID: user.GetId(), Username: user.GetUsername(), InvitedAt: user.GetInvitationCreatedAt()})
 	}
 	return stale, nil
 }
 
-// RemovePendingOrgUsers deletes the stale PENDING org memberships found by ListStalePendingOrgUsers
-// and returns how many were removed.
-func RemovePendingOrgUsers(ctx context.Context, dryRun bool, client *admin.APIClient, orgID string, prefixes []string, invitedBefore time.Time) (int, error) {
-	stale, err := ListStalePendingOrgUsers(ctx, client, orgID, prefixes, invitedBefore)
-	if err != nil {
-		return 0, err
-	}
+func RemovePendingOrgUsers(ctx context.Context, dryRun bool, client *admin.APIClient, orgID string, users []PendingOrgUser) (int, error) {
 	if dryRun {
-		return len(stale), nil
+		return len(users), nil
 	}
 	removed := 0
-	for i := range stale {
-		if _, err := client.MongoDBCloudUsersAPI.RemoveOrgUser(ctx, orgID, stale[i].ID).Execute(); err != nil {
+	for i := range users {
+		if _, err := client.MongoDBCloudUsersAPI.RemoveOrgUser(ctx, orgID, users[i].ID).Execute(); err != nil {
 			return removed, err
 		}
 		removed++

--- a/internal/testutil/clean/org_clean.go
+++ b/internal/testutil/clean/org_clean.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
+	"time"
 
 	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 )
 
@@ -21,6 +24,70 @@ func SkipUnauthorizedErr(resp *http.Response, err error) error {
 		return ErrUnauthorized
 	}
 	return err
+}
+
+// PendingOrgUser is a PENDING org membership that RemovePendingOrgUsers considers stale.
+type PendingOrgUser struct {
+	InvitedAt time.Time
+	ID        string
+	Username  string
+}
+
+// ListStalePendingOrgUsers returns PENDING org memberships whose username matches one of the
+// prefixes and whose invitation predates invitedBefore. Acceptance tests that assign a not-yet
+// existing username to a project or team leave the org membership behind on destroy, and those
+// pile up until the org hits MAX_USERS_PER_ORG_EXCEEDED. Both guards matter: the status filter
+// keeps active members out, and the prefix keeps a real person's open invitation out.
+func ListStalePendingOrgUsers(ctx context.Context, client *admin.APIClient, orgID string, prefixes []string, invitedBefore time.Time) ([]PendingOrgUser, error) {
+	users, err := dsschema.AllPages(ctx, func(ctx context.Context, pageNum int) (dsschema.PaginateResponse[admin.OrgUserResponse], *http.Response, error) {
+		return client.MongoDBCloudUsersAPI.ListOrgUsers(ctx, orgID).
+			OrgMembershipStatus("PENDING").ItemsPerPage(500).PageNum(pageNum).IncludeCount(true).Execute()
+	})
+	if err != nil {
+		return nil, err
+	}
+	stale := []PendingOrgUser{}
+	for i := range users {
+		user := &users[i]
+		if !hasAnyPrefix(user.Username, prefixes) {
+			continue
+		}
+		// A membership without invitationCreatedAt has no age to judge, treat it as stale.
+		if invitedAt := user.GetInvitationCreatedAt(); !invitedAt.IsZero() && invitedAt.After(invitedBefore) {
+			continue
+		}
+		stale = append(stale, PendingOrgUser{ID: user.GetId(), Username: user.Username, InvitedAt: user.GetInvitationCreatedAt()})
+	}
+	return stale, nil
+}
+
+// RemovePendingOrgUsers deletes the stale PENDING org memberships found by ListStalePendingOrgUsers
+// and returns how many were removed.
+func RemovePendingOrgUsers(ctx context.Context, dryRun bool, client *admin.APIClient, orgID string, prefixes []string, invitedBefore time.Time) (int, error) {
+	stale, err := ListStalePendingOrgUsers(ctx, client, orgID, prefixes, invitedBefore)
+	if err != nil {
+		return 0, err
+	}
+	if dryRun {
+		return len(stale), nil
+	}
+	removed := 0
+	for i := range stale {
+		if _, err := client.MongoDBCloudUsersAPI.RemoveOrgUser(ctx, orgID, stale[i].ID).Execute(); err != nil {
+			return removed, err
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+func hasAnyPrefix(name string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // RemoveStreamInstances deletes all stream instances in the project.

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -25,6 +25,9 @@ import (
 const (
 	itemsPerPage                   = 100
 	keepProjectsCreatedWithinHours = 5
+	// Pending org memberships are created by tests still running in the same Test Suite workflow,
+	// give them time to finish before revoking the invitation.
+	keepPendingUsersInvitedWithinHours = 5
 	// Resource cleanup for a project can be slow, especially when there are active clusters, that can take more than 10 minutes to delete
 	// Once 5 minutes are passed, we give up deleting and hope for the project to be deleted within the next run
 	retryInterval = 60 * time.Second
@@ -37,6 +40,11 @@ var (
 		"ct-",  // CFN contract tests
 		"test-acc-tf-p-",
 		"atlas-examples-e2e-", // terraform-mongodbatlas-modules/atlas-examples e2e tests
+	}
+	// pendingUserPrefixes has the username prefixes of the pending org memberships created by tests,
+	// see acc.RandomEmail. Deliberately narrow so a real person's open invitation is never revoked.
+	pendingUserPrefixes = []string{
+		"test-acc-tf-",
 	}
 	// keptPrefixes has the prefix of the projects that we want to delete their resources but keep the projects themselves.
 	// Useful when a feature flag or cloud provider is configured outside of the test
@@ -68,6 +76,35 @@ func TestSingleProjectRemoval(t *testing.T) {
 	if !dryRun {
 		require.NoError(t, deleteProject(t.Context(), client, projectToClean))
 	}
+}
+
+// TestCleanOrgPendingUsers removes PENDING org memberships left behind by cloud user tests, they
+// count towards the org user limit and eventually fail tests with MAX_USERS_PER_ORG_EXCEEDED.
+func TestCleanOrgPendingUsers(t *testing.T) {
+	cleanOrg, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_ORG"))
+	if !cleanOrg {
+		t.Skip("skipping test; set MONGODB_ATLAS_CLEAN_ORG=true to run")
+	}
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	require.NotEmpty(t, orgID, "MONGODB_ATLAS_ORG_ID must be set")
+	client := acc.ConnV2()
+	dryRun, _ := strconv.ParseBool(os.Getenv("DRY_RUN"))
+	invitedBefore := time.Now().Add(-keepPendingUsersInvitedWithinHours * time.Hour)
+	if skipGracePeriod, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_SKIP_GRACE_PERIOD")); skipGracePeriod {
+		invitedBefore = time.Now()
+	}
+	stale, err := clean.ListStalePendingOrgUsers(t.Context(), client, orgID, pendingUserPrefixes, invitedBefore)
+	require.NoError(t, err)
+	userInfos := []string{}
+	for i := range stale {
+		userInfos = append(userInfos, fmt.Sprintf("Pending user invited at %s %s (%s)", stale[i].InvitedAt.Format(time.RFC3339), stale[i].Username, stale[i].ID))
+	}
+	slices.Sort(userInfos)
+	t.Logf("found %d stale pending users invited before %s (DRY_RUN=%t)\n%s",
+		len(stale), invitedBefore.Format(time.RFC3339), dryRun, strings.Join(userInfos, "\n"))
+	removed, err := clean.RemovePendingOrgUsers(t.Context(), dryRun, client, orgID, pendingUserPrefixes, invitedBefore)
+	t.Logf("SUMMARY\npending users removed=%d\nDRY_RUN=%t", removed, dryRun)
+	require.NoError(t, err)
 }
 
 // Using a test to simplify logging and parallelization

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -23,11 +23,8 @@ import (
 )
 
 const (
-	itemsPerPage                   = 100
-	keepProjectsCreatedWithinHours = 5
-	// Pending org memberships are created by tests still running in the same Test Suite workflow,
-	// give them time to finish before revoking the invitation.
-	keepPendingUsersInvitedWithinHours = 5
+	itemsPerPage                    = 100
+	keepResourcesCreatedWithinHours = 5
 	// Resource cleanup for a project can be slow, especially when there are active clusters, that can take more than 10 minutes to delete
 	// Once 5 minutes are passed, we give up deleting and hope for the project to be deleted within the next run
 	retryInterval = 60 * time.Second
@@ -41,8 +38,6 @@ var (
 		"test-acc-tf-p-",
 		"atlas-examples-e2e-", // terraform-mongodbatlas-modules/atlas-examples e2e tests
 	}
-	// pendingUserPrefixes has the username prefixes of the pending org memberships created by tests,
-	// see acc.RandomEmail. Deliberately narrow so a real person's open invitation is never revoked.
 	pendingUserPrefixes = []string{
 		"test-acc-tf-",
 	}
@@ -78,8 +73,6 @@ func TestSingleProjectRemoval(t *testing.T) {
 	}
 }
 
-// TestCleanOrgPendingUsers removes PENDING org memberships left behind by cloud user tests, they
-// count towards the org user limit and eventually fail tests with MAX_USERS_PER_ORG_EXCEEDED.
 func TestCleanOrgPendingUsers(t *testing.T) {
 	cleanOrg, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_ORG"))
 	if !cleanOrg {
@@ -89,7 +82,7 @@ func TestCleanOrgPendingUsers(t *testing.T) {
 	require.NotEmpty(t, orgID, "MONGODB_ATLAS_ORG_ID must be set")
 	client := acc.ConnV2()
 	dryRun, _ := strconv.ParseBool(os.Getenv("DRY_RUN"))
-	invitedBefore := time.Now().Add(-keepPendingUsersInvitedWithinHours * time.Hour)
+	invitedBefore := time.Now().Add(-keepResourcesCreatedWithinHours * time.Hour)
 	if skipGracePeriod, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_SKIP_GRACE_PERIOD")); skipGracePeriod {
 		invitedBefore = time.Now()
 	}
@@ -102,7 +95,7 @@ func TestCleanOrgPendingUsers(t *testing.T) {
 	slices.Sort(userInfos)
 	t.Logf("found %d stale pending users invited before %s (DRY_RUN=%t)\n%s",
 		len(stale), invitedBefore.Format(time.RFC3339), dryRun, strings.Join(userInfos, "\n"))
-	removed, err := clean.RemovePendingOrgUsers(t.Context(), dryRun, client, orgID, pendingUserPrefixes, invitedBefore)
+	removed, err := clean.RemovePendingOrgUsers(t.Context(), dryRun, client, orgID, stale)
 	t.Logf("SUMMARY\npending users removed=%d\nDRY_RUN=%t", removed, dryRun)
 	require.NoError(t, err)
 }
@@ -117,7 +110,7 @@ func TestCleanProjectAndClusters(t *testing.T) {
 	dryRun, _ := strconv.ParseBool(os.Getenv("DRY_RUN"))
 	onlyZeroClusters, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_ONLY_WHEN_NO_CLUSTERS"))
 	skipGracePeriod, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_CLEAN_SKIP_GRACE_PERIOD"))
-	skipProjectsAfter := time.Now().Add(-keepProjectsCreatedWithinHours * time.Hour)
+	skipProjectsAfter := time.Now().Add(-keepResourcesCreatedWithinHours * time.Hour)
 	if skipGracePeriod {
 		skipProjectsAfter = time.Now()
 	}


### PR DESCRIPTION
## Description

Acceptance tests that assign a not-yet-existing username to a project or team (via `acc.RandomEmail`) create a **PENDING** org membership. Project/team destroy removes the assignment but not the org membership, so these pile up until the org hits `MAX_USERS_PER_ORG_EXCEEDED`, which recently failed the `cloud_user` job in the scheduled Test Suite.

This adds `TestCleanOrgPendingUsers` to the `clean-atlas-org` run. It:

- lists org users filtered to `orgMembershipStatus=PENDING`,
- keeps only usernames matching the `test-acc-tf-` prefix (so a real person's open invitation is never revoked),
- skips invitations newer than a 5h grace period (bypassed by `MONGODB_ATLAS_CLEAN_SKIP_GRACE_PERIOD`), so a concurrently-running test's user is left alone,
- honors `DRY_RUN` and logs each candidate plus a summary.

A one-time manual sweep already cleared stale pending users from the cloud-dev CI org.

## Type of change

- [x] Bug fix (test infrastructure)

## Required Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have not added a changelog entry (test-only infrastructure change)