### PR TITLE
chore: Send detected AI agents in User-Agent header

### DIFF
--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
 	admin20241113 "go.mongodb.org/atlas-sdk/v20241113005/admin"
 	"go.mongodb.org/atlas-sdk/v20250312024/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/detectaiagent"
 	matlasClient "go.mongodb.org/atlas/mongodbatlas"
 	realmAuth "go.mongodb.org/realm/auth"
 	"go.mongodb.org/realm/realm"
@@ -36,6 +38,15 @@ const (
 	idleConnTimeout       = 30 * time.Second
 	expectContinueTimeout = 1 * time.Second
 )
+
+// Detect agent usage only once across UserAgent() calls.
+var detectedAgentIdentifier = sync.OnceValue(func() string {
+	agent, ok := detectaiagent.Detect()
+	if !ok {
+		return ""
+	}
+	return agent.UserAgentIdentifier
+})
 
 type AuthMethod int
 
@@ -336,6 +347,8 @@ func (c *MongoDBClient) UntypedAPICall(ctx context.Context, params APICallParams
 }
 
 func UserAgent(terraformVersion string) string {
+	// The Terraform version does not change within a single execution, but acceptance/migration tests do create multiple
+	// clients passing in different values, so version identifiers are re-calculated in every UserAgent() call.
 	metadata := []struct {
 		Name  string
 		Value string
@@ -350,6 +363,11 @@ func UserAgent(terraformVersion string) string {
 		}
 		part := fmt.Sprintf("%s/%s", info.Name, info.Value)
 		parts = append(parts, part)
+	}
+
+	// Agent detection runs only once.
+	if identifier := detectedAgentIdentifier(); identifier != "" {
+		parts = append(parts, identifier)
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/config/user_agent_test.go
+++ b/internal/config/user_agent_test.go
@@ -116,3 +116,11 @@ func TestAddUserAgentExtra(t *testing.T) {
 	assert.Equal(t, "NewName", ua.Name)
 	assert.Equal(t, "FromOther", ua.Operation)
 }
+
+func TestUserAgent_TerraformVersionPerCall(t *testing.T) {
+	first := config.UserAgent("1.10.0")
+	second := config.UserAgent("1.11.0")
+
+	assert.Contains(t, first, "Terraform/1.10.0")
+	assert.Contains(t, second, "Terraform/1.11.0")
+}


### PR DESCRIPTION
## Description

Use the SDK helper introduced in https://github.com/mongodb/atlas-sdk-go/pull/842 to detect operations ran by AI agents and report them via the User-Agent header.

AI agent detection runs just once across client creations.

Manually verified executing terraform within claude-code and codex sessions.

Link to any related issue(s): CLOUDP-432501

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
