### PR TITLE
refactor: Replace clearMaintenanceWave workaround with SDK NullFields

### DIFF
--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -269,10 +269,10 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if d.HasChange("wave_assignment") {
 		// SDKv2 GetOk() cannot distinguish an explicit value (including 0) from an unset field,
 		// since TypeInt treats 0 and absent identically. GetRawConfig() allows to distinguish between the two.
-		if !d.GetRawConfig().GetAttr("wave_assignment").IsNull() {
-			params.SetWaveAssignment(d.Get("wave_assignment").(int))
-		} else {
+		if d.GetRawConfig().GetAttr("wave_assignment").IsNull() {
 			params.SetWaveAssignmentNil()
+		} else {
+			params.SetWaveAssignment(d.Get("wave_assignment").(int))
 		}
 	}
 

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -230,23 +230,6 @@ func flattenProtectedHours(protectedHours admin.ProtectedHours) []map[string]int
 	return res
 }
 
-// clearMaintenanceWave sends a PATCH with `waveAssignment: null` via UntypedAPICall.
-// Needed because the SDK field is *int with omitempty, so a nil pointer is omitted instead of serialized as null.
-// Once CLOUDP-315290 is resolved, remove this and use the SDK directly.
-func clearMaintenanceWave(ctx context.Context, client *config.MongoDBClient, projectID string) diag.Diagnostics {
-	body := []byte(`{"waveAssignment":null}`)
-	_, err := client.UntypedAPICall(ctx, config.APICallParams{
-		VersionHeader: "application/vnd.atlas.preview+json",
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
-		PathParams:    map[string]string{"groupId": projectID},
-		Method:        "PATCH",
-	}, body)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceUpdate, projectID, err))
-	}
-	return nil
-}
-
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Id()
@@ -287,12 +270,9 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		// SDKv2 GetOk() cannot distinguish an explicit value (including 0) from an unset field,
 		// since TypeInt treats 0 and absent identically. GetRawConfig() allows to distinguish between the two.
 		if !d.GetRawConfig().GetAttr("wave_assignment").IsNull() {
-			wave := d.Get("wave_assignment").(int)
-			params.WaveAssignment = &wave
+			params.SetWaveAssignment(d.Get("wave_assignment").(int))
 		} else {
-			if diags := clearMaintenanceWave(ctx, meta.(*config.MongoDBClient), projectID); diags != nil {
-				return diags
-			}
+			params.SetWaveAssignmentNil()
 		}
 	}
 


### PR DESCRIPTION
## Description

Internal refactor. Replaces the `clearMaintenanceWave` workaround (a hand-rolled untyped PATCH that sent `waveAssignment: null`) with the Atlas SDK's `SetWaveAssignmentNil()` mechanism, so the explicit null is serialized into the same maintenance window update request as the rest of the change. No user-facing behavior change.

Link to any related issue(s): CLOUDP-426997

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

Internal refactor (no functional change), so none of the above apply.

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

The wave-clear path is already covered by `TestAccConfigRSMaintenanceWindow_waveAssignment` (removing `wave_assignment` from a resource that had one exercises the null-clear), so no new test is required.
