### PR TITLE
Treat missing Atlas database user as successful delete

### DIFF
--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -364,12 +364,16 @@ func (r *databaseUserRS) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	connV2 := r.Client.AtlasV2
-	_, err := connV2.DatabaseUsersAPI.DeleteDatabaseUser(
+	httpResponse, err := connV2.DatabaseUsersAPI.DeleteDatabaseUser(
 		ctx,
 		state.ProjectID.ValueString(),
 		state.AuthDatabaseName.ValueString(),
 		state.Username.ValueString()).Execute()
 	if err != nil {
+		// Already deleted on the Atlas side: desired end state is reached.
+		if validate.StatusNotFound(httpResponse) {
+			return
+		}
 		resp.Diagnostics.AddError("error when destroying the database user resource", err.Error())
 		return
 	}


### PR DESCRIPTION
## Summary
When destroy calls Delete for mongodbatlas_database_user and Atlas returns 404 USER_NOT_FOUND, treat that as success so apply can finish. This matches Read behavior and sibling resources such as teamprojectassignment.

Closes #4656

## Test plan
1. Unit tests for the databaseuser package passed locally
2. Reviewers can confirm Delete ignores StatusNotFound the same way as teamprojectassignment