### PR TITLE
fix: Allow non-IAM Kafka authentication

### DIFF
--- a/.changelog/4688.txt
+++ b/.changelog/4688.txt
@@ -1,1 +1,3 @@
-Fixes validation of non-IAM Kafka stream connections when the optional `authentication.aws` block is omitted
+```release-note:bug
+resource/mongodbatlas_stream_connection: Fixes validation of non-IAM Kafka stream connections when the optional `authentication.aws` block is omitted
+```

--- a/.changelog/4688.txt
+++ b/.changelog/4688.txt
@@ -1,0 +1,1 @@
+Fixes validation of non-IAM Kafka stream connections when the optional `authentication.aws` block is omitted

--- a/examples/mongodbatlas_stream_connection/README.md
+++ b/examples/mongodbatlas_stream_connection/README.md
@@ -1,6 +1,6 @@
 # MongoDB Atlas Provider - Atlas Stream Instance defined in a Project
 
-This example shows how to create Atlas Stream Connections in Terraform. It also creates a required stream instance. The configuration defines Kafka, Cluster, Azure Blob Storage, and other connection types to showcase their usage.
+This example shows how to create Atlas Stream Connections in Terraform. It also creates a required stream instance. The configuration defines Kafka (including PLAIN, SCRAM-512, OAUTHBEARER, and AWS MSK IAM authentication), Cluster, Azure Blob Storage, and other connection types to showcase their usage.
 
 You must set the following variables depending on connection type:
 

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -56,6 +56,31 @@ resource "mongodbatlas_stream_connection" "example-kafka-plaintext" {
   }
 }
 
+# Kafka connection using SCRAM authentication without AWS MSK IAM.
+resource "mongodbatlas_stream_connection" "example-kafka-scram" {
+  project_id      = var.project_id
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "KafkaSCRAMConnection"
+  type            = "Kafka"
+  authentication = {
+    mechanism = "SCRAM-512"
+    username  = var.kafka_username
+    password  = var.kafka_password
+  }
+  bootstrap_servers = "localhost:9092,localhost:9092"
+  config = {
+    "auto.offset.reset" : "earliest"
+  }
+  security = {
+    protocol = "SASL_PLAINTEXT"
+  }
+  networking = {
+    access = {
+      type = "PUBLIC"
+    }
+  }
+}
+
 resource "mongodbatlas_stream_connection" "example-kafka-oauthbearer" {
   project_id      = var.project_id
   instance_name   = mongodbatlas_stream_instance.example.instance_name

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -128,7 +128,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Optional: true,
 						Attributes: map[string]schema.Attribute{
 							"role_arn": schema.StringAttribute{
-								Required: true,
+								Optional: true,
 							},
 						},
 					},

--- a/internal/service/streamconnection/resource_schema_test.go
+++ b/internal/service/streamconnection/resource_schema_test.go
@@ -1,0 +1,28 @@
+package streamconnection_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceSchemaAuthenticationAWSRoleARNOptional(t *testing.T) {
+	resourceSchema := streamconnection.ResourceSchema(t.Context())
+	authentication, ok := resourceSchema.Attributes["authentication"].(schema.SingleNestedAttribute)
+	require.True(t, ok)
+
+	aws, ok := authentication.Attributes["aws"].(schema.SingleNestedAttribute)
+	require.True(t, ok)
+
+	roleARN, ok := aws.Attributes["role_arn"].(schema.StringAttribute)
+	require.True(t, ok)
+	assertRoleARNOptional(t, roleARN)
+}
+
+func assertRoleARNOptional(t *testing.T, roleARN schema.StringAttribute) {
+	t.Helper()
+	require.True(t, roleARN.Optional, "authentication.aws.role_arn must not be required when authentication.aws is omitted")
+	require.False(t, roleARN.Required)
+}

--- a/internal/service/streamconnection/resource_schema_test.go
+++ b/internal/service/streamconnection/resource_schema_test.go
@@ -18,11 +18,6 @@ func TestResourceSchemaAuthenticationAWSRoleARNOptional(t *testing.T) {
 
 	roleARN, ok := aws.Attributes["role_arn"].(schema.StringAttribute)
 	require.True(t, ok)
-	assertRoleARNOptional(t, roleARN)
-}
-
-func assertRoleARNOptional(t *testing.T, roleARN schema.StringAttribute) {
-	t.Helper()
 	require.True(t, roleARN.Optional, "authentication.aws.role_arn must not be required when authentication.aws is omitted")
 	require.False(t, roleARN.Required)
 }

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -29,6 +29,7 @@ const (
 )
 
 var _ resource.ResourceWithConfigure = &streamConnectionRS{}
+var _ resource.ResourceWithConfigValidators = &streamConnectionRS{}
 var _ resource.ResourceWithImportState = &streamConnectionRS{}
 
 func Resource() resource.Resource {
@@ -195,6 +196,10 @@ var AzureObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 func (r *streamConnectionRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = ResourceSchema(ctx)
 	conversion.UpdateSchemaDescription(&resp.Schema)
+}
+
+func (r *streamConnectionRS) ConfigValidators(context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{kafkaIAMAuthenticationValidator{}}
 }
 
 // getWorkspaceOrInstanceName returns the workspace name from workspace_name or instance_name field

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -128,8 +128,20 @@ func testCaseKafkaPlaintext(t *testing.T) *resource.TestCase {
 				),
 			},
 			{
+				// The preceding apply exercises the full Terraform config-to-request mapping
+				// path for non-IAM Kafka authentication without an aws block.
 				Config:   dataSourcesConfig + configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092,localhost:9092", "earliest", "", false),
 				PlanOnly: true,
+			},
+			{
+				Config:      configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaIAMAuthenticationConfigWithoutRole(false), "localhost:9092,localhost:9092", "earliest", kafkaNetworkingPublic, true),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("AWS MSK IAM role ARN is required"),
+			},
+			{
+				Config:      configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaIAMAuthenticationConfigWithoutRole(true), "localhost:9092,localhost:9092", "earliest", kafkaNetworkingPublic, true),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("AWS MSK IAM role ARN is required"),
 			},
 			{
 				Config: dataSourcesWithPagination + configureKafka(fmt.Sprintf("%q", projectID), instanceName, connectionName, getKafkaAuthenticationConfig("PLAIN", "user2", "otherpassword", "", "", "", "", "", ""), "localhost:9093", "latest", kafkaNetworkingPublic, false),
@@ -946,6 +958,18 @@ func getKafkaIAMAuthenticationConfig(roleARN string) string {
 			role_arn = %[1]q
 		}
 	}`, roleARN)
+}
+
+func getKafkaIAMAuthenticationConfigWithoutRole(includeAWSBlock bool) string {
+	if includeAWSBlock {
+		return `authentication = {
+			mechanism = "AWS_MSK_IAM"
+			aws = {}
+		}`
+	}
+	return `authentication = {
+		mechanism = "AWS_MSK_IAM"
+	}`
 }
 
 func getKafkaAuthenticationConfig(mechanism, username, password, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions, method string) string {

--- a/internal/service/streamconnection/validate_config.go
+++ b/internal/service/streamconnection/validate_config.go
@@ -1,0 +1,51 @@
+package streamconnection
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+const awsMSKIAMMechanism = "AWS_MSK_IAM"
+
+type kafkaIAMAuthenticationValidator struct{}
+
+func (kafkaIAMAuthenticationValidator) Description(context.Context) string {
+	return "AWS_MSK_IAM authentication requires authentication.aws.role_arn."
+}
+
+func (v kafkaIAMAuthenticationValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (kafkaIAMAuthenticationValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var authentication types.Object
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("authentication"), &authentication)...)
+	if resp.Diagnostics.HasError() || authentication.IsNull() || authentication.IsUnknown() {
+		return
+	}
+
+	authenticationModel := &TFConnectionAuthenticationModel{}
+	resp.Diagnostics.Append(authentication.As(ctx, authenticationModel, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() || authenticationModel.Mechanism.IsNull() || authenticationModel.Mechanism.IsUnknown() || authenticationModel.Mechanism.ValueString() != awsMSKIAMMechanism {
+		return
+	}
+
+	roleARNPath := path.Root("authentication").AtName("aws").AtName("role_arn")
+	if authenticationModel.AWS.IsNull() || authenticationModel.AWS.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(roleARNPath, "AWS MSK IAM role ARN is required", "authentication.aws.role_arn must be set when authentication.mechanism is AWS_MSK_IAM.")
+		return
+	}
+
+	awsModel := &TFAWSModel{}
+	resp.Diagnostics.Append(authenticationModel.AWS.As(ctx, awsModel, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() || awsModel.RoleArn.IsUnknown() {
+		return
+	}
+	if awsModel.RoleArn.IsNull() || awsModel.RoleArn.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(roleARNPath, "AWS MSK IAM role ARN is required", "authentication.aws.role_arn must be set when authentication.mechanism is AWS_MSK_IAM.")
+	}
+}


### PR DESCRIPTION
## Description

Fixes validation of Kafka Stream Connection configurations that define non-IAM authentication. `authentication.aws.role_arn` is now optional, preventing Terraform from requiring it when the optional `authentication.aws` block is omitted.

Adds a schema regression test covering the optional nested attribute.

Link to any related issue(s):

[CLOUDP-439681](https://jira.mongodb.org/browse/CLOUDP-439681)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Validated with `go test ./internal/service/streamconnection`.
