### PR TITLE
chore: Delete org SA after checking project SA was destroyed

### DIFF
--- a/internal/service/projectserviceaccountaccesslistentry/resource_test.go
+++ b/internal/service/projectserviceaccountaccesslistentry/resource_test.go
@@ -2,6 +2,7 @@ package projectserviceaccountaccesslistentry_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -233,10 +234,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 }
 
 func checkDestroy(s *terraform.State) error {
-	err := acc.CheckDestroyDeleteProjectSAs(s)
-	if err != nil {
-		return err
-	}
+	var errs []error
 	for name, rs := range s.RootModule().Resources {
 		if !strings.HasPrefix(name, resourceName) {
 			continue
@@ -247,15 +245,20 @@ func checkDestroy(s *terraform.State) error {
 		cidrOrIP := getCidrOrIP(rs)
 
 		if projectID == "" || clientID == "" || cidrOrIP == "" {
-			return fmt.Errorf("checkExists, attributes not found for: %s", resourceName)
+			errs = append(errs, fmt.Errorf("checkExists, attributes not found for: %s", resourceName))
+			break
 		}
 
 		entry, _ := getEntry(projectID, clientID, cidrOrIP)
 		if entry != nil {
-			return fmt.Errorf("access list entry (%s/%s/%s) still exists", projectID, clientID, cidrOrIP)
+			errs = append(errs, fmt.Errorf("access list entry (%s/%s/%s) still exists", projectID, clientID, cidrOrIP))
+			break
 		}
 	}
-	return nil
+	if err := acc.CheckDestroyDeleteProjectSAs(s); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/internal/serviceapi/projectserviceaccount/resource_test.go
+++ b/internal/serviceapi/projectserviceaccount/resource_test.go
@@ -2,6 +2,7 @@ package projectserviceaccount_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -147,10 +148,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 }
 
 func checkDestroy(s *terraform.State) error {
-	err := acc.CheckDestroyDeleteProjectSAs(s)
-	if err != nil {
-		return err
-	}
+	var errs []error
 	for name, rs := range s.RootModule().Resources {
 		if name != resourceName {
 			continue
@@ -158,15 +156,20 @@ func checkDestroy(s *terraform.State) error {
 		projectID := rs.Primary.Attributes["project_id"]
 		clientID := rs.Primary.Attributes["client_id"]
 		if projectID == "" || clientID == "" {
-			return fmt.Errorf("checkDestroy, attributes not found for: %s", resourceName)
+			errs = append(errs, fmt.Errorf("checkDestroy, attributes not found for: %s", resourceName))
+			break
 		}
 
 		_, _, err := acc.ConnV2().ServiceAccountsAPI.GetGroupServiceAccount(context.Background(), projectID, clientID).Execute()
 		if err == nil {
-			return fmt.Errorf("project service account (%s/%s) still exists", projectID, clientID)
+			errs = append(errs, fmt.Errorf("project service account (%s/%s) still exists", projectID, clientID))
+			break
 		}
 	}
-	return nil
+	if err := acc.CheckDestroyDeleteProjectSAs(s); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/internal/serviceapi/projectserviceaccountsecret/resource_test.go
+++ b/internal/serviceapi/projectserviceaccountsecret/resource_test.go
@@ -2,6 +2,7 @@ package projectserviceaccountsecret_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"testing"
@@ -217,10 +218,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 }
 
 func checkDestroy(s *terraform.State) error {
-	err := acc.CheckDestroyDeleteProjectSAs(s)
-	if err != nil {
-		return err
-	}
+	var errs []error
 	for name, rs := range s.RootModule().Resources {
 		if name != resourceName {
 			continue
@@ -229,14 +227,19 @@ func checkDestroy(s *terraform.State) error {
 		projectID := rs.Primary.Attributes["project_id"]
 		clientID := rs.Primary.Attributes["client_id"]
 		if id == "" || projectID == "" || clientID == "" {
-			return fmt.Errorf("checkDestroy, attributes not found for: %s", resourceName)
+			errs = append(errs, fmt.Errorf("checkDestroy, attributes not found for: %s", resourceName))
+			break
 		}
 
 		if exists, _ := secretExists(projectID, clientID, id); exists {
-			return fmt.Errorf("project service account secret (%s/%s/%s) still exists", id, projectID, clientID)
+			errs = append(errs, fmt.Errorf("project service account secret (%s/%s/%s) still exists", id, projectID, clientID))
+			break
 		}
 	}
-	return nil
+	if err := acc.CheckDestroyDeleteProjectSAs(s); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 func secretExists(projectID, clientID, secretID string) (bool, error) {


### PR DESCRIPTION
## Description

We were deleting the org SA before checking that the project SA was destroyed, so checkDestroy would always pass.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
