### PR TITLE
chore: Enable CI acceptance tests 

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -333,6 +333,10 @@ jobs:
             - 'internal/serviceapi/streamconnectionfailover/*.go'
             - 'internal/serviceapi/logintegration/*.go'
             - 'internal/serviceapi/metricintegration/*.go'
+            - 'internal/serviceapi/mcpconfig/*.go'
+            - 'internal/serviceapi/mcpconfigsecret/*.go'
+            - 'internal/serviceapi/projectmcpconfig/*.go'
+            - 'internal/serviceapi/projectmcpconfigsecret/*.go'
           autogen_slow:
             - 'internal/common/autogen/*.go'
             - 'internal/serviceapi/clusterapi/*.go'
@@ -710,6 +714,10 @@ jobs:
             ./internal/serviceapi/databaseuserapi
             ./internal/serviceapi/logintegration
             ./internal/serviceapi/metricintegration
+            ./internal/serviceapi/mcpconfig
+            ./internal/serviceapi/mcpconfigsecret
+            ./internal/serviceapi/projectmcpconfig
+            ./internal/serviceapi/projectmcpconfigsecret
             ./internal/serviceapi/maintenancewindowapi
             ./internal/serviceapi/privatelinkendpointservicedatafederationonlinearchive
             ./internal/serviceapi/projectapi


### PR DESCRIPTION
Rate limit for remoteMcpConfigurations was bumped to 100/60s (from 10/60s), so the mcp resources no longer need to be excluded from autogen_fast.

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
