### PR TITLE
fix: Avoid redundant autoscaling start request

### DIFF
--- a/.changelog/4683.txt
+++ b/.changelog/4683.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_stream_processor: Avoids resending already persisted autoscaling configuration when starting a stream processor
+```

--- a/.changelog/4683.txt
+++ b/.changelog/4683.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/mongodbatlas_stream_processor: Avoids resending already persisted autoscaling configuration when starting a stream processor
-```

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -111,8 +111,6 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		if plan.Tier.ValueString() != "" {
 			startWithOptions.SetTier(plan.Tier.ValueString())
 		}
-		// Autoscaling is persisted through the preceding Create request. Do not repeat
-		// it in :startWith: that endpoint treats it as a new autoscaling modification.
 		_, err := connV2.StreamsAPI.StartStreamProcessorWith(ctx, projectID, workspaceOrInstanceName, processorName, startWithOptions).Execute()
 		if err != nil {
 			resp.Diagnostics.AddError(errorCreateStart, err.Error())
@@ -241,8 +239,6 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		if plan.Tier.ValueString() != "" {
 			startWithOptions.SetTier(plan.Tier.ValueString())
 		}
-		// Autoscaling is persisted through the preceding PATCH request. Do not repeat
-		// it in :startWith: that endpoint treats it as a new autoscaling modification.
 		_, err := r.Client.AtlasV2.StreamsAPI.StartStreamProcessorWith(ctx, projectID, workspaceOrInstanceName, processorName, startWithOptions).Execute()
 		if err != nil {
 			resp.Diagnostics.AddError("Error starting stream processor", err.Error())

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -111,14 +111,8 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		if plan.Tier.ValueString() != "" {
 			startWithOptions.SetTier(plan.Tier.ValueString())
 		}
-		// On the :startWith endpoint, `autoscaling` is TOP-LEVEL (no options wrapper).
-		autoscaling, diags := autoscalingFromOptions(ctx, plan.Options)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-		startWithOptions.Autoscaling = autoscaling
-
+		// Autoscaling is persisted through the preceding Create request. Do not repeat
+		// it in :startWith: that endpoint treats it as a new autoscaling modification.
 		_, err := connV2.StreamsAPI.StartStreamProcessorWith(ctx, projectID, workspaceOrInstanceName, processorName, startWithOptions).Execute()
 		if err != nil {
 			resp.Diagnostics.AddError(errorCreateStart, err.Error())
@@ -247,14 +241,8 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		if plan.Tier.ValueString() != "" {
 			startWithOptions.SetTier(plan.Tier.ValueString())
 		}
-		// On the :startWith endpoint, `autoscaling` is TOP-LEVEL (see create path).
-		autoscaling, diags := autoscalingFromOptions(ctx, plan.Options)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-		startWithOptions.Autoscaling = autoscaling
-
+		// Autoscaling is persisted through the preceding PATCH request. Do not repeat
+		// it in :startWith: that endpoint treats it as a new autoscaling modification.
 		_, err := r.Client.AtlasV2.StreamsAPI.StartStreamProcessorWith(ctx, projectID, workspaceOrInstanceName, processorName, startWithOptions).Execute()
 		if err != nil {
 			resp.Diagnostics.AddError("Error starting stream processor", err.Error())

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -138,22 +138,8 @@ func TestAccStreamProcessor_withOptionsDLQAutoscaling(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithOptionsDLQAutoscaling(t, projectID, workspaceName, clusterName, processorName, streamProcessorOptionsConfig{
-					includeDLQ:         true,
-					autoscalingMinTier: "SP10",
-					autoscalingMaxTier: "SP50",
-					state:              streamprocessor.CreatedState,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.min_tier", "SP10"),
-					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.max_tier", "SP50"),
-					resource.TestCheckResourceAttrSet(resourceName, "effective_tier"),
-				),
-			},
-			{
-				// Starts a configured autoscaling processor through the top-level
-				// autoscaling field of the :startWith request.
+				// Autoscaling is persisted by Create before the provider starts the
+				// processor. The subsequent :startWith request does not repeat it.
 				Config: configWithOptionsDLQAutoscaling(t, projectID, workspaceName, clusterName, processorName, streamProcessorOptionsConfig{
 					includeDLQ:         true,
 					autoscalingMinTier: "SP10",
@@ -161,6 +147,7 @@ func TestAccStreamProcessor_withOptionsDLQAutoscaling(t *testing.T) {
 					state:              streamprocessor.StartedState,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "state", streamprocessor.StartedState),
 					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.min_tier", "SP10"),
 					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.max_tier", "SP50"),

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -138,8 +138,20 @@ func TestAccStreamProcessor_withOptionsDLQAutoscaling(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				// Autoscaling is persisted by Create before the provider starts the
-				// processor. The subsequent :startWith request does not repeat it.
+				Config: configWithOptionsDLQAutoscaling(t, projectID, workspaceName, clusterName, processorName, streamProcessorOptionsConfig{
+					includeDLQ:         true,
+					autoscalingMinTier: "SP10",
+					autoscalingMaxTier: "SP50",
+					state:              streamprocessor.CreatedState,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.min_tier", "SP10"),
+					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.max_tier", "SP50"),
+					resource.TestCheckResourceAttrSet(resourceName, "effective_tier"),
+				),
+			},
+			{
 				Config: configWithOptionsDLQAutoscaling(t, projectID, workspaceName, clusterName, processorName, streamProcessorOptionsConfig{
 					includeDLQ:         true,
 					autoscalingMinTier: "SP10",
@@ -147,7 +159,6 @@ func TestAccStreamProcessor_withOptionsDLQAutoscaling(t *testing.T) {
 					state:              streamprocessor.StartedState,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "state", streamprocessor.StartedState),
 					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.min_tier", "SP10"),
 					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.max_tier", "SP50"),
@@ -179,6 +190,38 @@ func TestAccStreamProcessor_withOptionsDLQAutoscaling(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "state", streamprocessor.StartedState),
 					resource.TestCheckResourceAttrSet(resourceName, "options.dlq.connection_name"),
 					resource.TestCheckNoResourceAttr(resourceName, "options.autoscaling"),
+				),
+			},
+			importStep(),
+		}})
+}
+
+func TestAccStreamProcessor_withOptionsDLQAutoscalingCreateStarted(t *testing.T) {
+	var (
+		projectID, workspaceName = acc.ProjectIDExecutionWithStreamInstance(t)
+		_, clusterName           = acc.ClusterNameExecution(t, false)
+		randomSuffix             = acctest.RandString(5)
+		processorName            = "new-processor-autoscaling-started-" + randomSuffix
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithOptionsDLQAutoscaling(t, projectID, workspaceName, clusterName, processorName, streamProcessorOptionsConfig{
+					includeDLQ:         true,
+					autoscalingMinTier: "SP10",
+					autoscalingMaxTier: "SP50",
+					state:              streamprocessor.StartedState,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "state", streamprocessor.StartedState),
+					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.min_tier", "SP10"),
+					resource.TestCheckResourceAttr(resourceName, "options.autoscaling.max_tier", "SP50"),
+					resource.TestCheckResourceAttrSet(resourceName, "effective_tier"),
 				),
 			},
 			importStep(),


### PR DESCRIPTION
## Summary

Fixes a post-merge issue in the vertical autoscaling support added by #4665.

The provider persists autoscaling through the preceding Create or PATCH request. When a processor is started, it no longer resends the same autoscaling configuration through `:startWith`, which MMS/SPM treats as an additional autoscaling modification.

## Validation

- `go test ./internal/service/streamprocessor -count=1`
- `make verify`
- Cloud Dev direct Create → `STARTED` test using the local provider build
  - Create persisted autoscaling
  - `:startWith` sent only `tier`
  - processor reached `STARTED` successfully

## Follow-up

The underlying MMS/SPM `:startWith` autoscaling path remains a backend issue for direct API clients and is being tracked separately.