### PR TITLE
test: Fails later collection-restore tests when sample load fails

### DIFF
--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -171,12 +171,33 @@ func PopulateWithSampleData(projectID, clusterName string) error {
 		Delay:      1 * time.Minute,
 		Refresh: func() (result any, state string, err error) {
 			job, _, err := ConnV2().ClustersAPI.GetSampleDatasetLoad(ctx, projectID, jobID).Execute()
+			if err != nil {
+				return nil, "", err
+			}
+			if job == nil {
+				return nil, "", fmt.Errorf("sample dataset load %s returned nil job for cluster %s:%s", jobID, projectID, clusterName)
+			}
 			state = job.GetState()
-			return job, state, err
+			if err := errIfSampleDatasetLoadFailed(projectID, clusterName, jobID, state); err != nil {
+				return job, state, err
+			}
+			return job, state, nil
 		},
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func errIfSampleDatasetLoadFailed(projectID, clusterName, jobID, state string) error {
+	if state == retrystrategy.RetryStrategyFailedState {
+		return fmt.Errorf("sample dataset load %s failed for cluster %s:%s", jobID, projectID, clusterName)
+	}
+	return nil
+}
+
+// ErrIfSampleDatasetLoadFailedForTest exposes sample-dataset FAILED mapping for unit tests.
+func ErrIfSampleDatasetLoadFailedForTest(projectID, clusterName, jobID, state string) error {
+	return errIfSampleDatasetLoadFailed(projectID, clusterName, jobID, state)
 }
 
 func ConfigBasicDedicated(projectID, name, zoneName string) string {

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture.go
@@ -79,9 +79,11 @@ func CloudBackupCollectionRestoreFixture(tb testing.TB) *CollectionRestoreFixtur
 	SkipInUnitTest(tb)
 	require.True(tb, sharedInfo.init, "sharedInfo not initialized, use acc.Run() to run tests that require shared resources")
 	collectionRestoreFixtureOnce.Do(func() {
+		// Do not require / FailNow in this callback: Once would still mark done and leave a nil fixture.
 		collectionRestoreFixture, collectionRestoreFixtureErr = initCollectionRestoreFixture(tb)
 	})
 	require.NoError(tb, collectionRestoreFixtureErr)
+	require.NotNil(tb, collectionRestoreFixture, "collection restore fixture is nil after init")
 	return collectionRestoreFixture
 }
 
@@ -105,7 +107,10 @@ func initCollectionRestoreFixture(tb testing.TB) (*CollectionRestoreFixture, err
 		}, nil
 	}
 
-	projectID, clusterName := clusterNameExecution(tb, true, true, true)
+	projectID, clusterName, err := clusterNameExecution(tb, true, true, true)
+	if err != nil {
+		return nil, err
+	}
 	if err := requireCloudBackupAndPIT(ctx, projectID, clusterName); err != nil {
 		return nil, err
 	}

--- a/internal/testutil/acc/cloud_backup_collection_restore_fixture_test.go
+++ b/internal/testutil/acc/cloud_backup_collection_restore_fixture_test.go
@@ -32,3 +32,18 @@ func TestErrIfCloudBackupOrPITDisabled_failsWhenPITOff(t *testing.T) {
 func TestErrIfCloudBackupOrPITDisabled_okWhenBothOn(t *testing.T) {
 	require.NoError(t, acc.ErrIfCloudBackupOrPITDisabledForTest("c1", true, true))
 }
+
+func TestErrIfSampleDatasetLoadFailed_failedState(t *testing.T) {
+	err := acc.ErrIfSampleDatasetLoadFailedForTest("p1", "c1", "job-123", "FAILED")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "job-123")
+	assert.Contains(t, err.Error(), "c1")
+}
+
+func TestErrIfSampleDatasetLoadFailed_workingOrCompleted(t *testing.T) {
+	for _, state := range []string{"WORKING", "COMPLETED"} {
+		t.Run(state, func(t *testing.T) {
+			require.NoError(t, acc.ErrIfSampleDatasetLoadFailedForTest("p1", "c1", "job-123", state))
+		})
+	}
+}

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -27,6 +27,7 @@ type projectInfo struct {
 }
 
 var sharedInfo = struct {
+	clusterPopulateErr error
 	clusterName        string
 	streamInstanceName string
 	projects           []projectInfo
@@ -175,16 +176,19 @@ func ProjectIDExecutionWithCluster(tb testing.TB, totalNodeCount int) (projectID
 // When `MONGODB_ATLAS_CLUSTER_NAME` and `MONGODB_ATLAS_PROJECT_ID` are defined it will be used instead of creating resources. This is useful for local execution but not intended for CI executions.
 func ClusterNameExecution(tb testing.TB, populateSampleData bool) (projectID, clusterName string) {
 	tb.Helper()
-	return clusterNameExecution(tb, populateSampleData, false, false)
+	projectID, clusterName, err := clusterNameExecution(tb, populateSampleData, false, false)
+	require.NoError(tb, err)
+	return projectID, clusterName
 }
 
-func clusterNameExecution(tb testing.TB, populateSampleData, backupEnabled, pitEnabled bool) (projectID, clusterName string) {
+func clusterNameExecution(tb testing.TB, populateSampleData, backupEnabled, pitEnabled bool) (projectID, clusterName string, err error) {
 	tb.Helper()
 	SkipInUnitTest(tb)
 	require.True(tb, sharedInfo.init, "sharedInfo not initialized, use acc.Run() to run tests that require shared resources")
 
 	if ExistingClusterUsed() {
-		return existingProjectIDClusterName()
+		projectID, clusterName = existingProjectIDClusterName()
+		return projectID, clusterName, nil
 	}
 
 	projectID = ProjectIDExecution(tb) // ensure the execution project is created before cluster creation
@@ -199,12 +203,17 @@ func clusterNameExecution(tb testing.TB, populateSampleData, backupEnabled, pitE
 		sharedInfo.clusterName = createCluster(tb, projectID, name, backupEnabled, pitEnabled)
 
 		if populateSampleData {
-			err := PopulateWithSampleData(projectID, sharedInfo.clusterName)
-			require.NoError(tb, err)
+			if populateErr := PopulateWithSampleData(projectID, sharedInfo.clusterName); populateErr != nil {
+				sharedInfo.clusterPopulateErr = populateErr
+			}
 		}
 	}
 
-	return projectID, sharedInfo.clusterName
+	if populateSampleData && sharedInfo.clusterPopulateErr != nil {
+		return projectID, sharedInfo.clusterName, sharedInfo.clusterPopulateErr
+	}
+
+	return projectID, sharedInfo.clusterName, nil
 }
 
 // ProjectIDExecutionWithStreamInstance returns the project ID and stream instance name for test execution.


### PR DESCRIPTION
## Why

When Atlas sample-dataset load fails during collection-restore acc fixture setup, `require.NoError` inside `sync.Once.Do` calls FailNow (`runtime.Goexit`). Once still marks done. `collectionRestoreFixture` and `collectionRestoreFixtureErr` stay nil. Sibling tests then panic on `fixture.ProjectID` instead of failing at fixture setup.

Seen in [Test Suite 33137809652](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/33137809652):

- `TestAccCloudBackupCollectionRestoreJob_snapshotSameClusterDatabaseRename`: `unexpected state 'FAILED', wanted target 'COMPLETED'. last error: %!s(<nil>)` in `PopulateWithSampleData`.
- `TestAccCloudBackupCollectionRestoreJob_pitDestClusterSuffixes`: SIGSEGV in `sourceClusterHCL`.

Jira: [CLOUDP-439893](https://jira.mongodb.org/browse/CLOUDP-439893)

## What

- `clusterNameExecution` returns the populate error instead of `require.NoError`. Public `ClusterNameExecution` still requires. Call sites are unchanged.
- Fixture stores that error from Once. Every test fails at `CloudBackupCollectionRestoreFixture`. Getter also `require.NotNil`s so a leftover FailNow inside Once (`createCluster`) does not return a nil fixture.
- Sticky `clusterPopulateErr` on `sharedInfo` so a later `ClusterNameExecution(t, true)` does not skip seed and hand out an unseeded cluster. `populateSampleData=false` callers still get the cluster.
- `PopulateWithSampleData` treats sample-load `FAILED` and a nil job as a real error with the job id (same Refresh pattern as snapshot wait).

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.