### PR TITLE
feat: Add include_system_managed attribute in service account plural datasources

### DIFF
--- a/.changelog/4699.txt
+++ b/.changelog/4699.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/mongodbatlas_service_accounts: Adds `include_system_managed` attribute to optionally include system-managed Service Accounts in the response
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_project_service_accounts: Adds `include_system_managed` attribute to optionally include system-managed Service Accounts in the response
+```

--- a/docs/data-sources/project_service_accounts.md
+++ b/docs/data-sources/project_service_accounts.md
@@ -53,6 +53,10 @@ output "service_accounts_results" {
 
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project, also known as `groupId` in the official documentation.
 
+### Optional
+
+- `include_system_managed` (Boolean) Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.
+
 ### Read-Only
 
 - `results` (Attributes List) List of returned documents that MongoDB Cloud provides when completing this request. (see [below for nested schema](#nestedatt--results))

--- a/docs/data-sources/service_accounts.md
+++ b/docs/data-sources/service_accounts.md
@@ -53,6 +53,10 @@ output "service_accounts_results" {
 
 - `org_id` (String) Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
 
+### Optional
+
+- `include_system_managed` (Boolean) Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.
+
 ### Read-Only
 
 - `results` (Attributes List) List of returned documents that MongoDB Cloud provides when completing this request. (see [below for nested schema](#nestedatt--results))

--- a/internal/serviceapi/projectserviceaccount/plural_data_source.go
+++ b/internal/serviceapi/projectserviceaccount/plural_data_source.go
@@ -55,10 +55,14 @@ func pluralDataSourceReadAPICallParams(ctx context.Context, model *TFPluralDSMod
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
+	queryParams := autogen.BuildQueryParamMap(ctx, []autogen.QueryParamArg{
+		{APIName: "includeSystemManaged", Value: model.IncludeSystemManaged},
+	})
 	return &config.APICallParams{
 		VersionHeader: "application/vnd.atlas.2024-08-05+json",
 		RelativePath:  "/api/atlas/v2/groups/{projectId}/serviceAccounts",
 		PathParams:    pathParams,
+		QueryParams:   queryParams,
 		Method:        "GET",
 	}
 }

--- a/internal/serviceapi/projectserviceaccount/plural_data_source_schema.go
+++ b/internal/serviceapi/projectserviceaccount/plural_data_source_schema.go
@@ -14,6 +14,11 @@ import (
 func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 	return dsschema.Schema{
 		Attributes: map[string]dsschema.Attribute{
+			"include_system_managed": dsschema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.",
+			},
 			"project_id": dsschema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project, also known as `groupId` in the official documentation.",
@@ -83,8 +88,9 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 }
 
 type TFPluralDSModel struct {
-	ProjectId types.String                                        `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
-	Results   customtypes.NestedListValue[TFPluralDSResultsModel] `tfsdk:"results" autogen:"omitjson"`
+	IncludeSystemManaged types.Bool                                          `tfsdk:"include_system_managed" autogen:"omitjson"`
+	ProjectId            types.String                                        `tfsdk:"project_id" apiname:"groupId" autogen:"omitjson"`
+	Results              customtypes.NestedListValue[TFPluralDSResultsModel] `tfsdk:"results" autogen:"omitjson"`
 }
 type TFPluralDSResultsModel struct {
 	ClientId    types.String                                               `tfsdk:"client_id" autogen:"omitjson"`

--- a/internal/serviceapi/projectserviceaccount/plural_data_source_schema.go
+++ b/internal/serviceapi/projectserviceaccount/plural_data_source_schema.go
@@ -15,7 +15,6 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 	return dsschema.Schema{
 		Attributes: map[string]dsschema.Attribute{
 			"include_system_managed": dsschema.BoolAttribute{
-				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.",
 			},

--- a/internal/serviceapi/serviceaccount/plural_data_source.go
+++ b/internal/serviceapi/serviceaccount/plural_data_source.go
@@ -55,10 +55,14 @@ func pluralDataSourceReadAPICallParams(ctx context.Context, model *TFPluralDSMod
 	pathParams := map[string]string{
 		"orgId": model.OrgId.ValueString(),
 	}
+	queryParams := autogen.BuildQueryParamMap(ctx, []autogen.QueryParamArg{
+		{APIName: "includeSystemManaged", Value: model.IncludeSystemManaged},
+	})
 	return &config.APICallParams{
 		VersionHeader: "application/vnd.atlas.2024-08-05+json",
 		RelativePath:  "/api/atlas/v2/orgs/{orgId}/serviceAccounts",
 		PathParams:    pathParams,
+		QueryParams:   queryParams,
 		Method:        "GET",
 	}
 }

--- a/internal/serviceapi/serviceaccount/plural_data_source_schema.go
+++ b/internal/serviceapi/serviceaccount/plural_data_source_schema.go
@@ -14,6 +14,11 @@ import (
 func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 	return dsschema.Schema{
 		Attributes: map[string]dsschema.Attribute{
+			"include_system_managed": dsschema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.",
+			},
 			"org_id": dsschema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the organization that contains your projects.",
@@ -83,8 +88,9 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 }
 
 type TFPluralDSModel struct {
-	OrgId   types.String                                        `tfsdk:"org_id" autogen:"omitjson"`
-	Results customtypes.NestedListValue[TFPluralDSResultsModel] `tfsdk:"results" autogen:"omitjson"`
+	IncludeSystemManaged types.Bool                                          `tfsdk:"include_system_managed" autogen:"omitjson"`
+	OrgId                types.String                                        `tfsdk:"org_id" autogen:"omitjson"`
+	Results              customtypes.NestedListValue[TFPluralDSResultsModel] `tfsdk:"results" autogen:"omitjson"`
 }
 type TFPluralDSResultsModel struct {
 	ClientId    types.String                                               `tfsdk:"client_id" autogen:"omitjson"`

--- a/internal/serviceapi/serviceaccount/plural_data_source_schema.go
+++ b/internal/serviceapi/serviceaccount/plural_data_source_schema.go
@@ -15,7 +15,6 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 	return dsschema.Schema{
 		Attributes: map[string]dsschema.Attribute{
 			"include_system_managed": dsschema.BoolAttribute{
-				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.",
 			},

--- a/tools/codegen/codespec/api_to_provider_spec_mapper.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper.go
@@ -323,6 +323,14 @@ func queryParamsToAttributes(op *high.Operation) (Attributes, error) {
 			log.Printf("[WARN] Query param %s could not be mapped: %s", paramName, err)
 			continue
 		}
+
+		// Query params are never returned in API responses.
+		// When the spec defines a default, these are promoted to ComputedOptional.
+		// Roll them back to Optional only.
+		if parameterAttribute.ComputedOptionalRequired == ComputedOptional {
+			parameterAttribute.ComputedOptionalRequired = Optional
+		}
+
 		queryAttributes = append(queryAttributes, *parameterAttribute)
 	}
 	return queryAttributes, nil

--- a/tools/codegen/gofilegen/datasource/data_source_file.go
+++ b/tools/codegen/gofilegen/datasource/data_source_file.go
@@ -79,16 +79,15 @@ func pluralizeName(name string) string {
 }
 
 // getQueryParams extracts query parameters from plural data source attributes.
-// Assumption made is that query parameters are optional top-level attributes
+// Assumption: query parameters are optional (or optional+computed) top-level attributes
 func getQueryParams(attributes codespec.Attributes) []codetemplate.Param {
 	var queryParams []codetemplate.Param
 
 	for i := range attributes {
-		// Only consider optional attributes as query parameters
-		if attributes[i].ComputedOptionalRequired == codespec.Optional {
+		if attributes[i].ComputedOptionalRequired == codespec.Optional || attributes[i].ComputedOptionalRequired == codespec.ComputedOptional {
 			param := codetemplate.Param{
 				PascalCaseName: stringcase.Capitalize(attributes[i].TFModelName),
-				CamelCaseName:  stringcase.Uncapitalize(attributes[i].APIName),
+				CamelCaseName:  attributes[i].APIName,
 			}
 			queryParams = append(queryParams, param)
 		}

--- a/tools/codegen/gofilegen/datasource/data_source_file.go
+++ b/tools/codegen/gofilegen/datasource/data_source_file.go
@@ -79,12 +79,12 @@ func pluralizeName(name string) string {
 }
 
 // getQueryParams extracts query parameters from plural data source attributes.
-// Assumption: query parameters are optional (or optional+computed) top-level attributes
+// Assumption: query parameters are optional top-level attributes.
 func getQueryParams(attributes codespec.Attributes) []codetemplate.Param {
 	var queryParams []codetemplate.Param
 
 	for i := range attributes {
-		if attributes[i].ComputedOptionalRequired == codespec.Optional || attributes[i].ComputedOptionalRequired == codespec.ComputedOptional {
+		if attributes[i].ComputedOptionalRequired == codespec.Optional {
 			param := codetemplate.Param{
 				PascalCaseName: stringcase.Capitalize(attributes[i].TFModelName),
 				CamelCaseName:  attributes[i].APIName,

--- a/tools/codegen/models/project_service_account.yaml
+++ b/tools/codegen/models/project_service_account.yaml
@@ -342,7 +342,7 @@ data_sources:
             - bool:
                 default: false
               description: Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.
-              computed_optional_required: computed_optional
+              computed_optional_required: optional
               tf_schema_name: include_system_managed
               tf_model_name: IncludeSystemManaged
               api_name: includeSystemManaged

--- a/tools/codegen/models/project_service_account.yaml
+++ b/tools/codegen/models/project_service_account.yaml
@@ -337,8 +337,20 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
     plural:
-        description: Returns all Service Accounts for the specified Project.
+        description: Returns all Service Accounts for the specified Project. By default, system-managed Service Accounts are excluded. Set `includeSystemManaged=true` to include them.
         attributes:
+            - bool:
+                default: false
+              description: Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.
+              computed_optional_required: computed_optional
+              tf_schema_name: include_system_managed
+              tf_model_name: IncludeSystemManaged
+              api_name: includeSystemManaged
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
             - string: {}
               description: Unique 24-hexadecimal digit string that identifies your project, also known as `groupId` in the official documentation.
               computed_optional_required: required

--- a/tools/codegen/models/service_account.yaml
+++ b/tools/codegen/models/service_account.yaml
@@ -342,7 +342,7 @@ data_sources:
             - bool:
                 default: false
               description: Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.
-              computed_optional_required: computed_optional
+              computed_optional_required: optional
               tf_schema_name: include_system_managed
               tf_model_name: IncludeSystemManaged
               api_name: includeSystemManaged

--- a/tools/codegen/models/service_account.yaml
+++ b/tools/codegen/models/service_account.yaml
@@ -337,8 +337,20 @@ data_sources:
               present_in_any_response: false
               request_only_required_on_create: false
     plural:
-        description: Returns all Service Accounts for the specified Organization.
+        description: Returns all Service Accounts for the specified Organization. By default, system-managed Service Accounts are excluded. Set `includeSystemManaged=true` to include them.
         attributes:
+            - bool:
+                default: false
+              description: Flag that indicates whether system-managed Service Accounts (such as those used for MCP ingress/egress integrations) are included in the response. When false, only user-managed Service Accounts are returned.
+              computed_optional_required: computed_optional
+              tf_schema_name: include_system_managed
+              tf_model_name: IncludeSystemManaged
+              api_name: includeSystemManaged
+              req_body_usage: omit_always
+              sensitive: false
+              create_only: false
+              present_in_any_response: false
+              request_only_required_on_create: false
             - string: {}
               description: Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
               computed_optional_required: required


### PR DESCRIPTION
## Description

Updated autogen to set optional+computed query params to optional only, these attributes are never returned by the API so the spec defining a default should not promote them to computed.
Regenerated service account resources to add `include_system_managed`.
No other autogen resource is impacted by the change.

Keeping this change separated from the MCP Config dev branch to avoid mixing codegen changes with new MCP resources.

Testing: 
* Will add/update acc tests in the MCP Config dev branch - We need an MCP config to verify its service account is returned by the SA plural DS when `include_system_managed = true`.
* Manually verified that the query param works as expected for both datasources.

Link to any related issue(s): CLOUDP-433211

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
