### PR TITLE
doc: Document Atlas Infinite Database support in advanced_cluster overview

### DIFF
--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -51,6 +51,38 @@ resource "mongodbatlas_advanced_cluster" "this" {
 }
 ```
 
+### Example Atlas Infinite Database cluster with a per-shard data-size limit
+
+```terraform
+resource "mongodbatlas_advanced_cluster" "infinite" {
+  project_id       = "PROJECT ID"
+  name             = "NAME OF CLUSTER"
+  cluster_type     = "REPLICASET"
+  database_edition = "INFINITE"
+
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          provider_name = "AWS"
+          priority      = 7
+          region_name   = "US_EAST_1"
+          electable_specs = {
+            instance_size = "M10"
+            node_count    = 2
+          }
+          auto_scaling = {
+            storage_config = {
+              shard_size_limit_gb = 1024 # Optional. Omit storage_config to use the Atlas default limit.
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ### Example using effective fields with auto-scaling
 
 ```terraform

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -4,7 +4,9 @@ subcategory: "Clusters"
 
 # Resource: mongodbatlas_advanced_cluster
 
-`mongodbatlas_advanced_cluster` provides an Advanced Cluster resource. The resource lets you create, edit and delete advanced clusters.
+`mongodbatlas_advanced_cluster` provides an Advanced Cluster resource. The resource lets you create, edit and delete advanced clusters, including clusters that use the Atlas Infinite Database.
+
+To create an Atlas Infinite Database cluster, set the `database_edition` attribute to `INFINITE`. For more information, including supported features and limitations, see the [Atlas Infinite Database documentation](https://www.mongodb.com/docs/atlas/infinite/atlas-infinite-landing/).
 
 We recommend all MongoDB Atlas Terraform users start with the [`Official MongoDB Atlas Cluster Module`](https://registry.terraform.io/modules/terraform-mongodbatlas-modules/cluster/mongodbatlas/latest). This module simplifies cluster deployment and implements MongoDB Atlas best practices by default.
 


### PR DESCRIPTION
## Description

Documents Atlas Infinite Database support for the `mongodbatlas_advanced_cluster` resource:

- States in the resource overview that `mongodbatlas_advanced_cluster` can create clusters that use the Atlas Infinite Database.
- Links the overview to the official Atlas Infinite Database documentation.
- Adds an "Example Atlas Infinite Database cluster with a per-shard data-size limit" example showing `database_edition = "INFINITE"` and `storage_config.shard_size_limit_gb`.

Closes DOCSP-64091.

## Notes

- **`node_count = 2`**: The example uses `node_count = 2` (not `3`) for the INFINITE cluster. Verified against cloud-dev — `node_count = 3` returns `HTTP 400 INVALID_ATTRIBUTE` ("Invalid attribute number of electable nodes"). This matches Leo's acceptance test but differs from the example currently in #4697, which uses `3`.
- **Docs link timing**: The linked page (`/docs/atlas/infinite/atlas-infinite-landing/`) is the final URL, but it is not yet published — it ships with DOCSP-60728. The URL is correct and will resolve when that work publishes.

## Type of change

- [x] Documentation fix/enhancement
