### PR TITLE
fix: Fix integer precision loss in auto-generated resources

### DIFF
--- a/.changelog/4661.txt
+++ b/.changelog/4661.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-provider: Fixes integer precision loss for JSON number values larger than 2^53 in auto-generated resources
-```

--- a/.changelog/4661.txt
+++ b/.changelog/4661.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Fixes integer precision loss for JSON number values larger than 2^53 in auto-generated resources
+```

--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -408,7 +408,7 @@ func refreshFunc(ctx context.Context, wait *WaitReq, client *config.MongoDBClien
 			return nil, "", callResult.Err
 		}
 		var objJSON map[string]any
-		if err := json.Unmarshal(callResult.Body, &objJSON); err != nil {
+		if err := DecodeUseNumber(callResult.Body, &objJSON); err != nil {
 			return nil, "", err
 		}
 		stateValAny, found := objJSON[wait.StateProperty]

--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -408,7 +408,7 @@ func refreshFunc(ctx context.Context, wait *WaitReq, client *config.MongoDBClien
 			return nil, "", callResult.Err
 		}
 		var objJSON map[string]any
-		if err := DecodeUseNumber(callResult.Body, &objJSON); err != nil {
+		if err := Decode(callResult.Body, &objJSON); err != nil {
 			return nil, "", err
 		}
 		stateValAny, found := objJSON[wait.StateProperty]

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -132,7 +132,7 @@ func getModelAttr(val attr.Value, isUpdate bool) (any, error) {
 		return v.ValueFloat64(), nil
 	case jsontypes.Normalized:
 		var valueJSON any
-		if err := DecodeUseNumber([]byte(v.ValueString()), &valueJSON); err != nil {
+		if err := Decode([]byte(v.ValueString()), &valueJSON); err != nil {
 			return nil, fmt.Errorf("marshal failed for JSON custom type: %v", err)
 		}
 		return valueJSON, nil

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -132,7 +132,7 @@ func getModelAttr(val attr.Value, isUpdate bool) (any, error) {
 		return v.ValueFloat64(), nil
 	case jsontypes.Normalized:
 		var valueJSON any
-		if err := json.Unmarshal([]byte(v.ValueString()), &valueJSON); err != nil {
+		if err := DecodeUseNumber([]byte(v.ValueString()), &valueJSON); err != nil {
 			return nil, fmt.Errorf("marshal failed for JSON custom type: %v", err)
 		}
 		return valueJSON, nil

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -848,3 +848,17 @@ func TestMarshalAnonymousNonStruct(t *testing.T) {
 	require.ErrorContains(t, err, "marshal unsupported anonymous field")
 	require.ErrorContains(t, err, "expected struct")
 }
+
+func TestMarshalDynamicJSONLargeInteger(t *testing.T) {
+	// Big integers inside jsontypes.Normalized attributes must be sent to the API unrounded.
+	// assert.JSONEq cannot be used here as it decodes numbers to float64 and would hide precision loss.
+	model := struct {
+		AttrDynamicJSON jsontypes.Normalized `tfsdk:"attr_dynamic_json"`
+	}{
+		AttrDynamicJSON: jsontypes.NewNormalizedValue(`{"bigInt": 9007199254740993, "nested": {"list": [9007199254740993]}}`),
+	}
+	raw, err := autogen.Marshal(&model, false)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"bigInt":9007199254740993`)
+	assert.Contains(t, string(raw), `"list":[9007199254740993]`)
+}

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -1,6 +1,7 @@
 package autogen
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,10 +24,18 @@ func Unmarshal(raw []byte, model any) error {
 		return nil // Some operations return an empty response body, in that case there is no need to update the model.
 	}
 	var objJSON map[string]any
-	if err := json.Unmarshal(raw, &objJSON); err != nil {
+	if err := DecodeUseNumber(raw, &objJSON); err != nil {
 		return err
 	}
 	return unmarshalAttrs(objJSON, model)
+}
+
+// DecodeUseNumber decodes JSON preserving number literals as json.Number instead of
+// float64, preventing silent precision loss for integers larger than 2^53.
+func DecodeUseNumber(raw []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return dec.Decode(v)
 }
 
 func unmarshalAttrs(objJSON map[string]any, model any) error {
@@ -136,6 +145,25 @@ func getTfAttr(value any, valueType attr.Type, oldVal attr.Value, name string, s
 			return types.BoolValue(v), nil
 		}
 		return nil, errUnmarshal(valueType, "Bool", nameErr)
+	case json.Number:
+		switch valueType {
+		case types.Int64Type:
+			if i, err := v.Int64(); err == nil {
+				return types.Int64Value(i), nil
+			}
+			f, err := v.Float64() // tolerate non-integer literals (e.g. 3.0) for Int64 attributes
+			if err != nil {
+				return nil, errUnmarshal(valueType, "Number", nameErr)
+			}
+			return types.Int64Value(int64(f)), nil
+		case types.Float64Type:
+			f, err := v.Float64()
+			if err != nil {
+				return nil, errUnmarshal(valueType, "Number", nameErr)
+			}
+			return types.Float64Value(f), nil
+		}
+		return nil, errUnmarshal(valueType, "Number", nameErr)
 	case float64:
 		switch valueType {
 		case types.Int64Type:

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 
@@ -35,7 +36,14 @@ func Unmarshal(raw []byte, model any) error {
 func DecodeUseNumber(raw []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
-	return dec.Decode(v)
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	// Match json.Unmarshal strictness: reject any data after the first JSON value.
+	if err := dec.Decode(new(any)); err != io.EOF {
+		return fmt.Errorf("unexpected data after JSON value")
+	}
+	return nil
 }
 
 func unmarshalAttrs(objJSON map[string]any, model any) error {

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -25,15 +25,15 @@ func Unmarshal(raw []byte, model any) error {
 		return nil // Some operations return an empty response body, in that case there is no need to update the model.
 	}
 	var objJSON map[string]any
-	if err := DecodeUseNumber(raw, &objJSON); err != nil {
+	if err := Decode(raw, &objJSON); err != nil {
 		return err
 	}
 	return unmarshalAttrs(objJSON, model)
 }
 
-// DecodeUseNumber decodes JSON preserving number literals as json.Number instead of
-// float64, preventing silent precision loss for integers larger than 2^53.
-func DecodeUseNumber(raw []byte, v any) error {
+// Decode decodes JSON like json.Unmarshal but preserves number literals as json.Number
+// instead of float64, preventing silent precision loss for integers larger than 2^53.
+func Decode(raw []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
 	if err := dec.Decode(v); err != nil {
@@ -170,14 +170,6 @@ func getTfAttr(value any, valueType attr.Type, oldVal attr.Value, name string, s
 				return nil, errUnmarshal(valueType, "Number", nameErr)
 			}
 			return types.Float64Value(f), nil
-		}
-		return nil, errUnmarshal(valueType, "Number", nameErr)
-	case float64:
-		switch valueType {
-		case types.Int64Type:
-			return types.Int64Value(int64(v)), nil
-		case types.Float64Type:
-			return types.Float64Value(v), nil
 		}
 		return nil, errUnmarshal(valueType, "Number", nameErr)
 	case map[string]any:

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -1020,3 +1020,25 @@ func TestDecodeUseNumber(t *testing.T) {
 	require.NoError(t, err)
 	assert.InEpsilon(t, 1.5, f, epsilon)
 }
+
+func TestDecodeUseNumberTrailingData(t *testing.T) {
+	testCases := map[string]struct {
+		raw       string
+		expectErr bool
+	}{
+		"concatenated JSON values are rejected": {`{"a": 1} {"b": 2}`, true},
+		"trailing garbage is rejected":          {`{"a": 1} garbage`, true},
+		"trailing whitespace is allowed":        {"{\"a\": 1}\n  ", false},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var obj map[string]any
+			err := autogen.DecodeUseNumber([]byte(tc.raw), &obj)
+			if tc.expectErr {
+				require.ErrorContains(t, err, "unexpected data after JSON value")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -2,6 +2,7 @@ package autogen_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -954,4 +955,68 @@ func TestUnmarshalAnonymousNonStruct(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "unmarshal unsupported anonymous field")
 	assert.ErrorContains(t, err, "expected struct")
+}
+
+func TestUnmarshalLargeIntegers(t *testing.T) {
+	ctx := context.Background()
+
+	type modelst struct {
+		AttrFloat        types.Float64                      `tfsdk:"attr_float"`
+		AttrListInt      customtypes.ListValue[types.Int64] `tfsdk:"attr_list_int"`
+		AttrSetInt       customtypes.SetValue[types.Int64]  `tfsdk:"attr_set_int"`
+		AttrMapInt       customtypes.MapValue[types.Int64]  `tfsdk:"attr_map_int"`
+		AttrDynamicJSON  jsontypes.Normalized               `tfsdk:"attr_dynamic_json"`
+		AttrIntBig       types.Int64                        `tfsdk:"attr_int_big"`
+		AttrIntMax       types.Int64                        `tfsdk:"attr_int_max"`
+		AttrIntWithFloat types.Int64                        `tfsdk:"attr_int_with_float"`
+	}
+
+	var model modelst
+	const jsonResp = `
+		{
+			"attrIntBig": 9007199254740993,
+			"attrIntMax": 9223372036854775807,
+			"attrIntWithFloat": 10.6,
+			"attrFloat": 1.234,
+			"attrDynamicJSON": {"bigInt": 9007199254740993, "nested": {"list": [9007199254740993]}},
+			"attrListInt": [9007199254740993],
+			"attrSetInt": [9007199254740993],
+			"attrMapInt": {"key1": 9007199254740993}
+		}
+	`
+
+	modelExpected := modelst{
+		AttrIntBig:       types.Int64Value(9007199254740993),    // 2^53+1, corrupted to 9007199254740992 if decoded as float64
+		AttrIntMax:       types.Int64Value(9223372036854775807), // math.MaxInt64
+		AttrIntWithFloat: types.Int64Value(10),                  // response floats stored in model ints have their decimals stripped
+		AttrFloat:        types.Float64Value(1.234),
+		AttrDynamicJSON:  jsontypes.NewNormalizedValue(`{"bigInt":9007199254740993,"nested":{"list":[9007199254740993]}}`),
+		AttrListInt: customtypes.NewListValue[types.Int64](ctx, []attr.Value{
+			types.Int64Value(9007199254740993),
+		}),
+		AttrSetInt: customtypes.NewSetValue[types.Int64](ctx, []attr.Value{
+			types.Int64Value(9007199254740993),
+		}),
+		AttrMapInt: customtypes.NewMapValue[types.Int64](ctx, map[string]attr.Value{
+			"key1": types.Int64Value(9007199254740993),
+		}),
+	}
+
+	require.NoError(t, autogen.Unmarshal([]byte(jsonResp), &model))
+	assert.Equal(t, modelExpected, model)
+}
+
+func TestDecodeUseNumber(t *testing.T) {
+	var obj map[string]any
+	require.NoError(t, autogen.DecodeUseNumber([]byte(`{"big": 9007199254740993, "float": 1.5}`), &obj))
+
+	num, ok := obj["big"].(json.Number)
+	require.True(t, ok, "expected json.Number, got %T", obj["big"])
+	i, err := num.Int64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(9007199254740993), i)
+
+	f, err := obj["float"].(json.Number).Float64()
+	require.NoError(t, err)
+	assert.InEpsilon(t, 1.5, f, epsilon)
 }

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -1006,9 +1006,9 @@ func TestUnmarshalLargeIntegers(t *testing.T) {
 	assert.Equal(t, modelExpected, model)
 }
 
-func TestDecodeUseNumber(t *testing.T) {
+func TestDecode(t *testing.T) {
 	var obj map[string]any
-	require.NoError(t, autogen.DecodeUseNumber([]byte(`{"big": 9007199254740993, "float": 1.5}`), &obj))
+	require.NoError(t, autogen.Decode([]byte(`{"big": 9007199254740993, "float": 1.5}`), &obj))
 
 	num, ok := obj["big"].(json.Number)
 	require.True(t, ok, "expected json.Number, got %T", obj["big"])
@@ -1021,7 +1021,7 @@ func TestDecodeUseNumber(t *testing.T) {
 	assert.InEpsilon(t, 1.5, f, epsilon)
 }
 
-func TestDecodeUseNumberTrailingData(t *testing.T) {
+func TestDecodeTrailingData(t *testing.T) {
 	testCases := map[string]struct {
 		raw       string
 		expectErr bool
@@ -1033,7 +1033,7 @@ func TestDecodeUseNumberTrailingData(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var obj map[string]any
-			err := autogen.DecodeUseNumber([]byte(tc.raw), &obj)
+			err := autogen.Decode([]byte(tc.raw), &obj)
 			if tc.expectErr {
 				require.ErrorContains(t, err, "unexpected data after JSON value")
 			} else {

--- a/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/data_source_custom_hooks.go
+++ b/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/data_source_custom_hooks.go
@@ -55,7 +55,7 @@ func (d *ds) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallRe
 	})
 
 	var obj map[string]any
-	if err := json.Unmarshal(result.Body, &obj); err != nil {
+	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 	// Mirror SDKv2 behavior for omitted optional strings in state.
@@ -85,7 +85,7 @@ func (d *pluralDS) PostReadAggregatedListAPICall(req autogen.HandleReadReq, resu
 	}
 
 	var obj map[string]any
-	if err := json.Unmarshal(result.Body, &obj); err != nil {
+	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 

--- a/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/data_source_custom_hooks.go
+++ b/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/data_source_custom_hooks.go
@@ -55,7 +55,7 @@ func (d *ds) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallRe
 	})
 
 	var obj map[string]any
-	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
+	if err := autogen.Decode(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 	// Mirror SDKv2 behavior for omitted optional strings in state.
@@ -85,7 +85,7 @@ func (d *pluralDS) PostReadAggregatedListAPICall(req autogen.HandleReadReq, resu
 	}
 
 	var obj map[string]any
-	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
+	if err := autogen.Decode(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 

--- a/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/resource_custom_hooks.go
+++ b/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/resource_custom_hooks.go
@@ -62,7 +62,7 @@ func stripProviderFromResult(result autogen.APICallResult) autogen.APICallResult
 	}
 
 	var obj map[string]any
-	if err := json.Unmarshal(result.Body, &obj); err != nil {
+	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
 		return result
 	}
 
@@ -145,7 +145,7 @@ func (r *rs) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallRe
 	})
 
 	var obj map[string]any
-	if err := json.Unmarshal(result.Body, &obj); err != nil {
+	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 
@@ -180,7 +180,7 @@ func (r *rs) PreImport(id string) (string, error) {
 
 func prepareBody(bodyReq []byte) ([]byte, bool) {
 	var body map[string]any
-	if err := json.Unmarshal(bodyReq, &body); err != nil {
+	if err := autogen.DecodeUseNumber(bodyReq, &body); err != nil {
 		return bodyReq, false
 	}
 

--- a/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/resource_custom_hooks.go
+++ b/internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive/resource_custom_hooks.go
@@ -62,7 +62,7 @@ func stripProviderFromResult(result autogen.APICallResult) autogen.APICallResult
 	}
 
 	var obj map[string]any
-	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
+	if err := autogen.Decode(result.Body, &obj); err != nil {
 		return result
 	}
 
@@ -145,7 +145,7 @@ func (r *rs) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallRe
 	})
 
 	var obj map[string]any
-	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
+	if err := autogen.Decode(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 
@@ -180,7 +180,7 @@ func (r *rs) PreImport(id string) (string, error) {
 
 func prepareBody(bodyReq []byte) ([]byte, bool) {
 	var body map[string]any
-	if err := autogen.DecodeUseNumber(bodyReq, &body); err != nil {
+	if err := autogen.Decode(bodyReq, &body); err != nil {
 		return bodyReq, false
 	}
 

--- a/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
+++ b/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
@@ -24,7 +24,7 @@ func resourcePostReadAPICall(secretID string, result autogen.APICallResult) auto
 		return result
 	}
 	var responseJSON readAPIResponse
-	if err := json.Unmarshal(result.Body, &responseJSON); err != nil {
+	if err := autogen.DecodeUseNumber(result.Body, &responseJSON); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err}
 	}
 

--- a/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
+++ b/internal/serviceapi/projectserviceaccountsecret/resource_custom_hooks.go
@@ -24,7 +24,7 @@ func resourcePostReadAPICall(secretID string, result autogen.APICallResult) auto
 		return result
 	}
 	var responseJSON readAPIResponse
-	if err := autogen.DecodeUseNumber(result.Body, &responseJSON); err != nil {
+	if err := autogen.Decode(result.Body, &responseJSON); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err}
 	}
 

--- a/internal/serviceapi/serviceaccountsecret/resource_custom_hooks.go
+++ b/internal/serviceapi/serviceaccountsecret/resource_custom_hooks.go
@@ -24,7 +24,7 @@ func resourcePostReadAPICall(secretID string, result autogen.APICallResult) auto
 		return result
 	}
 	var responseJSON readAPIResponse
-	if err := json.Unmarshal(result.Body, &responseJSON); err != nil {
+	if err := autogen.DecodeUseNumber(result.Body, &responseJSON); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err}
 	}
 

--- a/internal/serviceapi/serviceaccountsecret/resource_custom_hooks.go
+++ b/internal/serviceapi/serviceaccountsecret/resource_custom_hooks.go
@@ -24,7 +24,7 @@ func resourcePostReadAPICall(secretID string, result autogen.APICallResult) auto
 		return result
 	}
 	var responseJSON readAPIResponse
-	if err := autogen.DecodeUseNumber(result.Body, &responseJSON); err != nil {
+	if err := autogen.Decode(result.Body, &responseJSON); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err}
 	}
 

--- a/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
+++ b/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
@@ -44,7 +44,7 @@ func (r *rs) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallRe
 	craftedID := fmt.Sprintf("%s-%s-%s", model.WorkspaceName.ValueString(), model.ProjectId.ValueString(), model.ConnectionName.ValueString())
 
 	var obj map[string]any
-	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
+	if err := autogen.Decode(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 

--- a/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
+++ b/internal/serviceapi/streamconnectionapi/resource_custom_hooks.go
@@ -44,7 +44,7 @@ func (r *rs) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallRe
 	craftedID := fmt.Sprintf("%s-%s-%s", model.WorkspaceName.ValueString(), model.ProjectId.ValueString(), model.ConnectionName.ValueString())
 
 	var obj map[string]any
-	if err := json.Unmarshal(result.Body, &obj); err != nil {
+	if err := autogen.DecodeUseNumber(result.Body, &obj); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err, Resp: result.Resp}
 	}
 

--- a/internal/serviceapi/streamconnectionfailover/resource_hooks.go
+++ b/internal/serviceapi/streamconnectionfailover/resource_hooks.go
@@ -44,7 +44,7 @@ func injectConnectionName(callParams config.APICallParams, bodyReq []byte) []byt
 		return bodyReq
 	}
 	var body map[string]any
-	if err := autogen.DecodeUseNumber(bodyReq, &body); err != nil {
+	if err := autogen.Decode(bodyReq, &body); err != nil {
 		return bodyReq
 	}
 	body["name"] = name

--- a/internal/serviceapi/streamconnectionfailover/resource_hooks.go
+++ b/internal/serviceapi/streamconnectionfailover/resource_hooks.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -43,7 +44,7 @@ func injectConnectionName(callParams config.APICallParams, bodyReq []byte) []byt
 		return bodyReq
 	}
 	var body map[string]any
-	if err := json.Unmarshal(bodyReq, &body); err != nil {
+	if err := autogen.DecodeUseNumber(bodyReq, &body); err != nil {
 		return bodyReq
 	}
 	body["name"] = name


### PR DESCRIPTION
## Description

Auto-generated (`serviceapi`) resources bypass the Atlas SDK response decoding (fixed in [atlas-sdk-go#790](https://github.com/mongodb/atlas-sdk-go/pull/790)) and decode raw response bodies themselves with `json.Unmarshal` into `map[string]any`. Go converts untyped JSON numbers to `float64`, so integers larger than 2^53 silently lose precision (e.g. in `jsontypes.Normalized` dynamic payloads like search index definitions), and can be corrupted during read-modify-write flows.

This PR mirrors the SDK fix in the provider's autogen conversion layer:

- Adds `autogen.DecodeUseNumber`, which decodes JSON with `json.Decoder.UseNumber()` so number literals are preserved as `json.Number`.
- Uses it in `autogen.Unmarshal` (response body to Terraform model), with a new `json.Number` case in `getTfAttr` that parses `types.Int64` exactly (`Int64()` with float fallback for non-integer literals, preserving existing truncation behavior) and `types.Float64` via `Float64()`.
- Uses it in `autogen.Marshal` for `jsontypes.Normalized` attributes so big integers in user-provided JSON config reach the API unrounded (`json.Number` re-marshals as the raw literal).
- Uses it in the serviceapi custom hooks and `refreshFunc` that decode bodies into `map[string]any`, mutate, and re-marshal.

No codegen template changes are needed since generated resources only call the shared `autogen` package. The pagination path already uses `json.RawMessage` and is unaffected.

Link to any related issue(s): CLOUDP-406929

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

New unit tests: `TestUnmarshalLargeIntegers`, `TestDecodeUseNumber`, `TestMarshalDynamicJSONLargeInteger` cover round-trip of integers above 2^53 (2^53+1 and `math.MaxInt64`) through Int64 attributes, list/set/map of Int64, and `jsontypes.Normalized` payloads. Note the marshal test deliberately asserts on the raw JSON string since `assert.JSONEq` decodes numbers to `float64` and would hide the precision loss.