### PR TITLE
fix: Requires replacement of mongodbatlas_stream_connection when networking changes

### DIFF
--- a/.changelog/4659.txt
+++ b/.changelog/4659.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_stream_connection: Require replacement when networking changes
+```

--- a/.changelog/4659.txt
+++ b/.changelog/4659.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_stream_connection: Require replacement when networking changes
+resource/mongodbatlas_stream_connection: Requires replacement of mongodbatlas_stream_connection when networking changes
 ```

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -149,6 +149,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed: true,
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.UseStateForUnknown(),
+					objectplanmodifier.RequiresReplaceIfConfigured(),
 				},
 				Attributes: map[string]schema.Attribute{
 					"access": schema.SingleNestedAttribute{

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -291,6 +291,19 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 						),
 					},
 				},
+				// Confirm the replacement actually has VPC networking.
+				Check: checkKafkaAttributesAcceptance(
+					resourceName,
+					instanceName,
+					"kafka-conn-ssl",
+					"user",
+					"rawpassword",
+					"localhost:9092",
+					"earliest",
+					networkingTypeVPC,
+					true,
+					true,
+				),
 			},
 			{
 				ResourceName:            resourceName,

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -267,7 +267,10 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 		networkPeeringConfig    = configNetworkPeeringAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion)
 	)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck: func() {
+			acc.PreCheckBasic(t)
+			acc.PreCheckPeeringEnvAWS(t)
+		},
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
@@ -279,7 +282,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 				),
 			},
 			{
-				Config: networkPeeringConfig + configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config: networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -272,8 +272,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 				),
 			},
 			{
-				Config:   configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
-				PlanOnly: true,
+				Config: configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(
@@ -381,7 +380,6 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingPublicToVPCRequiresReplace(t
 					kafkaNetworkingVPC,
 					true,
 				),
-				PlanOnly: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -258,6 +258,13 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 	var (
 		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		vpcID                   = os.Getenv("AWS_VPC_ID")
+		vpcCIDRBlock            = os.Getenv("AWS_VPC_CIDR_BLOCK")
+		awsAccountID            = os.Getenv("AWS_ACCOUNT_ID")
+		peerRegion              = os.Getenv("AWS_REGION")
+		containerRegion         = conversion.AWSRegionToMongoDBRegion(peerRegion)
+		providerName            = "AWS"
+		networkPeeringConfig    = configNetworkPeeringAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion)
 	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -272,7 +279,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 				),
 			},
 			{
-				Config: configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config: networkPeeringConfig + configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
@@ -257,13 +258,6 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 	var (
 		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
-		vpcID                   = os.Getenv("AWS_VPC_ID")
-		vpcCIDRBlock            = os.Getenv("AWS_VPC_CIDR_BLOCK")
-		awsAccountID            = os.Getenv("AWS_ACCOUNT_ID")
-		peerRegion              = os.Getenv("AWS_REGION")
-		containerRegion         = conversion.AWSRegionToMongoDBRegion(peerRegion)
-		providerName            = "AWS"
-		networkPeeringConfig    = configNetworkPeeringAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion)
 	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -278,8 +272,16 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 				),
 			},
 			{
-				Config:      networkPeeringConfig + configureKafka("mongodbatlas_network_peering.test.project_id", instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
-				ExpectError: regexp.MustCompile("STREAM_NETWORKING_CANNOT_BE_MODIFIED"),
+				Config:   configureKafka(fmt.Sprintf("%q", projectID), instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				PlanOnly: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							resourceName,
+							plancheck.ResourceActionDestroyBeforeCreate,
+						),
+					},
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -287,6 +289,107 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"authentication.password"},
+			},
+		},
+	})
+}
+
+func TestAccStreamRSStreamConnection_kafkaNetworkingPublicToVPCRequiresReplace(t *testing.T) {
+	var (
+		projectID, instanceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		vpcID                   = os.Getenv("AWS_VPC_ID")
+		vpcCIDRBlock            = os.Getenv("AWS_VPC_CIDR_BLOCK")
+		awsAccountID            = os.Getenv("AWS_ACCOUNT_ID")
+		peerRegion              = os.Getenv("AWS_REGION")
+		containerRegion         = conversion.AWSRegionToMongoDBRegion(peerRegion)
+		providerName            = "AWS"
+		networkPeeringConfig    = configNetworkPeeringAWS(
+			projectID,
+			providerName,
+			vpcID,
+			awsAccountID,
+			vpcCIDRBlock,
+			containerRegion,
+			peerRegion,
+		)
+		connectionName = "kafka-conn-public-to-vpc"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acc.PreCheckBasic(t)
+			acc.PreCheckPeeringEnvAWS(t)
+		},
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				// Create the connection with PUBLIC networking.
+				Config: configureKafka(
+					fmt.Sprintf("%q", projectID),
+					instanceName,
+					connectionName,
+					getKafkaAuthenticationConfig(
+						"PLAIN",
+						"user",
+						"rawpassword",
+						"",
+						"",
+						"",
+						"",
+						"",
+						"",
+					),
+					"localhost:9092",
+					"earliest",
+					kafkaNetworkingPublic,
+					true,
+				),
+				Check: checkKafkaAttributesAcceptance(
+					resourceName,
+					instanceName,
+					connectionName,
+					"user",
+					"rawpassword",
+					"localhost:9092",
+					"earliest",
+					networkingTypePublic,
+					true,
+					true,
+				),
+			},
+			{
+				// Changing networking from PUBLIC to VPC must replace
+				// the stream connection rather than update it in place.
+				Config: networkPeeringConfig + configureKafka(
+					"mongodbatlas_network_peering.test.project_id",
+					instanceName,
+					connectionName,
+					getKafkaAuthenticationConfig(
+						"PLAIN",
+						"user",
+						"rawpassword",
+						"",
+						"",
+						"",
+						"",
+						"",
+						"",
+					),
+					"localhost:9092",
+					"earliest",
+					kafkaNetworkingVPC,
+					true,
+				),
+				PlanOnly: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							resourceName,
+							plancheck.ResourceActionDestroyBeforeCreate,
+						),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Stream connections require replacement when networking changes

https://jira.mongodb.org/browse/CLOUDP-436423

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
