### PR TITLE
chore: POC for unsetting O+C sizing/autoscaling attrs on advanced_cluster

### DIFF
--- a/internal/common/customplanmodifier/keep_unknown_on_removal.go
+++ b/internal/common/customplanmodifier/keep_unknown_on_removal.go
@@ -1,0 +1,89 @@
+package customplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// POC (unsetting Optional+Computed sizing/autoscaling attributes on advanced_cluster):
+//
+// These attribute plan modifiers make it possible to REMOVE an Optional+Computed attribute from the
+// configuration and have that removal reflected in the plan (and, paired with keepUnknown in the
+// resource-level ModifyPlan and ForceUpdateAttr in the update payload, actually sent to the API as an
+// unset) — instead of the current silent no-op where the prior value is kept.
+//
+// Mechanism: when the attribute is absent from config (ConfigValue is null) but the prior state holds
+// a concrete value, the planned value is forced to unknown ("known after apply"). Keeping the field
+// Optional+Computed (rather than switching to Optional-only) avoids "provider produced inconsistent
+// result after apply", because Computed permits the server-returned value to be accepted into state.
+//
+// IMPORTANT LIMITATION: Terraform cannot distinguish "removed from config" from "never set in config"
+// — both present as a null config value with a populated state. So these modifiers fire on ANY
+// omission, which introduces a perpetual "known after apply" for users who simply leave the attribute
+// unset. This is the fundamental Optional+Computed indistinguishability tradeoff; see the PR description.
+
+const keepUnknownOnRemovalDesc = "POC: forces the planned value to unknown when the attribute is omitted from config but present in state, so the removal is detectable and can be unset via the API."
+
+func KeepUnknownOnRemovalString() planmodifier.String   { return keepUnknownOnRemovalString{} }
+func KeepUnknownOnRemovalBool() planmodifier.Bool       { return keepUnknownOnRemovalBool{} }
+func KeepUnknownOnRemovalInt64() planmodifier.Int64     { return keepUnknownOnRemovalInt64{} }
+func KeepUnknownOnRemovalFloat64() planmodifier.Float64 { return keepUnknownOnRemovalFloat64{} }
+
+type keepUnknownOnRemovalString struct{}
+
+func (m keepUnknownOnRemovalString) Description(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalString) MarkdownDescription(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalString) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// StateValue must be a real, non-empty value; empty string is treated as effectively unset.
+	if req.ConfigValue.IsNull() && IsKnown(req.StateValue) && req.StateValue.ValueString() != "" {
+		resp.PlanValue = types.StringUnknown()
+	}
+}
+
+type keepUnknownOnRemovalBool struct{}
+
+func (m keepUnknownOnRemovalBool) Description(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalBool) MarkdownDescription(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalBool) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	if req.ConfigValue.IsNull() && IsKnown(req.StateValue) {
+		resp.PlanValue = types.BoolUnknown()
+	}
+}
+
+type keepUnknownOnRemovalInt64 struct{}
+
+func (m keepUnknownOnRemovalInt64) Description(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalInt64) MarkdownDescription(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalInt64) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	if req.ConfigValue.IsNull() && IsKnown(req.StateValue) {
+		resp.PlanValue = types.Int64Unknown()
+	}
+}
+
+type keepUnknownOnRemovalFloat64 struct{}
+
+func (m keepUnknownOnRemovalFloat64) Description(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalFloat64) MarkdownDescription(context.Context) string {
+	return keepUnknownOnRemovalDesc
+}
+func (m keepUnknownOnRemovalFloat64) PlanModifyFloat64(_ context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
+	if req.ConfigValue.IsNull() && IsKnown(req.StateValue) {
+		resp.PlanValue = types.Float64Unknown()
+	}
+}

--- a/internal/service/advancedcluster/plan_modifier.go
+++ b/internal/service/advancedcluster/plan_modifier.go
@@ -61,6 +61,7 @@ func handleModifyPlan(ctx context.Context, diags *diag.Diagnostics, state, plan 
 	keepUnknown := []string{"connection_strings", "state_name", "mongo_db_version", "config_server_type"} // Volatile attributes, should not be copied from state
 	keepUnknown = append(keepUnknown, attributeChanges.KeepUnknown(attributeRootChangeMapping)...)
 	keepUnknown = append(keepUnknown, determineKeepUnknownsAutoScaling(ctx, diags, state, plan)...)
+	keepUnknown = append(keepUnknown, determineKeepUnknownsRemoved(ctx, diags, state, plan)...) // POC: keep removed O+C leaves unknown so the unset isn't refilled from state
 	schemafunc.CopyUnknowns(ctx, state, plan, keepUnknown, nil)
 }
 
@@ -173,6 +174,69 @@ func determineKeepUnknownsAutoScaling(ctx context.Context, diags *diag.Diagnosti
 	}
 	// When either compute or disk auto-scaling is enabled, all three fields may be adjusted by Atlas
 	return []string{"instance_size", "disk_size_gb", "disk_iops"}
+}
+
+// determineKeepUnknownsRemoved (POC: unsetting Optional+Computed sizing/autoscaling attributes) returns
+// the tfsdk names of sizing/autoscaling leaves that the attribute plan modifiers forced to unknown
+// because they were removed from config (config null) while state held a value. Adding them to
+// keepUnknown prevents CopyUnknowns from refilling them from state, so the removal survives into the
+// plan (and, together with ForceUpdateAttr in findClusterDiff, is sent to the API as an unset).
+func determineKeepUnknownsRemoved(ctx context.Context, diags *diag.Diagnostics, state, plan *TFModel) []string {
+	found := map[string]bool{}
+	markIfRemoved := func(name string, planVal, stateVal attr.Value) {
+		if planVal.IsUnknown() && isKnown(stateVal) {
+			found[name] = true
+		}
+	}
+	stateRepSpecsTF := TFModelList[TFReplicationSpecsModel](ctx, diags, state.ReplicationSpecs)
+	planRepSpecsTF := TFModelList[TFReplicationSpecsModel](ctx, diags, plan.ReplicationSpecs)
+	if diags.HasError() {
+		return nil
+	}
+	for i := range minLen(planRepSpecsTF, stateRepSpecsTF) {
+		stateRegionConfigsTF := TFModelList[TFRegionConfigsModel](ctx, diags, stateRepSpecsTF[i].RegionConfigs)
+		planRegionConfigsTF := TFModelList[TFRegionConfigsModel](ctx, diags, planRepSpecsTF[i].RegionConfigs)
+		if diags.HasError() {
+			return nil
+		}
+		for j := range minLen(planRegionConfigsTF, stateRegionConfigsTF) {
+			pRC, sRC := planRegionConfigsTF[j], stateRegionConfigsTF[j]
+			for _, pair := range [][2]types.Object{
+				{pRC.ElectableSpecs, sRC.ElectableSpecs},
+				{pRC.AnalyticsSpecs, sRC.AnalyticsSpecs},
+				{pRC.ReadOnlySpecs, sRC.ReadOnlySpecs},
+			} {
+				planSpec := TFModelObject[TFSpecsModel](ctx, pair[0])
+				stateSpec := TFModelObject[TFSpecsModel](ctx, pair[1])
+				if planSpec == nil || stateSpec == nil {
+					continue
+				}
+				markIfRemoved("instance_size", planSpec.InstanceSize, stateSpec.InstanceSize)
+				markIfRemoved("disk_iops", planSpec.DiskIops, stateSpec.DiskIops)
+				markIfRemoved("disk_size_gb", planSpec.DiskSizeGb, stateSpec.DiskSizeGb)
+			}
+			for _, pair := range [][2]types.Object{
+				{pRC.AutoScaling, sRC.AutoScaling},
+				{pRC.AnalyticsAutoScaling, sRC.AnalyticsAutoScaling},
+			} {
+				planAS := TFModelObject[TFAutoScalingModel](ctx, pair[0])
+				stateAS := TFModelObject[TFAutoScalingModel](ctx, pair[1])
+				if planAS == nil || stateAS == nil {
+					continue
+				}
+				markIfRemoved("compute_enabled", planAS.ComputeEnabled, stateAS.ComputeEnabled)
+				markIfRemoved("compute_scale_down_enabled", planAS.ComputeScaleDownEnabled, stateAS.ComputeScaleDownEnabled)
+				markIfRemoved("compute_min_instance_size", planAS.ComputeMinInstanceSize, stateAS.ComputeMinInstanceSize)
+				markIfRemoved("compute_max_instance_size", planAS.ComputeMaxInstanceSize, stateAS.ComputeMaxInstanceSize)
+				markIfRemoved("disk_gb_enabled", planAS.DiskGBEnabled, stateAS.DiskGBEnabled)
+			}
+		}
+	}
+	result := make([]string, 0, len(found))
+	for name := range found {
+		result = append(result, name)
+	}
+	return result
 }
 
 // autoScalingUsed checks if auto-scaling was enabled (state) or will be enabled (plan).

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -41,9 +41,26 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 		autoScalingEnabled = autoScalingKnownValue(true, true, true, "M10", "M30")
 		testCases          = []unit.PlanCheckTest{
 			{
+				// POC (unsetting O+C sizing/autoscaling attrs): previously a Noop. With the
+				// keep-unknown-on-removal plan modifiers, the omitted (computed) disk_iops/disk_size_gb
+				// on the kept electable_specs are forced unknown, so this is now an Update. This is the
+				// concrete cost of the "can't distinguish removed vs never-set" limitation: fields the
+				// user never set in config now show (known after apply) on every plan.
 				ConfigFilename: "main_removed_blocks_from_config_no_plan_changes.tf",
 				Checks: []plancheck.PlanCheck{
-					plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					plancheck.ExpectUnknownValue(resourceName, regionConfig0.AtMapKey("electable_specs").AtMapKey("disk_size_gb")),
+					plancheck.ExpectUnknownValue(resourceName, regionConfig0.AtMapKey("electable_specs").AtMapKey("disk_iops")),
+				},
+			},
+			{
+				// POC: deliberately removing a set autoscaling field (auto_scaling.compute_max_instance_size,
+				// "M30" in state) makes the unset a real, sendable change instead of a silent no-op.
+				ConfigFilename: "main_removed_optional_attrs.tf",
+				Checks: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					plancheck.ExpectUnknownValue(resourceName, regionConfig0.AtMapKey("auto_scaling").AtMapKey("compute_max_instance_size")),
+					plancheck.ExpectUnknownValue(resourceName, regionConfig0.AtMapKey("electable_specs").AtMapKey("disk_size_gb")),
 				},
 			},
 			{

--- a/internal/service/advancedcluster/resource.go
+++ b/internal/service/advancedcluster/resource.go
@@ -530,6 +530,13 @@ func findClusterDiff(ctx context.Context, state, plan *TFModel, diags *diag.Diag
 	patchOptions := update.PatchOptions{
 		IgnoreInStatePrefix: []string{"replicationSpecs"}, // only use config values for replicationSpecs, state values might come from the UseStateForUnknown and shouldn't be used, `id` is added in updateLegacyReplicationSpecs
 	}
+	// POC (unsetting O+C sizing/autoscaling attrs): a bare field removal is not counted as a change by
+	// PatchPayload's hasChanged(), so replicationSpecs would be dropped from the PATCH entirely. When a
+	// removal is detected, force replicationSpecs to be (re)sent; the plan value already omits the removed
+	// field (NilForUnknown), and IgnoreInStatePrefix keeps it from being re-added from state.
+	if len(determineKeepUnknownsRemoved(ctx, diags, state, plan)) > 0 {
+		patchOptions.ForceUpdateAttr = append(patchOptions.ForceUpdateAttr, "replicationSpecs")
+	}
 	patchReq, err := update.PatchPayload(stateReq, planReq, patchOptions)
 	if err != nil {
 		diags.AddError(errorPatchPayload, err.Error())

--- a/internal/service/advancedcluster/schema.go
+++ b/internal/service/advancedcluster/schema.go
@@ -459,28 +459,43 @@ func autoScalingSchema() schema.SingleNestedAttribute {
 		MarkdownDescription: descAutoScaling,
 		Attributes: map[string]schema.Attribute{
 			"compute_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					customplanmodifier.KeepUnknownOnRemovalBool(), // POC: allow unsetting via config removal
+				},
 				MarkdownDescription: descComputeEnabled,
 			},
 			"compute_max_instance_size": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					customplanmodifier.KeepUnknownOnRemovalString(), // POC: allow unsetting via config removal
+				},
 				MarkdownDescription: descComputeMinMaxInstanceSize,
 			},
 			"compute_min_instance_size": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					customplanmodifier.KeepUnknownOnRemovalString(), // POC: allow unsetting via config removal
+				},
 				MarkdownDescription: descComputeMinMaxInstanceSize,
 			},
 			"compute_scale_down_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					customplanmodifier.KeepUnknownOnRemovalBool(), // POC: allow unsetting via config removal
+				},
 				MarkdownDescription: descComputeScaleDownEnabled,
 			},
 			"disk_gb_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					customplanmodifier.KeepUnknownOnRemovalBool(), // POC: allow unsetting via config removal
+				},
 				MarkdownDescription: descDiskGBEnabled,
 			},
 		},
@@ -523,13 +538,19 @@ func specsSchema() schema.SingleNestedAttribute {
 		MarkdownDescription: descSpecs,
 		Attributes: map[string]schema.Attribute{
 			"disk_iops": schema.Int64Attribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					customplanmodifier.KeepUnknownOnRemovalInt64(), // POC: allow unsetting via config removal
+				},
 				MarkdownDescription: descDiskIops,
 			},
 			"disk_size_gb": schema.Float64Attribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Float64{
+					customplanmodifier.KeepUnknownOnRemovalFloat64(), // POC: allow unsetting via config removal
+				},
 				MarkdownDescription: descDiskSizeGb,
 			},
 			"ebs_volume_type": schema.StringAttribute{
@@ -542,6 +563,7 @@ func specsSchema() schema.SingleNestedAttribute {
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					customplanmodifier.InstanceSizeStringAttributePlanModifier(),
+					customplanmodifier.KeepUnknownOnRemovalString(), // POC: allow unsetting via config removal
 				},
 				MarkdownDescription: descInstanceSize,
 			},

--- a/internal/service/advancedcluster/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_optional_attrs.tf
+++ b/internal/service/advancedcluster/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_optional_attrs.tf
@@ -1,0 +1,71 @@
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = "111111111111111111111111"
+  name         = "mocked-cluster"
+  cluster_type = "GEOSHARDED"
+
+
+  replication_specs = [{
+    region_configs = [{
+      analytics_auto_scaling = {
+        compute_enabled            = true
+        compute_max_instance_size  = "M30"
+        compute_min_instance_size  = "M10"
+        compute_scale_down_enabled = true
+        disk_gb_enabled            = true
+      }
+      auto_scaling = {
+        compute_enabled = true
+        # compute_max_instance_size removed from config (was "M30" in state) -> POC: forced unknown
+        compute_min_instance_size  = "M10"
+        compute_scale_down_enabled = true
+        disk_gb_enabled            = true
+      }
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 5
+        # disk_size_gb / disk_iops never set in config (computed) -> POC: also forced unknown
+      }
+      priority      = 7
+      provider_name = "AWS"
+      read_only_specs = {
+        instance_size = "M10"
+        node_count    = 2
+      }
+      region_name = "US_EAST_1"
+    }]
+    zone_name = "Zone 1"
+    }, {
+    region_configs = [{
+      analytics_auto_scaling = {
+        compute_enabled            = true
+        compute_max_instance_size  = "M30"
+        compute_min_instance_size  = "M10"
+        compute_scale_down_enabled = true
+        disk_gb_enabled            = true
+      }
+      analytics_specs = {
+        instance_size = "M10"
+        node_count    = 4
+      }
+      auto_scaling = {
+        compute_enabled            = true
+        compute_max_instance_size  = "M30"
+        compute_min_instance_size  = "M10"
+        compute_scale_down_enabled = true
+        disk_gb_enabled            = true
+      }
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      priority      = 7
+      provider_name = "AWS"
+      read_only_specs = {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      region_name = "US_WEST_2"
+    }]
+    zone_name = "Zone 2"
+  }]
+}


### PR DESCRIPTION
## Description

**POC / draft — not for merge as-is.** Feasibility spike for the design-doc discussion: can existing **Optional+Computed** sizing/autoscaling attributes on `mongodbatlas_advanced_cluster` be made *removable* — unset in config → unset in the API request — via **attribute-level plan modifiers**, keeping the attributes O+C, so we avoid both a breaking change (making them Optional-only, which is the v3.x direction) *and* "no support for unsetting"?

**Answer this POC demonstrates: yes, mechanically feasible — with an important, inherent cost (below).**

Attributes covered (individual-attribute removal; parent block kept):
- spec leaves: `instance_size`, `disk_iops`, `disk_size_gb`
- autoscaling leaves: `compute_enabled`, `compute_scale_down_enabled`, `compute_min_instance_size`, `compute_max_instance_size`, `disk_gb_enabled` (on both `auto_scaling` and `analytics_auto_scaling`)

### Why keep Optional+Computed (not Optional-only)
Atlas always echoes concrete values for these fields and the provider writes them into state. Dropping `Computed` would cause "provider produced inconsistent result after apply" / perpetual plan-to-null drift, and would break the copy-from-state / keep-unknown plan logic that is built on O+C. Keeping `Computed` lets the server value be accepted into state; a small plan-modifier layer turns a removal from a silent no-op into a real, sendable change.

### What this changes
1. **`internal/common/customplanmodifier/keep_unknown_on_removal.go`** (new): typed attribute plan modifiers (String/Bool/Int64/Float64) that force the planned value to *unknown* when the attribute is null in config but present in state. Attached to the 8 leaves in `schema.go` (`specsSchema()` / `autoScalingSchema()`).
2. **`plan_modifier.go`** — `determineKeepUnknownsRemoved` adds those leaves to `keepUnknown` in `handleModifyPlan` so `CopyUnknowns` does not refill them from state.
3. **`resource.go`** — `findClusterDiff` sets `ForceUpdateAttr=["replicationSpecs"]` when a removal is detected, so the PATCH re-emits `replication_specs` with the removed field omitted (`NilForUnknown`/`NilForUnknownOrEmptyString` already omit unknown/empty). No change to the shared `update.PatchPayload` helper; no HTTP interceptor.

### Validation
Mocked plan-check test (`plan_modifier_test.go`, `unit.MockPlanChecksAndRun`; runs in unit CI, no backend/credentials):
- New case `main_removed_optional_attrs.tf`: removing `auto_scaling.compute_max_instance_size` (was `M30` in state) now yields an **Update** with the value `(known after apply)`.
- Previously validated end-to-end for `instance_size` against a dev environment: the PATCH is sent with the field omitted → `400 MISSING_ATTRIBUTE` (backend still requires it), confirming the request carries the unset (where before nothing was sent).

### Caveats / callouts (please read)
- **Fundamental limitation — "removed" vs "never set" are indistinguishable.** Terraform gives the provider no way to tell a *removed* attribute from one that was *never set*: both appear as a null config value over a populated state. So these modifiers fire on **any** omission, forcing `(known after apply)` even for users who simply never set the field. This is the exact "omission is indistinguishable" point from the spike, made concrete.
- **`disk_iops` / `disk_size_gb` are the clearest example:** most users never set them (they are computed). Wiring the modifier there means every plan now shows them as `(known after apply)`. This is visible in the test diff: the previously-Noop case `main_removed_blocks_from_config_no_plan_changes.tf` **flips to Update** purely because those omitted computed fields are now forced unknown. That behavior change is the cost of covering these fields.
- **Perpetual diff:** config-null + a server-populated value re-shows `(known after apply)` on every plan, until the API round-trips intent (AUTO / effective fields). The plan modifier makes unsetting *possible* without a breaking change; the fully drift-free UX is the follow-on API work.
- **Backend dependency + interdependencies** (e.g. `maxInstanceSize` required when compute autoscaling is enabled): some removals will `400` until the backend accepts them; no provider-side interdependency validation is added here.
- **Scope:** individual-attribute removal only (parent block kept). Whole-block `auto_scaling` removal (restored by `adjustRegionConfigsChildren`) and `node_count` are follow-ups; removing spec leaves on `read_only_specs`/`analytics_specs` also interacts with `adjustRegionConfigsChildren` and is not fully covered here.

### Conclusion
The plan-modifier-on-O+C approach **is** feasible. But it can't distinguish removed-from-never-set, so it imposes `(known after apply)` on all omitters of these computed fields — a real UX cost the team should weigh

## Type of change
(POC / experimental)


---

## Testing

### 1. Added unit tests pass (this branch)

```console
$ go test ./internal/service/advancedcluster/ -run 'TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs' -v
=== RUN   TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs
=== RUN   TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_no_plan_changes.tf
=== RUN   TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_optional_attrs.tf
=== RUN   TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs/main_node_count_unknown.tf
=== RUN   TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_and_instance_change.tf
--- PASS: TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs (1.05s)
PASS
ok  	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster	2.798s
```

The new `main_removed_optional_attrs.tf` case removes `auto_scaling.compute_max_instance_size` (which is `"M30"` in state) and asserts the plan is an **Update** with the value `(known after apply)` — a mocked-backend plan check confirming the removal now produces a real diff (no credentials required). It uses `plancheck.ExpectResourceAction(..., ResourceActionUpdate)` + `plancheck.ExpectUnknownValue(..., auto_scaling.compute_max_instance_size)`.

### 2. Real `terraform plan` diff on an existing cluster

The same mechanism was validated end-to-end against a live Atlas cluster. With the plan modifier in place, deleting the field's line from an existing cluster's config produces a genuine diff (previously a silent no-op). 'instance_size' was removed resulting in below plan :

```diff
  # mongodbatlas_advanced_cluster.poc will be updated in-place
  ~ resource "mongodbatlas_advanced_cluster" "poc" {
      ~ replication_specs = [
          ~ {
              ~ region_configs = [
                  ~ {
                      ~ electable_specs = {
                          ~ instance_size = "M10" -> (known after apply)
                            # (3 unchanged attributes hidden)
                        }
                    },
                ]
            },
        ]
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

On apply, the provider then sends a PATCH that omits the field. Against the current backend that returns `400 MISSING_ATTRIBUTE` (the API still requires it) — a separate backend gate, not a provider limitation. This confirms the removal is both **detected in the plan** and **carried into the request**.
