### PR TITLE
test: Adds collection restore job acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -275,6 +275,7 @@ jobs:
       autogen_fast: ${{ steps.filter.outputs.autogen_fast == 'true' || env.mustTrigger == 'true' }}
       autogen_slow: ${{ steps.filter.outputs.autogen_slow == 'true' || env.mustTrigger == 'true' }}
       backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
+      backup_collection_restore: ${{ steps.filter.outputs.backup_collection_restore == 'true' || env.mustTrigger == 'true' }}
       control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
       cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
       cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
@@ -349,6 +350,12 @@ jobs:
             - 'internal/service/cloudbackupsnapshotexportjob/*.go'
             - 'internal/service/cloudbackupsnapshotrestorejob/*.go'  
             - 'internal/service/onlinearchive/*.go'
+          backup_collection_restore:
+            - 'internal/serviceapi/cloudbackupcollectionrestorejob/*.go'
+            - 'internal/serviceapi/cloudbackupcollectionrestorejobcollection/*.go'
+            - 'internal/serviceapi/cloudbackupsnapshotdatabase/*.go'
+            - 'internal/serviceapi/cloudbackupsnapshotdatabasecollection/*.go'
+            - 'internal/testutil/acc/cloud_backup_collection_restore*.go'
           control_plane_ip_addresses:
             - 'internal/service/controlplaneipaddresses/*.go'
           cloud_user:
@@ -799,6 +806,30 @@ jobs:
             ./internal/service/cloudbackupsnapshotexportjob
             ./internal/service/cloudbackupsnapshotrestorejob
             ./internal/service/onlinearchive
+        run: make testacc
+
+  backup_collection_restore:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ needs.change-detection.outputs.backup_collection_restore == 'true' || inputs.test_group == 'backup_collection_restore' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Acceptance Tests
+        env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: |
+            ./internal/serviceapi/cloudbackupcollectionrestorejob
+            ./internal/serviceapi/cloudbackupsnapshotdatabase
         run: make testacc
 
   control_plane_ip_addresses:

--- a/internal/serviceapi/cloudbackupcollectionrestorejob/main_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejob/main_test.go
@@ -1,0 +1,12 @@
+package cloudbackupcollectionrestorejob_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(acc.Run(m))
+}

--- a/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
@@ -45,7 +45,7 @@ func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t 
 		targetClusterName: sourceClusterNameRef,
 		databaseSource:    acc.CollectionRestoreSeedDatabase,
 		databaseTarget:    renamedDB,
-		collectionSource:  acc.CollectionRestoreSeedCollectionNS,
+		collectionSource:  acc.CollectionRestoreSeedRestaurantsNS,
 		withDataSources:   true,
 	}
 
@@ -69,7 +69,7 @@ func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t 
 						"effective_target_namespace": knownvalue.StringExact(renamedDB + "." + acc.CollectionRestoreSeedCollectionName),
 						"state":                      knownvalue.StringExact(stateSuccessful),
 					}),
-					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedCollectionNS), map[string]knownvalue.Check{
+					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedRestaurantsNS), map[string]knownvalue.Check{
 						"effective_target_namespace": knownvalue.StringRegexp(regexp.MustCompile(`^sample_restaurants\.restaurants`)),
 						"state":                      knownvalue.StringExact(stateSuccessful),
 					}),

--- a/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
@@ -17,22 +17,16 @@ import (
 )
 
 const (
-	resourceName            = "mongodbatlas_cloud_backup_collection_restore_job.test"
-	dataSourceName          = "data.mongodbatlas_cloud_backup_collection_restore_job.test"
-	pluralDataSourceName    = "data.mongodbatlas_cloud_backup_collection_restore_jobs.test"
-	collectionsDSName       = "data.mongodbatlas_cloud_backup_collection_restore_job_collections.test"
-	writeStrategyCreate     = "CREATE_NEW"
-	indexStrategyAll        = "ALL"
-	stateSuccessful         = "SUCCESSFUL"
-	stateCanceled           = "CANCELED"
-	createTimeout1m         = "1m"
-	databaseSuffixPIT       = "_pit"
-	collectionSuffixPIT     = "_restored"
-	sourceProjectIDRef      = "data.mongodbatlas_advanced_cluster.source.project_id"
-	sourceClusterNameRef    = "data.mongodbatlas_advanced_cluster.source.name"
-	destProjectIDRef        = "mongodbatlas_project.dest.id"
-	destClusterNameRef      = "mongodbatlas_advanced_cluster.dest.name"
-	destClusterProjectIDRef = "mongodbatlas_advanced_cluster.dest.project_id"
+	resourceName         = "mongodbatlas_cloud_backup_collection_restore_job.test"
+	dataSourceName       = "data.mongodbatlas_cloud_backup_collection_restore_job.test"
+	pluralDataSourceName = "data.mongodbatlas_cloud_backup_collection_restore_jobs.test"
+	collectionsDSName    = "data.mongodbatlas_cloud_backup_collection_restore_job_collections.test"
+	stateSuccessful      = "SUCCESSFUL"
+	stateCanceled        = "CANCELED"
+	sourceProjectIDRef   = "data.mongodbatlas_advanced_cluster.source.project_id"
+	sourceClusterNameRef = "data.mongodbatlas_advanced_cluster.source.name"
+	destProjectIDRef     = "mongodbatlas_project.dest.id"
+	destClusterNameRef   = "mongodbatlas_advanced_cluster.dest.name"
 )
 
 func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t *testing.T) {
@@ -40,16 +34,12 @@ func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t 
 	renamedDB := acc.RandomName()
 	moviesNS := acc.CollectionRestoreSeedDatabase + "." + acc.CollectionRestoreSeedCollectionName
 	restaurantsNS := acc.CollectionRestoreSeedRestaurantsNS
-	cfg := restoreJobConfig{
-		prefixHCL:         sourceClusterHCL(t, fixture),
-		snapshotID:        fixture.SnapshotID,
-		targetProjectID:   sourceProjectIDRef,
-		targetClusterName: sourceClusterNameRef,
-		databaseSource:    acc.CollectionRestoreSeedDatabase,
-		databaseTarget:    renamedDB,
-		collectionSource:  restaurantsNS,
-		withDataSources:   true,
-	}
+	cfg := restoreConfig(t, fixture, nil, "")
+	cfg.snapshotID = fixture.SnapshotID
+	cfg.databaseSource = acc.CollectionRestoreSeedDatabase
+	cfg.databaseTarget = renamedDB
+	cfg.collectionSource = restaurantsNS
+	cfg.withDataSources = true
 	filtered := cfg.withCollectionsFilter(restaurantsNS)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -91,19 +81,19 @@ func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t 
 }
 
 func TestAccCloudBackupCollectionRestoreJob_pitDestClusterSuffixes(t *testing.T) {
+	const (
+		databaseSuffix   = "_pit"
+		collectionSuffix = "_restored"
+	)
 	fixture := acc.CloudBackupCollectionRestoreFixture(t)
 	destProject := destProjectHCL()
 	dest := destClusterInfo(t, destProjectIDRef)
-	cfg := restoreJobConfig{
-		prefixHCL:         sourceAndDestHCL(t, fixture, &dest, destProject),
-		targetProjectID:   destProjectIDRef,
-		targetClusterName: destClusterNameRef,
-		pointInTime:       fixture.AfterSnapshotUTCSeconds,
-		databaseSource:    acc.CollectionRestoreSeedDatabase,
-		databaseSuffix:    databaseSuffixPIT,
-		collectionSuffix:  collectionSuffixPIT,
-		withDataSources:   true,
-	}
+	cfg := restoreConfig(t, fixture, &dest, destProject)
+	cfg.pointInTime = fixture.AfterSnapshotUTCSeconds
+	cfg.databaseSource = acc.CollectionRestoreSeedDatabase
+	cfg.databaseSuffix = databaseSuffix
+	cfg.collectionSuffix = collectionSuffix
+	cfg.withDataSources = true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, &dest, "", ""),
@@ -119,7 +109,7 @@ func TestAccCloudBackupCollectionRestoreJob_pitDestClusterSuffixes(t *testing.T)
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedDatabase+"."+acc.CollectionRestoreSeedCollectionName), map[string]knownvalue.Check{
-						"effective_target_namespace": knownvalue.StringExact(acc.CollectionRestoreSeedDatabase + databaseSuffixPIT + "." + acc.CollectionRestoreSeedCollectionName + collectionSuffixPIT),
+						"effective_target_namespace": knownvalue.StringExact(acc.CollectionRestoreSeedDatabase + databaseSuffix + "." + acc.CollectionRestoreSeedCollectionName + collectionSuffix),
 						"state":                      knownvalue.StringExact(stateSuccessful),
 					}),
 				},
@@ -131,13 +121,9 @@ func TestAccCloudBackupCollectionRestoreJob_pitDestClusterSuffixes(t *testing.T)
 func TestAccCloudBackupCollectionRestoreJob_pitMissingCollection(t *testing.T) {
 	fixture := acc.CloudBackupCollectionRestoreFixture(t)
 	dest := destClusterInfo(t, fixture.ProjectID)
-	cfg := restoreJobConfig{
-		prefixHCL:         sourceAndDestHCL(t, fixture, &dest, ""),
-		targetProjectID:   destClusterProjectIDRef,
-		targetClusterName: destClusterNameRef,
-		pointInTime:       fixture.AfterSnapshotUTCSeconds,
-		collectionSource:  acc.CollectionRestoreMissingCollectionNS,
-	}
+	cfg := restoreConfig(t, fixture, &dest, "")
+	cfg.pointInTime = fixture.AfterSnapshotUTCSeconds
+	cfg.collectionSource = acc.CollectionRestoreMissingCollectionNS
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, &dest, "", ""),
@@ -154,14 +140,10 @@ func TestAccCloudBackupCollectionRestoreJob_pitMissingCollection(t *testing.T) {
 func TestAccCloudBackupCollectionRestoreJob_createTimeoutPlanCreate(t *testing.T) {
 	fixture := acc.CloudBackupCollectionRestoreFixture(t)
 	dest := destClusterInfo(t, fixture.ProjectID)
-	cfg := restoreJobConfig{
-		prefixHCL:         sourceAndDestHCL(t, fixture, &dest, ""),
-		snapshotID:        fixture.SnapshotID,
-		targetProjectID:   destClusterProjectIDRef,
-		targetClusterName: destClusterNameRef,
-		databaseSource:    acc.CollectionRestoreSeedDatabase,
-		createTimeout:     createTimeout1m,
-	}
+	cfg := restoreConfig(t, fixture, &dest, "")
+	cfg.snapshotID = fixture.SnapshotID
+	cfg.databaseSource = acc.CollectionRestoreSeedDatabase
+	cfg.createTimeout = "1m"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, &dest, "", ""),
@@ -274,14 +256,33 @@ func (c *restoreJobConfig) HCL() string {
 		cluster_name        = %[3]s
 		target_project_id   = %[4]s
 		target_cluster_name = %[5]s
-		write_strategy      = %[6]q
-		index_strategy      = %[7]q
+		write_strategy      = "CREATE_NEW"
+		index_strategy      = "ALL"
+		%[6]s
+		%[7]s
 		%[8]s
-		%[9]s
-		%[10]s
 	}
-	%[11]s
-	`, c.prefixHCL, sourceProjectIDRef, sourceClusterNameRef, c.targetProjectID, c.targetClusterName, writeStrategyCreate, indexStrategyAll, optional, databases, collections, ds)
+	%[9]s
+	`, c.prefixHCL, sourceProjectIDRef, sourceClusterNameRef, c.targetProjectID, c.targetClusterName, optional, databases, collections, ds)
+}
+
+func restoreConfig(t *testing.T, fixture *acc.CollectionRestoreFixture, dest *acc.ClusterInfo, destProject string) restoreJobConfig {
+	t.Helper()
+	cfg := restoreJobConfig{
+		prefixHCL: sourceAndDestHCL(t, fixture, dest, destProject),
+	}
+	switch {
+	case dest == nil:
+		cfg.targetProjectID = sourceProjectIDRef
+		cfg.targetClusterName = sourceClusterNameRef
+	case destProject != "":
+		cfg.targetProjectID = destProjectIDRef
+		cfg.targetClusterName = destClusterNameRef
+	default:
+		cfg.targetProjectID = "mongodbatlas_advanced_cluster.dest.project_id"
+		cfg.targetClusterName = destClusterNameRef
+	}
+	return cfg
 }
 
 func sourceClusterHCL(t *testing.T, fixture *acc.CollectionRestoreFixture) string {

--- a/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
@@ -278,6 +278,8 @@ func destClusterInfo(t *testing.T, projectID string) acc.ClusterInfo {
 	return acc.GetClusterInfo(t, &acc.ClusterRequest{
 		ProjectID:      projectID,
 		ResourceSuffix: "dest",
+		// Collection restore POST fails with COLLECTION_RESTORE_INSUFFICIENT_DISK_SPACE on default M10 disk (source cluster might have auto-scaled).
+		DiskSizeGb: 40,
 		ReplicationSpecs: []acc.ReplicationSpecRequest{
 			{Region: acc.NextCollectionRestoreDestRegion()},
 		},

--- a/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
@@ -1,0 +1,334 @@
+package cloudbackupcollectionrestorejob_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+const (
+	resourceName            = "mongodbatlas_cloud_backup_collection_restore_job.test"
+	dataSourceName          = "data.mongodbatlas_cloud_backup_collection_restore_job.test"
+	pluralDataSourceName    = "data.mongodbatlas_cloud_backup_collection_restore_jobs.test"
+	collectionsDSName       = "data.mongodbatlas_cloud_backup_collection_restore_job_collections.test"
+	writeStrategyCreate     = "CREATE_NEW"
+	indexStrategyAll        = "ALL"
+	stateSuccessful         = "SUCCESSFUL"
+	stateCanceled           = "CANCELED"
+	createTimeout1m         = "1m"
+	databaseSuffixPIT       = "_pit"
+	collectionSuffixPIT     = "_restored"
+	sourceProjectIDRef      = "data.mongodbatlas_advanced_cluster.source.project_id"
+	sourceClusterNameRef    = "data.mongodbatlas_advanced_cluster.source.name"
+	destProjectIDRef        = "mongodbatlas_project.dest.id"
+	destClusterNameRef      = "mongodbatlas_advanced_cluster.dest.name"
+	destClusterProjectIDRef = "mongodbatlas_advanced_cluster.dest.project_id"
+)
+
+func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t *testing.T) {
+	fixture := acc.CloudBackupCollectionRestoreFixture(t)
+	renamedDB := acc.RandomName()
+	cfg := restoreJobConfig{
+		prefixHCL:         sourceClusterHCL(t, fixture),
+		snapshotID:        fixture.SnapshotID,
+		targetProjectID:   sourceProjectIDRef,
+		targetClusterName: sourceClusterNameRef,
+		databaseSource:    acc.CollectionRestoreSeedDatabase,
+		databaseTarget:    renamedDB,
+		collectionSource:  acc.CollectionRestoreSeedCollectionNS,
+		withDataSources:   true,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg.HCL(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", stateSuccessful),
+					resource.TestCheckResourceAttr(dataSourceName, "state", stateSuccessful),
+					resource.TestCheckResourceAttrSet(resourceName, "job_id"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					acc.PluralResultCheck(pluralDataSourceName, "target_cluster_name", knownvalue.StringExact(fixture.ClusterName), map[string]knownvalue.Check{
+						"state": knownvalue.StringExact(stateSuccessful),
+					}),
+					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedDatabase+"."+acc.CollectionRestoreSeedCollectionName), map[string]knownvalue.Check{
+						"effective_target_namespace": knownvalue.StringExact(renamedDB + "." + acc.CollectionRestoreSeedCollectionName),
+						"state":                      knownvalue.StringExact(stateSuccessful),
+					}),
+					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedCollectionNS), map[string]knownvalue.Check{
+						"effective_target_namespace": knownvalue.StringRegexp(regexp.MustCompile(`^sample_restaurants\.restaurants`)),
+						"state":                      knownvalue.StringExact(stateSuccessful),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudBackupCollectionRestoreJob_pitDestClusterSuffixes(t *testing.T) {
+	fixture := acc.CloudBackupCollectionRestoreFixture(t)
+	destProject := destProjectHCL()
+	dest := destClusterInfo(t, destProjectIDRef)
+	cfg := restoreJobConfig{
+		prefixHCL:         sourceAndDestHCL(t, fixture, &dest, destProject),
+		targetProjectID:   destProjectIDRef,
+		targetClusterName: destClusterNameRef,
+		pointInTime:       fixture.AfterSnapshotUTCSeconds,
+		databaseSource:    acc.CollectionRestoreSeedDatabase,
+		databaseSuffix:    databaseSuffixPIT,
+		collectionSuffix:  collectionSuffixPIT,
+		withDataSources:   true,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, &dest, "", ""),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyProject,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg.HCL(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", stateSuccessful),
+					resource.TestCheckResourceAttr(dataSourceName, "state", stateSuccessful),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedDatabase+"."+acc.CollectionRestoreSeedCollectionName), map[string]knownvalue.Check{
+						"effective_target_namespace": knownvalue.StringExact(acc.CollectionRestoreSeedDatabase + databaseSuffixPIT + "." + acc.CollectionRestoreSeedCollectionName + collectionSuffixPIT),
+						"state":                      knownvalue.StringExact(stateSuccessful),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudBackupCollectionRestoreJob_pitMissingCollection(t *testing.T) {
+	fixture := acc.CloudBackupCollectionRestoreFixture(t)
+	dest := destClusterInfo(t, fixture.ProjectID)
+	cfg := restoreJobConfig{
+		prefixHCL:         sourceAndDestHCL(t, fixture, &dest, ""),
+		targetProjectID:   destClusterProjectIDRef,
+		targetClusterName: destClusterNameRef,
+		pointInTime:       fixture.AfterSnapshotUTCSeconds,
+		collectionSource:  acc.CollectionRestoreMissingCollectionNS,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, &dest, "", ""),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg.HCL(),
+				ExpectError: regexp.MustCompile(`collection was not found`),
+			},
+		},
+	})
+}
+
+func TestAccCloudBackupCollectionRestoreJob_createTimeoutPlanCreate(t *testing.T) {
+	fixture := acc.CloudBackupCollectionRestoreFixture(t)
+	dest := destClusterInfo(t, fixture.ProjectID)
+	cfg := restoreJobConfig{
+		prefixHCL:         sourceAndDestHCL(t, fixture, &dest, ""),
+		snapshotID:        fixture.SnapshotID,
+		targetProjectID:   destClusterProjectIDRef,
+		targetClusterName: destClusterNameRef,
+		databaseSource:    acc.CollectionRestoreSeedDatabase,
+		createTimeout:     createTimeout1m,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, &dest, "", ""),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyWaitJob(fixture.ProjectID, fixture.ClusterName, dest.Name, stateCanceled),
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg.HCL(),
+				ExpectError: regexp.MustCompile(`timeout while waiting for state to become`),
+			},
+			{
+				Config:             cfg.HCL(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+type restoreJobConfig struct {
+	prefixHCL         string
+	snapshotID        string
+	targetProjectID   string
+	targetClusterName string
+	databaseSource    string
+	databaseTarget    string
+	collectionSource  string
+	databaseSuffix    string
+	collectionSuffix  string
+	createTimeout     string
+	pointInTime       int64
+	withDataSources   bool
+}
+
+func (c *restoreJobConfig) HCL() string {
+	optional := ""
+	if c.snapshotID != "" {
+		optional += fmt.Sprintf("\n\tsnapshot_id = %q", c.snapshotID)
+	}
+	if c.pointInTime != 0 {
+		optional += fmt.Sprintf("\n\tpoint_in_time_utc_seconds = %d", c.pointInTime)
+	}
+	if c.databaseSuffix != "" {
+		optional += fmt.Sprintf("\n\tdatabase_suffix = %q", c.databaseSuffix)
+	}
+	if c.collectionSuffix != "" {
+		optional += fmt.Sprintf("\n\tcollection_suffix = %q", c.collectionSuffix)
+	}
+	if c.createTimeout != "" {
+		optional += fmt.Sprintf("\n\ttimeouts = { create = %q }", c.createTimeout)
+	}
+
+	databases := ""
+	if c.databaseSource != "" {
+		target := ""
+		if c.databaseTarget != "" {
+			target = fmt.Sprintf("\n\t\ttarget_namespace = %q", c.databaseTarget)
+		}
+		databases = fmt.Sprintf(`
+	databases = [{
+		source_namespace = %q%s
+	}]`, c.databaseSource, target)
+	}
+
+	collections := ""
+	if c.collectionSource != "" {
+		collections = fmt.Sprintf(`
+	collections = [{
+		source_namespace = %q
+	}]`, c.collectionSource)
+	}
+
+	ds := ""
+	if c.withDataSources {
+		ds = `
+	data "mongodbatlas_cloud_backup_collection_restore_job" "test" {
+		project_id   = mongodbatlas_cloud_backup_collection_restore_job.test.project_id
+		cluster_name = mongodbatlas_cloud_backup_collection_restore_job.test.cluster_name
+		job_id       = mongodbatlas_cloud_backup_collection_restore_job.test.job_id
+	}
+
+	data "mongodbatlas_cloud_backup_collection_restore_jobs" "test" {
+		project_id   = mongodbatlas_cloud_backup_collection_restore_job.test.project_id
+		cluster_name = mongodbatlas_cloud_backup_collection_restore_job.test.cluster_name
+		depends_on   = [mongodbatlas_cloud_backup_collection_restore_job.test]
+	}
+
+	data "mongodbatlas_cloud_backup_collection_restore_job_collections" "test" {
+		project_id   = mongodbatlas_cloud_backup_collection_restore_job.test.project_id
+		cluster_name = mongodbatlas_cloud_backup_collection_restore_job.test.cluster_name
+		job_id       = mongodbatlas_cloud_backup_collection_restore_job.test.job_id
+	}`
+	}
+
+	return fmt.Sprintf(`
+	%[1]s
+	resource "mongodbatlas_cloud_backup_collection_restore_job" "test" {
+		project_id          = %[2]s
+		cluster_name        = %[3]s
+		target_project_id   = %[4]s
+		target_cluster_name = %[5]s
+		write_strategy      = %[6]q
+		index_strategy      = %[7]q
+		%[8]s
+		%[9]s
+		%[10]s
+	}
+	%[11]s
+	`, c.prefixHCL, sourceProjectIDRef, sourceClusterNameRef, c.targetProjectID, c.targetClusterName, writeStrategyCreate, indexStrategyAll, optional, databases, collections, ds)
+}
+
+func sourceClusterHCL(t *testing.T, fixture *acc.CollectionRestoreFixture) string {
+	t.Helper()
+	hcl, _, _, err := acc.ClusterDatasourceHcl(&acc.ClusterRequest{
+		ProjectID:      fixture.ProjectID,
+		ClusterName:    fixture.ClusterName,
+		ResourceSuffix: "source",
+	})
+	require.NoError(t, err)
+	return hcl
+}
+
+func destClusterInfo(t *testing.T, projectID string) acc.ClusterInfo {
+	t.Helper()
+	return acc.GetClusterInfo(t, &acc.ClusterRequest{
+		ProjectID:      projectID,
+		ResourceSuffix: "dest",
+		ReplicationSpecs: []acc.ReplicationSpecRequest{
+			{Region: acc.NextCollectionRestoreDestRegion()},
+		},
+	})
+}
+
+func destProjectHCL() string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "dest" {
+  org_id = %q
+  name   = %q
+}
+`, os.Getenv("MONGODB_ATLAS_ORG_ID"), acc.RandomProjectName())
+}
+
+func sourceAndDestHCL(t *testing.T, fixture *acc.CollectionRestoreFixture, dest *acc.ClusterInfo, destProject string) string {
+	t.Helper()
+	hcl := sourceClusterHCL(t, fixture)
+	if destProject != "" {
+		hcl += destProject
+	}
+	if dest != nil {
+		hcl += dest.TerraformStr
+	}
+	return hcl
+}
+
+func checkExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+		projectID := rs.Primary.Attributes["project_id"]
+		clusterName := rs.Primary.Attributes["cluster_name"]
+		jobID := rs.Primary.Attributes["job_id"]
+		if projectID == "" || clusterName == "" || jobID == "" {
+			return fmt.Errorf("checkExists, attributes not found for: %s", name)
+		}
+		_, err := acc.GetCollectionRestoreJob(context.Background(), projectID, clusterName, jobID)
+		return err
+	}
+}
+
+func checkDestroyWaitJob(sourceProjectID, sourceClusterName, destClusterName, wantState string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		ctx := context.Background()
+		jobID, err := acc.LatestCollectionRestoreJobID(ctx, sourceProjectID, sourceClusterName, destClusterName)
+		if err != nil {
+			return err
+		}
+		return acc.WaitCollectionRestoreJobState(ctx, sourceProjectID, sourceClusterName, jobID, wantState)
+	}
+}

--- a/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejob/resource_test.go
@@ -38,6 +38,8 @@ const (
 func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t *testing.T) {
 	fixture := acc.CloudBackupCollectionRestoreFixture(t)
 	renamedDB := acc.RandomName()
+	moviesNS := acc.CollectionRestoreSeedDatabase + "." + acc.CollectionRestoreSeedCollectionName
+	restaurantsNS := acc.CollectionRestoreSeedRestaurantsNS
 	cfg := restoreJobConfig{
 		prefixHCL:         sourceClusterHCL(t, fixture),
 		snapshotID:        fixture.SnapshotID,
@@ -45,9 +47,10 @@ func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t 
 		targetClusterName: sourceClusterNameRef,
 		databaseSource:    acc.CollectionRestoreSeedDatabase,
 		databaseTarget:    renamedDB,
-		collectionSource:  acc.CollectionRestoreSeedRestaurantsNS,
+		collectionSource:  restaurantsNS,
 		withDataSources:   true,
 	}
+	filtered := cfg.withCollectionsFilter(restaurantsNS)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -65,15 +68,23 @@ func TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename(t 
 					acc.PluralResultCheck(pluralDataSourceName, "target_cluster_name", knownvalue.StringExact(fixture.ClusterName), map[string]knownvalue.Check{
 						"state": knownvalue.StringExact(stateSuccessful),
 					}),
-					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedDatabase+"."+acc.CollectionRestoreSeedCollectionName), map[string]knownvalue.Check{
+					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(moviesNS), map[string]knownvalue.Check{
 						"effective_target_namespace": knownvalue.StringExact(renamedDB + "." + acc.CollectionRestoreSeedCollectionName),
 						"state":                      knownvalue.StringExact(stateSuccessful),
 					}),
-					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(acc.CollectionRestoreSeedRestaurantsNS), map[string]knownvalue.Check{
+					acc.PluralResultCheck(collectionsDSName, "source_namespace", knownvalue.StringExact(restaurantsNS), map[string]knownvalue.Check{
 						"effective_target_namespace": knownvalue.StringRegexp(regexp.MustCompile(`^sample_restaurants\.restaurants`)),
 						"state":                      knownvalue.StringExact(stateSuccessful),
 					}),
 				},
+			},
+			{
+				Config: filtered.HCL(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(collectionsDSName, "results.#", "1"),
+					resource.TestCheckResourceAttr(collectionsDSName, "source_namespace", restaurantsNS),
+					resource.TestCheckResourceAttr(collectionsDSName, "results.0.source_namespace", restaurantsNS),
+				),
 			},
 		},
 	})
@@ -171,18 +182,25 @@ func TestAccCloudBackupCollectionRestoreJob_createTimeoutPlanCreate(t *testing.T
 }
 
 type restoreJobConfig struct {
-	prefixHCL         string
-	snapshotID        string
-	targetProjectID   string
-	targetClusterName string
-	databaseSource    string
-	databaseTarget    string
-	collectionSource  string
-	databaseSuffix    string
-	collectionSuffix  string
-	createTimeout     string
-	pointInTime       int64
-	withDataSources   bool
+	prefixHCL               string
+	snapshotID              string
+	targetProjectID         string
+	targetClusterName       string
+	databaseSource          string
+	databaseTarget          string
+	collectionSource        string
+	databaseSuffix          string
+	collectionSuffix        string
+	createTimeout           string
+	collectionsSourceFilter string
+	pointInTime             int64
+	withDataSources         bool
+}
+
+func (c *restoreJobConfig) withCollectionsFilter(ns string) restoreJobConfig {
+	out := *c
+	out.collectionsSourceFilter = ns
+	return out
 }
 
 func (c *restoreJobConfig) HCL() string {
@@ -225,7 +243,11 @@ func (c *restoreJobConfig) HCL() string {
 
 	ds := ""
 	if c.withDataSources {
-		ds = `
+		collectionsDSFilter := ""
+		if c.collectionsSourceFilter != "" {
+			collectionsDSFilter = fmt.Sprintf("\n\t\tsource_namespace = %q", c.collectionsSourceFilter)
+		}
+		ds = fmt.Sprintf(`
 	data "mongodbatlas_cloud_backup_collection_restore_job" "test" {
 		project_id   = mongodbatlas_cloud_backup_collection_restore_job.test.project_id
 		cluster_name = mongodbatlas_cloud_backup_collection_restore_job.test.cluster_name
@@ -241,8 +263,8 @@ func (c *restoreJobConfig) HCL() string {
 	data "mongodbatlas_cloud_backup_collection_restore_job_collections" "test" {
 		project_id   = mongodbatlas_cloud_backup_collection_restore_job.test.project_id
 		cluster_name = mongodbatlas_cloud_backup_collection_restore_job.test.cluster_name
-		job_id       = mongodbatlas_cloud_backup_collection_restore_job.test.job_id
-	}`
+		job_id       = mongodbatlas_cloud_backup_collection_restore_job.test.job_id%s
+	}`, collectionsDSFilter)
 	}
 
 	return fmt.Sprintf(`

--- a/internal/serviceapi/cloudbackupcollectionrestorejobcollection/data_source_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejobcollection/data_source_test.go
@@ -1,0 +1,68 @@
+package cloudbackupcollectionrestorejobcollection_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+const collectionsDSName = "data.mongodbatlas_cloud_backup_collection_restore_job_collections.test"
+
+func TestAccCloudBackupCollectionRestoreJobCollections_envRead(t *testing.T) {
+	acc.SkipTestForCI(t) // needs a finished restore job via env vars
+	var (
+		projectID   = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		clusterName = os.Getenv("MONGODB_ATLAS_CLUSTER_NAME")
+		jobID       = os.Getenv("MONGODB_ATLAS_COLLECTION_RESTORE_JOB_ID")
+		sourceNS    = os.Getenv("MONGODB_ATLAS_SOURCE_NAMESPACE")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acc.PreCheckBasic(t)
+			if projectID == "" || clusterName == "" || jobID == "" {
+				t.Fatal("`MONGODB_ATLAS_PROJECT_ID`, `MONGODB_ATLAS_CLUSTER_NAME`, and `MONGODB_ATLAS_COLLECTION_RESTORE_JOB_ID` must be set for acceptance testing")
+			}
+		},
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configCollectionsEnvRead(projectID, clusterName, jobID, sourceNS),
+				Check:  collectionsEnvReadChecks(sourceNS),
+			},
+		},
+	})
+}
+
+func collectionsEnvReadChecks(sourceNS string) resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttrWith(collectionsDSName, "results.#", acc.IntGreatThan(0)),
+		resource.TestCheckResourceAttrSet(collectionsDSName, "results.0.source_namespace"),
+		resource.TestCheckResourceAttrSet(collectionsDSName, "results.0.state"),
+	}
+	if sourceNS != "" {
+		checks = append(checks,
+			resource.TestCheckResourceAttr(collectionsDSName, "source_namespace", sourceNS),
+			resource.TestCheckResourceAttr(collectionsDSName, "results.0.source_namespace", sourceNS),
+		)
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func configCollectionsEnvRead(projectID, clusterName, jobID, sourceNS string) string {
+	filter := ""
+	if sourceNS != "" {
+		filter = fmt.Sprintf("\n  source_namespace = %q", sourceNS)
+	}
+	return fmt.Sprintf(`
+data "mongodbatlas_cloud_backup_collection_restore_job_collections" "test" {
+  project_id   = %q
+  cluster_name = %q
+  job_id       = %q%s
+}
+`, projectID, clusterName, jobID, filter)
+}

--- a/internal/serviceapi/cloudbackupcollectionrestorejobcollection/main_test.go
+++ b/internal/serviceapi/cloudbackupcollectionrestorejobcollection/main_test.go
@@ -1,0 +1,12 @@
+package cloudbackupcollectionrestorejobcollection_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(acc.Run(m))
+}

--- a/internal/serviceapi/cloudbackupsnapshotdatabase/data_source_test.go
+++ b/internal/serviceapi/cloudbackupsnapshotdatabase/data_source_test.go
@@ -1,0 +1,69 @@
+package cloudbackupsnapshotdatabase_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+const (
+	snapshotDatabasesDS  = "data.mongodbatlas_cloud_backup_snapshot_databases.test"
+	snapshotCollections1 = "data.mongodbatlas_cloud_backup_snapshot_database_collections.sample_mflix"
+	snapshotCollections2 = "data.mongodbatlas_cloud_backup_snapshot_database_collections.sample_restaurants"
+	sampleRestaurantsDB  = "sample_restaurants"
+	sampleRestaurantsCol = "restaurants"
+)
+
+func TestAccCloudBackupSnapshotDatabase_collectionsInSnapshot(t *testing.T) {
+	var (
+		fixture = acc.CloudBackupCollectionRestoreFixture(t)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configSnapshotDiscovery(fixture.ProjectID, fixture.ClusterName, fixture.SnapshotID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrWith(snapshotDatabasesDS, "results.#", acc.IntGreatThan(0)),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					acc.PluralResultCheck(snapshotDatabasesDS, "name", knownvalue.StringExact(acc.CollectionRestoreSeedDatabase), map[string]knownvalue.Check{}),
+					acc.PluralResultCheck(snapshotDatabasesDS, "name", knownvalue.StringExact(sampleRestaurantsDB), map[string]knownvalue.Check{}),
+					acc.PluralResultCheck(snapshotCollections1, "name", knownvalue.StringExact(acc.CollectionRestoreSeedCollectionName), map[string]knownvalue.Check{}),
+					acc.PluralResultCheck(snapshotCollections2, "name", knownvalue.StringExact(sampleRestaurantsCol), map[string]knownvalue.Check{}),
+				},
+			},
+		},
+	})
+}
+
+func configSnapshotDiscovery(projectID, clusterName, snapshotID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_cloud_backup_snapshot_databases" "test" {
+			project_id   = %[1]q
+			cluster_name = %[2]q
+			snapshot_id  = %[3]q
+		}
+
+		data "mongodbatlas_cloud_backup_snapshot_database_collections" "sample_mflix" {
+			project_id    = %[1]q
+			cluster_name  = %[2]q
+			snapshot_id   = %[3]q
+			database_name = %[4]q
+		}
+
+		data "mongodbatlas_cloud_backup_snapshot_database_collections" "sample_restaurants" {
+			project_id    = %[1]q
+			cluster_name  = %[2]q
+			snapshot_id   = %[3]q
+			database_name = %[5]q
+		}
+	`, projectID, clusterName, snapshotID, acc.CollectionRestoreSeedDatabase, sampleRestaurantsDB)
+}

--- a/internal/serviceapi/cloudbackupsnapshotdatabase/main_test.go
+++ b/internal/serviceapi/cloudbackupsnapshotdatabase/main_test.go
@@ -1,0 +1,12 @@
+package cloudbackupsnapshotdatabase_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(acc.Run(m))
+}

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -39,9 +39,9 @@ func deleteProject(id string) error {
 	return nil
 }
 
-func createCluster(tb testing.TB, projectID, name string) string {
+func createCluster(tb testing.TB, projectID, name string, backupEnabled, pitEnabled bool) string {
 	tb.Helper()
-	req := clusterReq(name, projectID)
+	req := clusterReq(name, projectID, backupEnabled, pitEnabled)
 	_, _, err := ConnV2().ClustersAPI.CreateCluster(tb.Context(), projectID, &req).Execute()
 	require.NoError(tb, err, "Cluster creation failed: %s, err: %s", name, err)
 	stateConf := cluster.CreateStateChangeConfig(tb.Context(), ConnV2(), projectID, name, 1*time.Hour)
@@ -64,11 +64,13 @@ func deleteCluster(projectID, name string) error {
 	return nil
 }
 
-func clusterReq(name, projectID string) admin.ClusterDescription20240805 {
+func clusterReq(name, projectID string, backupEnabled, pitEnabled bool) admin.ClusterDescription20240805 {
 	return admin.ClusterDescription20240805{
-		Name:        new(name),
-		GroupId:     new(projectID),
-		ClusterType: new("REPLICASET"),
+		Name:          new(name),
+		GroupId:       new(projectID),
+		ClusterType:   new("REPLICASET"),
+		BackupEnabled: new(backupEnabled),
+		PitEnabled:    new(pitEnabled),
 		ReplicationSpecs: &[]admin.ReplicationSpec20240805{
 			{
 				RegionConfigs: &[]admin.CloudRegionConfig20240805{

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
@@ -23,7 +23,7 @@ const (
 	CollectionRestoreAPIVersion          = "application/vnd.atlas.2025-03-12+json"
 	CollectionRestoreSeedDatabase        = "sample_mflix"
 	CollectionRestoreSeedDatabaseRenamed = "sample_mflix_renamed"
-	CollectionRestoreSeedCollectionNS    = "sample_restaurants.restaurants"
+	CollectionRestoreSeedRestaurantsNS   = "sample_restaurants.restaurants"
 	CollectionRestoreSeedCollectionName  = "movies"
 	CollectionRestoreMissingCollectionNS = "sample_mflix.never_there"
 	collectionRestoreSnapshotRetention   = 1

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
@@ -95,11 +95,11 @@ func initCollectionRestoreFixture(tb testing.TB) (*CollectionRestoreFixture, err
 	tb.Helper()
 	ctx := tb.Context()
 	if env, ok := collectionRestoreEnvFromOS(); ok {
-		snapshot, _, err := ConnV2().CloudBackupsAPI.GetClusterBackupSnapshot(ctx, env.ProjectID, env.ClusterName, env.SnapshotID).Execute()
-		if err != nil {
-			return nil, fmt.Errorf("get snapshot %s: %w", env.SnapshotID, err)
-		}
 		if err := requireCloudBackupAndPIT(ctx, env.ProjectID, env.ClusterName); err != nil {
+			return nil, err
+		}
+		snapshot, err := waitForCompletedSnapshot(ctx, env.ProjectID, env.ClusterName, env.SnapshotID)
+		if err != nil {
 			return nil, err
 		}
 		return &CollectionRestoreFixture{
@@ -167,6 +167,13 @@ func takeCompletedOnDemandSnapshot(ctx context.Context, projectID, clusterName s
 		return "", 0, fmt.Errorf("take snapshot: %w", err)
 	}
 	snapshotID = snapshot.GetId()
+	if _, err := waitForCompletedSnapshot(ctx, projectID, clusterName, snapshotID); err != nil {
+		return "", 0, err
+	}
+	return snapshotID, time.Now().UTC().Unix(), nil
+}
+
+func waitForCompletedSnapshot(ctx context.Context, projectID, clusterName, snapshotID string) (*admin.DiskBackupReplicaSet, error) {
 	requestParams := &admin.GetClusterBackupSnapshotApiParams{
 		GroupId:     projectID,
 		ClusterName: clusterName,
@@ -190,10 +197,14 @@ func takeCompletedOnDemandSnapshot(ctx context.Context, projectID, clusterName s
 			return cur, status, nil
 		},
 	}
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return "", 0, fmt.Errorf("wait snapshot %s: %w", snapshotID, err)
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return nil, fmt.Errorf("wait snapshot %s: %w", snapshotID, err)
 	}
-	return snapshotID, time.Now().UTC().Unix(), nil
+	snapshot, _, err := ConnV2().CloudBackupsAPI.GetClusterBackupSnapshot(ctx, projectID, clusterName, snapshotID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("get snapshot %s: %w", snapshotID, err)
+	}
+	return snapshot, nil
 }
 
 type collectionRestoreJobView struct {
@@ -224,6 +235,13 @@ func collectionRestoreJobCall(projectID, clusterName, jobID string) config.APICa
 	}
 }
 
+func closeOnAPIErr(resp *http.Response, err error) error {
+	if err != nil && resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
 func readJSONBody(resp *http.Response, dest any) error {
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
@@ -236,7 +254,7 @@ func readJSONBody(resp *http.Response, dest any) error {
 // GetCollectionRestoreJob GETs one job via the untyped client and the resource version header.
 func GetCollectionRestoreJob(ctx context.Context, projectID, clusterName, jobID string) (map[string]any, error) {
 	resp, err := MongoDBClient.UntypedAPICall(ctx, collectionRestoreJobCall(projectID, clusterName, jobID), nil)
-	if err != nil {
+	if err := closeOnAPIErr(resp, err); err != nil {
 		return nil, err
 	}
 	var body map[string]any
@@ -249,7 +267,7 @@ func GetCollectionRestoreJob(ctx context.Context, projectID, clusterName, jobID 
 // LatestCollectionRestoreJobID returns the newest job on the source cluster whose target matches destClusterName.
 func LatestCollectionRestoreJobID(ctx context.Context, projectID, clusterName, destClusterName string) (string, error) {
 	resp, err := MongoDBClient.UntypedAPICall(ctx, collectionRestoreJobCall(projectID, clusterName, ""), nil)
-	if err != nil {
+	if err := closeOnAPIErr(resp, err); err != nil {
 		return "", err
 	}
 	var list collectionRestoreJobList

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 const (

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
@@ -1,0 +1,299 @@
+package acc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+)
+
+const (
+	CollectionRestoreAPIVersion          = "application/vnd.atlas.2025-03-12+json"
+	CollectionRestoreSeedDatabase        = "sample_mflix"
+	CollectionRestoreSeedDatabaseRenamed = "sample_mflix_renamed"
+	CollectionRestoreSeedCollectionNS    = "sample_restaurants.restaurants"
+	CollectionRestoreSeedCollectionName  = "movies"
+	CollectionRestoreMissingCollectionNS = "sample_mflix.never_there"
+	collectionRestoreSnapshotRetention   = 1
+)
+
+var collectionRestoreDestRegions = []string{"US_EAST_1", "US_EAST_2", "EU_WEST_1"}
+
+var (
+	collectionRestoreFixtureOnce sync.Once
+	collectionRestoreFixture     *CollectionRestoreFixture
+	collectionRestoreFixtureErr  error
+	collectionRestoreDestIdx     atomic.Uint32
+)
+
+// CollectionRestoreFixture is the shared source cluster and snapshot for collection-restore acceptance tests.
+type CollectionRestoreFixture struct {
+	ProjectID               string
+	ClusterName             string
+	SnapshotID              string
+	AfterSnapshotUTCSeconds int64
+	External                bool
+}
+
+type collectionRestoreEnv struct {
+	ProjectID   string
+	ClusterName string
+	SnapshotID  string
+}
+
+func collectionRestoreEnvFromOS() (collectionRestoreEnv, bool) {
+	env := collectionRestoreEnv{
+		ProjectID:   os.Getenv("MONGODB_ATLAS_PROJECT_ID"),
+		ClusterName: os.Getenv("MONGODB_ATLAS_CLUSTER_NAME"),
+		SnapshotID:  os.Getenv("MONGODB_ATLAS_SNAPSHOT_ID"),
+	}
+	ok := env.ProjectID != "" && env.ClusterName != "" && env.SnapshotID != ""
+	return env, ok
+}
+
+func afterSnapshotUTCSeconds(created time.Time) int64 {
+	return created.UTC().Unix()
+}
+
+// CollectionRestoreEnvFromOSForTest exposes env-var parsing for unit tests.
+func CollectionRestoreEnvFromOSForTest() (projectID, clusterName, snapshotID string, ok bool) {
+	env, ok := collectionRestoreEnvFromOS()
+	return env.ProjectID, env.ClusterName, env.SnapshotID, ok
+}
+
+// AfterSnapshotUTCSecondsForTest exposes snapshot timestamp conversion for unit tests.
+func AfterSnapshotUTCSecondsForTest(created time.Time) int64 {
+	return afterSnapshotUTCSeconds(created)
+}
+
+// CloudBackupCollectionRestoreFixture returns the process-wide source cluster and snapshot.
+// When MONGODB_ATLAS_PROJECT_ID, MONGODB_ATLAS_CLUSTER_NAME, and MONGODB_ATLAS_SNAPSHOT_ID are set, those values are reused.
+func CloudBackupCollectionRestoreFixture(tb testing.TB) *CollectionRestoreFixture {
+	tb.Helper()
+	SkipInUnitTest(tb)
+	require.True(tb, sharedInfo.init, "sharedInfo not initialized, use acc.Run() to run tests that require shared resources")
+	collectionRestoreFixtureOnce.Do(func() {
+		collectionRestoreFixture, collectionRestoreFixtureErr = initCollectionRestoreFixture(tb)
+	})
+	require.NoError(tb, collectionRestoreFixtureErr)
+	return collectionRestoreFixture
+}
+
+func initCollectionRestoreFixture(tb testing.TB) (*CollectionRestoreFixture, error) {
+	tb.Helper()
+	ctx := tb.Context()
+	if env, ok := collectionRestoreEnvFromOS(); ok {
+		snapshot, _, err := ConnV2().CloudBackupsAPI.GetClusterBackupSnapshot(ctx, env.ProjectID, env.ClusterName, env.SnapshotID).Execute()
+		if err != nil {
+			return nil, fmt.Errorf("get snapshot %s: %w", env.SnapshotID, err)
+		}
+		if err := requireCloudBackupAndPIT(ctx, env.ProjectID, env.ClusterName); err != nil {
+			return nil, err
+		}
+		return &CollectionRestoreFixture{
+			ProjectID:               env.ProjectID,
+			ClusterName:             env.ClusterName,
+			SnapshotID:              env.SnapshotID,
+			AfterSnapshotUTCSeconds: afterSnapshotUTCSeconds(snapshot.GetCreatedAt()),
+			External:                true,
+		}, nil
+	}
+
+	projectID, clusterName := clusterNameExecution(tb, true, true, true)
+	if err := requireCloudBackupAndPIT(ctx, projectID, clusterName); err != nil {
+		return nil, err
+	}
+	snapshotID, afterSeconds, err := takeCompletedOnDemandSnapshot(ctx, projectID, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	return &CollectionRestoreFixture{
+		ProjectID:               projectID,
+		ClusterName:             clusterName,
+		SnapshotID:              snapshotID,
+		AfterSnapshotUTCSeconds: afterSeconds,
+	}, nil
+}
+
+func requireCloudBackupAndPIT(ctx context.Context, projectID, clusterName string) error {
+	src, _, err := ConnV2().ClustersAPI.GetCluster(ctx, projectID, clusterName).Execute()
+	if err != nil {
+		return fmt.Errorf("get cluster %s: %w", clusterName, err)
+	}
+	return errIfCloudBackupOrPITDisabled(clusterName, src.GetBackupEnabled(), src.GetPitEnabled())
+}
+
+func errIfCloudBackupOrPITDisabled(clusterName string, backupEnabled, pitEnabled bool) error {
+	if !backupEnabled {
+		return fmt.Errorf("cluster %s does not have cloud backup enabled", clusterName)
+	}
+	if !pitEnabled {
+		return fmt.Errorf("cluster %s does not have point-in-time restore enabled", clusterName)
+	}
+	return nil
+}
+
+// ErrIfCloudBackupOrPITDisabledForTest exposes backup/PIT flag checking for unit tests.
+func ErrIfCloudBackupOrPITDisabledForTest(clusterName string, backupEnabled, pitEnabled bool) error {
+	return errIfCloudBackupOrPITDisabled(clusterName, backupEnabled, pitEnabled)
+}
+
+// NextCollectionRestoreDestRegion returns a distinct AWS region for each dest cluster in this process.
+func NextCollectionRestoreDestRegion() string {
+	i := collectionRestoreDestIdx.Add(1) - 1
+	return collectionRestoreDestRegions[int(i)%len(collectionRestoreDestRegions)]
+}
+
+func takeCompletedOnDemandSnapshot(ctx context.Context, projectID, clusterName string) (snapshotID string, afterSeconds int64, err error) {
+	retention := collectionRestoreSnapshotRetention
+	params := &admin.DiskBackupOnDemandSnapshotRequest{
+		Description:     admin.PtrString("tf acc collection restore fixture"),
+		RetentionInDays: &retention,
+	}
+	snapshot, _, err := ConnV2().CloudBackupsAPI.TakeSnapshots(ctx, projectID, clusterName, params).Execute()
+	if err != nil {
+		return "", 0, fmt.Errorf("take snapshot: %w", err)
+	}
+	snapshotID = snapshot.GetId()
+	requestParams := &admin.GetClusterBackupSnapshotApiParams{
+		GroupId:     projectID,
+		ClusterName: clusterName,
+		SnapshotId:  snapshotID,
+	}
+	stateConf := retry.StateChangeConf{
+		Pending:    []string{"queued", "inProgress"},
+		Target:     []string{"completed"},
+		Timeout:    2 * time.Hour,
+		MinTimeout: 1 * time.Minute,
+		Delay:      1 * time.Minute,
+		Refresh: func() (any, string, error) {
+			cur, _, getErr := ConnV2().CloudBackupsAPI.GetClusterBackupSnapshotWithParams(ctx, requestParams).Execute()
+			if getErr != nil {
+				return nil, "", getErr
+			}
+			status := cur.GetStatus()
+			if status == "failed" {
+				return nil, status, fmt.Errorf("snapshot %s failed", snapshotID)
+			}
+			return cur, status, nil
+		},
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return "", 0, fmt.Errorf("wait snapshot %s: %w", snapshotID, err)
+	}
+	return snapshotID, time.Now().UTC().Unix(), nil
+}
+
+type collectionRestoreJobView struct {
+	ID                string `json:"id"`
+	State             string `json:"state"`
+	TargetClusterName string `json:"targetClusterName"`
+}
+
+type collectionRestoreJobList struct {
+	Results []collectionRestoreJobView `json:"results"`
+}
+
+func collectionRestoreJobCall(projectID, clusterName, jobID string) config.APICallParams {
+	pathParams := map[string]string{
+		"projectId":   projectID,
+		"clusterName": clusterName,
+	}
+	relativePath := "/api/atlas/v2/groups/{projectId}/clusters/{clusterName}/collectionRestoreJobs"
+	if jobID != "" {
+		pathParams["jobId"] = jobID
+		relativePath += "/{jobId}"
+	}
+	return config.APICallParams{
+		VersionHeader: CollectionRestoreAPIVersion,
+		RelativePath:  relativePath,
+		PathParams:    pathParams,
+		Method:        http.MethodGet,
+	}
+}
+
+func readJSONBody(resp *http.Response, dest any) error {
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, dest)
+}
+
+// GetCollectionRestoreJob GETs one job via the untyped client and the resource version header.
+func GetCollectionRestoreJob(ctx context.Context, projectID, clusterName, jobID string) (map[string]any, error) {
+	resp, err := MongoDBClient.UntypedAPICall(ctx, collectionRestoreJobCall(projectID, clusterName, jobID), nil)
+	if err != nil {
+		return nil, err
+	}
+	var body map[string]any
+	if err := readJSONBody(resp, &body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// LatestCollectionRestoreJobID returns the newest job on the source cluster whose target matches destClusterName.
+func LatestCollectionRestoreJobID(ctx context.Context, projectID, clusterName, destClusterName string) (string, error) {
+	resp, err := MongoDBClient.UntypedAPICall(ctx, collectionRestoreJobCall(projectID, clusterName, ""), nil)
+	if err != nil {
+		return "", err
+	}
+	var list collectionRestoreJobList
+	if err := readJSONBody(resp, &list); err != nil {
+		return "", err
+	}
+	fallback := ""
+	for _, job := range list.Results {
+		if job.TargetClusterName != destClusterName || job.ID == "" {
+			continue
+		}
+		switch job.State {
+		case "INITIALIZING", "IN_PROGRESS", "FINALIZING":
+			return job.ID, nil
+		default:
+			fallback = job.ID
+		}
+	}
+	if fallback != "" {
+		return fallback, nil
+	}
+	return "", fmt.Errorf("no collection restore job targeting %s", destClusterName)
+}
+
+// WaitCollectionRestoreJobState polls until job state matches wantState.
+func WaitCollectionRestoreJobState(ctx context.Context, projectID, clusterName, jobID, wantState string) error {
+	stateConf := retry.StateChangeConf{
+		Pending:    []string{"INITIALIZING", "IN_PROGRESS", "FINALIZING"},
+		Target:     []string{wantState},
+		Timeout:    constant.DefaultTimeout,
+		MinTimeout: 1 * time.Minute,
+		Delay:      30 * time.Second,
+		Refresh: func() (any, string, error) {
+			body, err := GetCollectionRestoreJob(ctx, projectID, clusterName, jobID)
+			if err != nil {
+				return nil, "", err
+			}
+			state, _ := body["state"].(string)
+			if (state == "FAILED" || state == "CANCELED") && state != wantState {
+				return body, state, fmt.Errorf("collection restore job %s ended with state %s", jobID, state)
+			}
+			return body, state, nil
+		},
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
@@ -67,12 +67,6 @@ func afterSnapshotUTCSeconds(created time.Time) int64 {
 	return created.UTC().Unix()
 }
 
-// CollectionRestoreEnvFromOSForTest exposes env-var parsing for unit tests.
-func CollectionRestoreEnvFromOSForTest() (projectID, clusterName, snapshotID string, ok bool) {
-	env, ok := collectionRestoreEnvFromOS()
-	return env.ProjectID, env.ClusterName, env.SnapshotID, ok
-}
-
 // AfterSnapshotUTCSecondsForTest exposes snapshot timestamp conversion for unit tests.
 func AfterSnapshotUTCSecondsForTest(created time.Time) int64 {
 	return afterSnapshotUTCSeconds(created)

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
@@ -159,7 +159,7 @@ func NextCollectionRestoreDestRegion() string {
 func takeCompletedOnDemandSnapshot(ctx context.Context, projectID, clusterName string) (snapshotID string, afterSeconds int64, err error) {
 	retention := collectionRestoreSnapshotRetention
 	params := &admin.DiskBackupOnDemandSnapshotRequest{
-		Description:     admin.PtrString("tf acc collection restore fixture"),
+		Description:     new("tf acc collection restore fixture"),
 		RetentionInDays: &retention,
 	}
 	snapshot, _, err := ConnV2().CloudBackupsAPI.TakeSnapshots(ctx, projectID, clusterName, params).Execute()

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture_test.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture_test.go
@@ -9,32 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCollectionRestoreEnvFromOS_requiresAllThree(t *testing.T) {
-	t.Setenv("MONGODB_ATLAS_PROJECT_ID", "")
-	t.Setenv("MONGODB_ATLAS_CLUSTER_NAME", "")
-	t.Setenv("MONGODB_ATLAS_SNAPSHOT_ID", "")
-	projectID, clusterName, snapshotID, ok := acc.CollectionRestoreEnvFromOSForTest()
-	assert.False(t, ok)
-	assert.Empty(t, projectID)
-	assert.Empty(t, clusterName)
-	assert.Empty(t, snapshotID)
-
-	t.Setenv("MONGODB_ATLAS_PROJECT_ID", "p")
-	t.Setenv("MONGODB_ATLAS_CLUSTER_NAME", "c")
-	projectID, clusterName, snapshotID, ok = acc.CollectionRestoreEnvFromOSForTest()
-	assert.False(t, ok)
-	assert.Equal(t, "p", projectID)
-	assert.Equal(t, "c", clusterName)
-	assert.Empty(t, snapshotID)
-
-	t.Setenv("MONGODB_ATLAS_SNAPSHOT_ID", "s")
-	projectID, clusterName, snapshotID, ok = acc.CollectionRestoreEnvFromOSForTest()
-	require.True(t, ok)
-	assert.Equal(t, "p", projectID)
-	assert.Equal(t, "c", clusterName)
-	assert.Equal(t, "s", snapshotID)
-}
-
 func TestAfterSnapshotUTCSeconds_convertsToUnixUTC(t *testing.T) {
 	created := time.Date(2026, 8, 20, 15, 4, 5, 0, time.FixedZone("CEST", 2*60*60))
 	want := time.Date(2026, 8, 20, 13, 4, 5, 0, time.UTC).Unix()

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture_test.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture_test.go
@@ -1,0 +1,60 @@
+package acc_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionRestoreEnvFromOS_requiresAllThree(t *testing.T) {
+	t.Setenv("MONGODB_ATLAS_PROJECT_ID", "")
+	t.Setenv("MONGODB_ATLAS_CLUSTER_NAME", "")
+	t.Setenv("MONGODB_ATLAS_SNAPSHOT_ID", "")
+	projectID, clusterName, snapshotID, ok := acc.CollectionRestoreEnvFromOSForTest()
+	assert.False(t, ok)
+	assert.Empty(t, projectID)
+	assert.Empty(t, clusterName)
+	assert.Empty(t, snapshotID)
+
+	t.Setenv("MONGODB_ATLAS_PROJECT_ID", "p")
+	t.Setenv("MONGODB_ATLAS_CLUSTER_NAME", "c")
+	projectID, clusterName, snapshotID, ok = acc.CollectionRestoreEnvFromOSForTest()
+	assert.False(t, ok)
+	assert.Equal(t, "p", projectID)
+	assert.Equal(t, "c", clusterName)
+	assert.Empty(t, snapshotID)
+
+	t.Setenv("MONGODB_ATLAS_SNAPSHOT_ID", "s")
+	projectID, clusterName, snapshotID, ok = acc.CollectionRestoreEnvFromOSForTest()
+	require.True(t, ok)
+	assert.Equal(t, "p", projectID)
+	assert.Equal(t, "c", clusterName)
+	assert.Equal(t, "s", snapshotID)
+}
+
+func TestAfterSnapshotUTCSeconds_convertsToUnixUTC(t *testing.T) {
+	created := time.Date(2026, 8, 20, 15, 4, 5, 0, time.FixedZone("CEST", 2*60*60))
+	want := time.Date(2026, 8, 20, 13, 4, 5, 0, time.UTC).Unix()
+	assert.Equal(t, want, acc.AfterSnapshotUTCSecondsForTest(created))
+}
+
+func TestErrIfCloudBackupOrPITDisabled_failsWhenBackupOff(t *testing.T) {
+	err := acc.ErrIfCloudBackupOrPITDisabledForTest("c1", false, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "c1")
+	assert.Contains(t, err.Error(), "cloud backup")
+}
+
+func TestErrIfCloudBackupOrPITDisabled_failsWhenPITOff(t *testing.T) {
+	err := acc.ErrIfCloudBackupOrPITDisabledForTest("c1", true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "c1")
+	assert.Contains(t, err.Error(), "point-in-time")
+}
+
+func TestErrIfCloudBackupOrPITDisabled_okWhenBothOn(t *testing.T) {
+	require.NoError(t, acc.ErrIfCloudBackupOrPITDisabledForTest("c1", true, true))
+}

--- a/internal/testutil/acc/config_cluster.go
+++ b/internal/testutil/acc/config_cluster.go
@@ -55,6 +55,7 @@ func ClusterResourceHcl(req *ClusterRequest) (configStr, clusterName, resourceNa
 		specRequest := specRequests[i]
 		specs[i] = replicationSpec(&specRequest)
 	}
+	applyDiskSizeGB(specs, req.DiskSizeGb)
 	clusterName = req.ClusterName
 	resourceSuffix := req.ResourceSuffix
 	clusterType := req.ClusterType()
@@ -170,6 +171,9 @@ func writeReplicationSpec(cluster *hclwrite.Body, specs []admin.ReplicationSpec2
 			if es.NodeCount != nil {
 				esMap["node_count"] = cty.NumberIntVal(int64(*es.NodeCount))
 			}
+			if es.DiskSizeGB != nil {
+				esMap["disk_size_gb"] = cty.NumberIntVal(int64(*es.DiskSizeGB))
+			}
 			if es.EbsVolumeType != nil && *es.EbsVolumeType != "" {
 				esMap["ebs_volume_type"] = cty.StringVal(*es.EbsVolumeType)
 			}
@@ -204,6 +208,22 @@ func writeReplicationSpec(cluster *hclwrite.Body, specs []admin.ReplicationSpec2
 
 	cluster.SetAttributeValue("replication_specs", cty.TupleVal(allSpecs))
 	return nil
+}
+
+func applyDiskSizeGB(specs []admin.ReplicationSpec20240805, diskSizeGB int) {
+	if diskSizeGB <= 0 {
+		return
+	}
+	gb := float64(diskSizeGB)
+	for i := range specs {
+		rcs := specs[i].GetRegionConfigs()
+		for j := range rcs {
+			if rcs[j].ElectableSpecs != nil {
+				rcs[j].ElectableSpecs.DiskSizeGB = &gb
+			}
+		}
+		specs[i].RegionConfigs = &rcs
+	}
 }
 
 func validateAdvancedConfig(cfg map[string]any) error {

--- a/internal/testutil/acc/config_cluster_test.go
+++ b/internal/testutil/acc/config_cluster_test.go
@@ -202,6 +202,34 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 }
 `
 
+var diskSizeGb = `
+resource "mongodbatlas_advanced_cluster" "cluster_info" {
+  backup_enabled = false
+  cluster_type   = "REPLICASET"
+  name           = "my-name"
+  pit_enabled    = false
+  project_id     = "project"
+
+  replication_specs = [{
+    region_configs = [{
+      auto_scaling = {
+        disk_gb_enabled = false
+      }
+      electable_specs = {
+        disk_size_gb  = 40
+        instance_size = "M10"
+        node_count    = 3
+      }
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_WEST_2"
+    }]
+    zone_name = "Zone 1"
+  }]
+
+}
+`
+
 var autoScalingDiskEnabled = `
 resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = false
@@ -273,6 +301,10 @@ func Test_ClusterResourceHcl(t *testing.T) {
 			"defaults": {
 				standardClusterResource,
 				acc.ClusterRequest{ClusterName: clusterName},
+			},
+			"diskSizeGb": {
+				diskSizeGb,
+				acc.ClusterRequest{ClusterName: clusterName, DiskSizeGb: 40},
 			},
 			"dependsOn": {
 				dependsOnClusterResource,

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -175,6 +175,11 @@ func ProjectIDExecutionWithCluster(tb testing.TB, totalNodeCount int) (projectID
 // When `MONGODB_ATLAS_CLUSTER_NAME` and `MONGODB_ATLAS_PROJECT_ID` are defined it will be used instead of creating resources. This is useful for local execution but not intended for CI executions.
 func ClusterNameExecution(tb testing.TB, populateSampleData bool) (projectID, clusterName string) {
 	tb.Helper()
+	return clusterNameExecution(tb, populateSampleData, false, false)
+}
+
+func clusterNameExecution(tb testing.TB, populateSampleData, backupEnabled, pitEnabled bool) (projectID, clusterName string) {
+	tb.Helper()
 	SkipInUnitTest(tb)
 	require.True(tb, sharedInfo.init, "sharedInfo not initialized, use acc.Run() to run tests that require shared resources")
 
@@ -191,7 +196,7 @@ func ClusterNameExecution(tb testing.TB, populateSampleData bool) (projectID, cl
 	if sharedInfo.clusterName == "" {
 		name := RandomClusterName()
 		tb.Logf("Creating execution cluster: %s\n", name)
-		sharedInfo.clusterName = createCluster(tb, projectID, name)
+		sharedInfo.clusterName = createCluster(tb, projectID, name, backupEnabled, pitEnabled)
 
 		if populateSampleData {
 			err := PopulateWithSampleData(projectID, sharedInfo.clusterName)


### PR DESCRIPTION
## Description

Adds acceptance tests for `mongodbatlas_cloud_backup_collection_restore_job` and snapshot database data sources, plus a shared fixture that provisions a backup-enabled source cluster and on-demand snapshot. CI gets a `backup_collection_restore` test group.

Link to any related issue(s): CLOUDP-435981

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

External reuse is supported via `MONGODB_ATLAS_PROJECT_ID`, `MONGODB_ATLAS_CLUSTER_NAME`, and `MONGODB_ATLAS_SNAPSHOT_ID`. The execution cluster helper can enable cloud backup and PIT when the fixture creates it.