### PR TITLE
fix: Sends plural data source list query params during pagination

### DIFF
--- a/.changelog/4680.txt
+++ b/.changelog/4680.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/mongodbatlas_log_integrations: Sends `integration_type` list filter during pagination
+```
+
+```release-note:bug
+data-source/mongodbatlas_metric_integrations: Sends `integration_type` and `provider_type` list filters during pagination
+```

--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -165,10 +165,8 @@ func HandleDataSourceReadList(ctx context.Context, req HandleReadReq) {
 			VersionHeader: req.CallParams.VersionHeader,
 			RelativePath:  req.CallParams.RelativePath,
 			PathParams:    req.CallParams.PathParams,
-			QueryParams: map[string]string{
-				"pageNum": fmt.Sprintf("%d", pageNum),
-			},
-			Method: req.CallParams.Method,
+			QueryParams:   WithPageNum(req.CallParams.QueryParams, pageNum),
+			Method:        req.CallParams.Method,
 		}
 		callResult := callReadWithHooksWithOptions(ctx, req.Client, paginatedParams, req, req.Hooks)
 		if callResult.Err != nil {

--- a/internal/common/autogen/query_param.go
+++ b/internal/common/autogen/query_param.go
@@ -3,6 +3,7 @@ package autogen
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -58,6 +59,17 @@ func BuildQueryParamMap(ctx context.Context, args []QueryParamArg) map[string]st
 	}
 
 	return result
+}
+
+// WithPageNum copies queryParams and sets pageNum on the copy so pagination
+// does not mutate CallParams.QueryParams across pages.
+func WithPageNum(queryParams map[string]string, pageNum int) map[string]string {
+	out := maps.Clone(queryParams)
+	if out == nil {
+		out = make(map[string]string, 1)
+	}
+	out["pageNum"] = fmt.Sprintf("%d", pageNum)
+	return out
 }
 
 // extractListValue extracts values from a types.List and joins them with commas.

--- a/internal/common/autogen/query_params_test.go
+++ b/internal/common/autogen/query_params_test.go
@@ -169,3 +169,70 @@ func TestBuildQueryParamMap(t *testing.T) {
 		})
 	}
 }
+
+func TestWithPageNum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expected map[string]string
+		input    map[string]string
+		name     string
+		pageNum  int
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			pageNum:  1,
+			expected: map[string]string{"pageNum": "1"},
+		},
+		{
+			name:     "empty map",
+			input:    map[string]string{},
+			pageNum:  2,
+			expected: map[string]string{"pageNum": "2"},
+		},
+		{
+			name: "preserves existing filters",
+			input: map[string]string{
+				"sourceNamespace": "db.coll",
+				"state":           "SUCCESSFUL",
+			},
+			pageNum: 3,
+			expected: map[string]string{
+				"sourceNamespace": "db.coll",
+				"state":           "SUCCESSFUL",
+				"pageNum":         "3",
+			},
+		},
+		{
+			name: "overwrites existing pageNum",
+			input: map[string]string{
+				"pageNum": "99",
+				"state":   "FAILED",
+			},
+			pageNum: 4,
+			expected: map[string]string{
+				"pageNum": "4",
+				"state":   "FAILED",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, autogen.WithPageNum(tc.input, tc.pageNum))
+		})
+	}
+}
+
+func TestWithPageNum_doesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	input := map[string]string{"state": "SUCCESSFUL"}
+	out := autogen.WithPageNum(input, 1)
+	assert.Equal(t, "1", out["pageNum"])
+	_, hasPageNum := input["pageNum"]
+	assert.False(t, hasPageNum)
+	out["state"] = "FAILED"
+	assert.Equal(t, "SUCCESSFUL", input["state"])
+}


### PR DESCRIPTION
## Summary

- `HandleDataSourceReadList` kept only `pageNum` and dropped list filters already built by `BuildQueryParamMap`.
- Clone existing query params, set `pageNum` on the copy (`WithPageNum`).
- Unblocks `integration_type` on `mongodbatlas_log_integrations` and `integration_type` / `provider_type` on `mongodbatlas_metric_integrations`.
- Collection-restore plural filters stay optional; the schema hook that hid them is dropped on #4669.

Does not close [CLOUDP-433211](https://jira.mongodb.org/browse/CLOUDP-433211). Codegen `getQueryParams` still skips `computed_optional` (`include_system_managed` on service accounts).

## Test plan

- [x] `go test ./internal/common/autogen/ -count=1`
- [x] Acc: `TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename` second step (`source_namespace` filter, `results.# = 1`) on #4671
- [x] Optional local: `TestAccCloudBackupCollectionRestoreJobCollections_envRead` (skipped in CI)
