### PR TITLE
refactor: Adds SDKv2 raw config helpers

### DIFF
--- a/contributing/development-best-practices.md
+++ b/contributing/development-best-practices.md
@@ -85,7 +85,7 @@ Unlike the Atlas SDK getters in the previous section, this package reads Terrafo
 [`internal/common/sdkv2config`](../internal/common/sdkv2config) reads [`GetRawConfig`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetRawConfig) and returns Terraform tri-state values: null (unset in HCL), unknown (expression not yet resolved), or set. Pass `*schema.ResourceData` or `*schema.ResourceDiff`. Do not call `GetRawConfig` at the call site. Empty string, `false`, and `0` are set values, not null.
 
 - **`String` / `Bool` / `Int64`**: Return a value with `IsNull`, `IsUnknown`, `HasChange`, and the value accessor. Pick the request policy with a named predicate instead of a hand-composed condition:
-  - **`Set`**: A known value set in HCL. Use for Optional+Computed attributes whose omitted value stays out of the request.
+  - **`Set`**: True only for a known value set in HCL. Null (unset or removed) and unknown both return false, so the request omits the attribute and an unresolved expression never fabricates a value. Use for Optional+Computed attributes, or for an API-validated field where an explicit `""` in HCL is still sent.
   - **`SetOrRemoved`**: Set in HCL or removed from it (send the zero value). Use for Optional-only attributes whose value is always sent; a bare null skip leaves the server value in place and drifts.
   - **`Removed`**: Dropped from HCL while state still holds a value. Use when a PATCH must send explicit API nil only after the user removed the field, as in `operations_contact`.
 - **`CollectionEmpty`**: True when the named list or set is null, unknown, or length 0. False when the resource raw-config object itself is null or unknown; that is not an HCL omit.

--- a/contributing/development-best-practices.md
+++ b/contributing/development-best-practices.md
@@ -82,9 +82,12 @@ In general, prefer SDK getters over direct field access, e.g. `project.GetTags()
 
 Unlike the Atlas SDK getters in the previous section, this package reads Terraform HCL. SDKv2 `Get` / `GetOk` / `GetOkExists` read plan or state. They cannot tell an unset attribute from a zero value (`""`, `false`, `0`). Optional+Computed `Get()` also still returns leftover state after the user drops the attribute from HCL.
 
-[`internal/common/sdkv2config`](../internal/common/sdkv2config) reads [`GetRawConfig`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetRawConfig) and returns TPF-like values: null, unknown, or a set value. Pass `*schema.ResourceData` or `*schema.ResourceDiff`. Do not call `GetRawConfig` at the call site. Empty string, `false`, and `0` are set values, not null.
+[`internal/common/sdkv2config`](../internal/common/sdkv2config) reads [`GetRawConfig`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetRawConfig) and returns Terraform tri-state values: null (unset in HCL), unknown (expression not yet resolved), or set. Pass `*schema.ResourceData` or `*schema.ResourceDiff`. Do not call `GetRawConfig` at the call site. Empty string, `false`, and `0` are set values, not null.
 
-- **`String` / `Bool` / `Int64`**: Return typed null, unknown, or a set value. `HasChange` is `ResourceData.HasChange` for that attribute. Combine `IsNull` and `HasChange` when a PATCH must send explicit API nil only after the user cleared the field. For an Optional-only attribute whose value is always sent, use `!IsNull() || HasChange()` so removing the attribute from HCL still sends the zero value; a bare `!IsNull()` skip leaves the server value in place and drifts.
+- **`String` / `Bool` / `Int64`**: Return a value with `IsNull`, `IsUnknown`, `HasChange`, and the value accessor. Pick the request policy with a named predicate instead of a hand-composed condition:
+  - **`Set`**: A known value set in HCL. Use for Optional+Computed attributes whose omitted value stays out of the request.
+  - **`SetOrRemoved`**: Set in HCL or removed from it (send the zero value). Use for Optional-only attributes whose value is always sent; a bare null skip leaves the server value in place and drifts.
+  - **`Removed`**: Dropped from HCL while state still holds a value. Use when a PATCH must send explicit API nil only after the user removed the field, as in `operations_contact`.
 - **`CollectionEmpty`**: True when the named list or set is null, unknown, or length 0. False when the resource raw-config object itself is null or unknown; that is not an HCL omit.
 - **`NestedCollectionLen`**: Known length of `list[index].attr` in raw config. Returns 0 when omitted, unknown, or empty. Use it when `Get()` leftovers from Optional+Computed nested sets must not count as user-set.
 

--- a/contributing/development-best-practices.md
+++ b/contributing/development-best-practices.md
@@ -14,6 +14,7 @@ This document is the single source of truth for Terraform provider development b
   - [Collections: Sets vs Lists](#collections-sets-vs-lists)
   - [Validation](#validation)
   - [SDK Getters](#sdk-getters)
+  - [SDKv2 raw config (`sdkv2config`)](#sdkv2-raw-config-sdkv2config)
 - [Resource and Data Source Design](#resource-and-data-source-design)
   - [Pagination in Plural Data Sources](#pagination-in-plural-data-sources)
   - [Auto-Generated Data Source Schemas](#auto-generated-data-source-schemas)
@@ -76,6 +77,22 @@ In general, prefer to skip validation in the Terraform provider and keep validat
 ### SDK Getters
 
 In general, prefer SDK getters over direct field access, e.g. `project.GetTags()` (see [PR #2135 discussion](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2135/files#r1560682050)).
+
+### SDKv2 raw config (`sdkv2config`)
+
+Unlike the Atlas SDK getters in the previous section, this package reads Terraform HCL. SDKv2 `Get` / `GetOk` / `GetOkExists` read plan or state. They cannot tell an unset attribute from a zero value (`""`, `false`, `0`). Optional+Computed `Get()` also still returns leftover state after the user drops the attribute from HCL.
+
+[`internal/common/sdkv2config`](../internal/common/sdkv2config) reads [`GetRawConfig`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetRawConfig) and returns TPF-like values: null, unknown, or a set value. Pass `*schema.ResourceData` or `*schema.ResourceDiff`. Do not call `GetRawConfig` at the call site. Empty string, `false`, and `0` are set values, not null.
+
+- **`String` / `Bool` / `Int64`**: Return typed null, unknown, or a set value. `HasChange` is `ResourceData.HasChange` for that attribute. Combine `IsNull` and `HasChange` when a PATCH must send explicit API nil only after the user cleared the field.
+- **`CollectionEmpty`**: True when the named list or set is null, unknown, or length 0. False when the resource raw-config object itself is null or unknown; that is not an HCL omit.
+- **`NestedCollectionLen`**: Known length of `list[index].attr` in raw config. Returns 0 when omitted, unknown, or empty. Use it when `Get()` leftovers from Optional+Computed nested sets must not count as user-set.
+
+`IsUnknown()` and `IsNull()` are different. A value like `project_id = mongodbatlas_project.this.id` is unknown at plan because `id` is computed until Terraform creates that project. Check `IsUnknown()` separately and skip the PATCH field until apply. Do not send explicit nil or `""` for that plan.
+
+Examples: [`mongodbatlas_cloud_backup_schedule`](../internal/service/cloudbackupschedule) and `operations_contact` on [`mongodbatlas_organization`](../internal/service/organization/resource_organization.go).
+
+`GetRawPlan` / `GetRawState`, `SetNew` wrappers, and nested primitives such as `mongodbatlas_cluster` `advanced_configuration.0.*` stay out of this package until a caller needs them.
 
 ## Resource and Data Source Design
 
@@ -234,4 +251,3 @@ An example implementation can be found in:
 - `internal/serviceapi/orgserviceaccountsecretapi/resource_custom_hooks.go`
 
 In this example, a custom `PostReadAPICall` implementation filters the raw API response to return only the specific secret matching the Terraform resource’s ID, mimicking the read response of a single secret which is not available in the API.
-

--- a/contributing/development-best-practices.md
+++ b/contributing/development-best-practices.md
@@ -84,7 +84,7 @@ Unlike the Atlas SDK getters in the previous section, this package reads Terrafo
 
 [`internal/common/sdkv2config`](../internal/common/sdkv2config) reads [`GetRawConfig`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetRawConfig) and returns TPF-like values: null, unknown, or a set value. Pass `*schema.ResourceData` or `*schema.ResourceDiff`. Do not call `GetRawConfig` at the call site. Empty string, `false`, and `0` are set values, not null.
 
-- **`String` / `Bool` / `Int64`**: Return typed null, unknown, or a set value. `HasChange` is `ResourceData.HasChange` for that attribute. Combine `IsNull` and `HasChange` when a PATCH must send explicit API nil only after the user cleared the field.
+- **`String` / `Bool` / `Int64`**: Return typed null, unknown, or a set value. `HasChange` is `ResourceData.HasChange` for that attribute. Combine `IsNull` and `HasChange` when a PATCH must send explicit API nil only after the user cleared the field. For an Optional-only attribute whose value is always sent, use `!IsNull() || HasChange()` so removing the attribute from HCL still sends the zero value; a bare `!IsNull()` skip leaves the server value in place and drifts.
 - **`CollectionEmpty`**: True when the named list or set is null, unknown, or length 0. False when the resource raw-config object itself is null or unknown; that is not an HCL omit.
 - **`NestedCollectionLen`**: Known length of `list[index].attr` in raw config. Returns 0 when omitted, unknown, or empty. Use it when `Get()` leftovers from Optional+Computed nested sets must not count as user-set.
 

--- a/internal/common/sdkv2config/sdkv2config.go
+++ b/internal/common/sdkv2config/sdkv2config.go
@@ -1,90 +1,121 @@
-// Package sdkv2config reads Terraform HCL from SDKv2 GetRawConfig as TPF-like values.
-// Use it when Get/GetOk/GetOkExists cannot tell unset from a zero value, or when
-// Optional+Computed Get still carries prior state.
+// Package sdkv2config reads Terraform HCL from SDKv2 GetRawConfig as Terraform
+// tri-state values: null (unset in HCL), unknown (expression not yet resolved),
+// or set. Use it when Get/GetOk/GetOkExists cannot tell unset from a zero value,
+// or when Optional+Computed Get still carries prior state.
 package sdkv2config
 
 import (
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// resourceView is satisfied by *schema.ResourceData and *schema.ResourceDiff.
 type resourceView interface {
 	GetRawConfig() cty.Value
 	HasChange(key string) bool
 }
 
-type hasChange bool
+// state classifies one attribute read from raw config.
+type state struct {
+	null, unknown, changed bool
+}
+
+// IsNull reports whether the attribute is unset in HCL.
+func (s state) IsNull() bool { return s.null }
+
+// IsUnknown reports whether the config expression is not yet resolved.
+// Apply-time config is usually resolved, but the ApplyResourceChange contract
+// permits unknown values, so request code must not fabricate a value.
+func (s state) IsUnknown() bool { return s.unknown }
 
 // HasChange reports ResourceData/ResourceDiff.HasChange for this attribute.
-func (h hasChange) HasChange() bool { return bool(h) }
+func (s state) HasChange() bool { return s.changed }
 
-// StringValue embeds TPF types.String so IsNull, IsUnknown, and ValueString promote.
+// Set reports a known value set in HCL. Use for Optional+Computed attributes:
+// an omitted or unknown value is left out of the request.
+func (s state) Set() bool { return !s.unknown && !s.null }
+
+// Removed reports an attribute dropped from HCL while state still holds a
+// value. Use to send an explicit API nil for the cleared field.
+func (s state) Removed() bool { return s.null && s.changed }
+
+// SetOrRemoved reports whether a request should carry the attribute's value:
+// set in HCL, or removed from it (send the zero value). Use for Optional-only
+// attributes whose value is always sent; skipping a removal leaves the server
+// value in place and drifts. Unknown is skipped so no value is fabricated.
+func (s state) SetOrRemoved() bool { return !s.unknown && (!s.null || s.changed) }
+
+// StringValue is a raw-config string: null, unknown, or set.
 type StringValue struct {
-	types.String
-	hasChange
+	value string
+	state
 }
 
-// BoolValue embeds TPF types.Bool so IsNull, IsUnknown, and ValueBool promote.
+// ValueString returns the HCL value; the Go zero value when null or unknown.
+func (v StringValue) ValueString() string { return v.value }
+
+// BoolValue is a raw-config bool: null, unknown, or set.
 type BoolValue struct {
-	types.Bool
-	hasChange
+	state
+	value bool
 }
 
-// Int64Value embeds TPF types.Int64 so IsNull, IsUnknown, and ValueInt64 promote.
+// ValueBool returns the HCL value; false when null or unknown.
+func (v BoolValue) ValueBool() bool { return v.value }
+
+// Int64Value is a raw-config int: null, unknown, or set.
 type Int64Value struct {
-	types.Int64
-	hasChange
+	state
+	value int64
 }
+
+// ValueInt64 returns the HCL value; 0 when null or unknown.
+func (v Int64Value) ValueInt64() int64 { return v.value }
 
 // String reads name from raw config. Missing, JSON null, and wrong type are null.
 // Empty string is a set value. Unknown stays unknown.
 func String(d resourceView, name string) StringValue {
-	v := StringValue{hasChange: hasChange(d.HasChange(name))}
+	v := StringValue{state: state{changed: d.HasChange(name)}}
 	raw := attrAt(d.GetRawConfig(), name)
-	if !raw.IsKnown() {
-		v.String = types.StringUnknown()
-		return v
+	switch {
+	case !raw.IsKnown():
+		v.unknown = true
+	case raw.IsNull() || raw.Type() != cty.String:
+		v.null = true
+	default:
+		v.value = raw.AsString()
 	}
-	if raw.IsNull() || raw.Type() != cty.String {
-		v.String = types.StringNull()
-		return v
-	}
-	v.String = types.StringValue(raw.AsString())
 	return v
 }
 
 // Bool reads name from raw config. Missing, JSON null, and wrong type are null.
-// false is a set value. ValueBool on null is false, so null+changed PATCHes false.
+// false is a set value. ValueBool on null is false, so a Removed value PATCHes false.
 func Bool(d resourceView, name string) BoolValue {
-	v := BoolValue{hasChange: hasChange(d.HasChange(name))}
+	v := BoolValue{state: state{changed: d.HasChange(name)}}
 	raw := attrAt(d.GetRawConfig(), name)
-	if !raw.IsKnown() {
-		v.Bool = types.BoolUnknown()
-		return v
+	switch {
+	case !raw.IsKnown():
+		v.unknown = true
+	case raw.IsNull() || raw.Type() != cty.Bool:
+		v.null = true
+	default:
+		v.value = raw.True()
 	}
-	if raw.IsNull() || raw.Type() != cty.Bool {
-		v.Bool = types.BoolNull()
-		return v
-	}
-	v.Bool = types.BoolValue(raw.True())
 	return v
 }
 
 // Int64 reads name from raw config. Schema TypeInt is a cty Number.
 // Missing, JSON null, and wrong type are null. 0 is a set value.
 func Int64(d resourceView, name string) Int64Value {
-	v := Int64Value{hasChange: hasChange(d.HasChange(name))}
+	v := Int64Value{state: state{changed: d.HasChange(name)}}
 	raw := attrAt(d.GetRawConfig(), name)
-	if !raw.IsKnown() {
-		v.Int64 = types.Int64Unknown()
-		return v
+	switch {
+	case !raw.IsKnown():
+		v.unknown = true
+	case raw.IsNull() || raw.Type() != cty.Number:
+		v.null = true
+	default:
+		v.value, _ = raw.AsBigFloat().Int64()
 	}
-	if raw.IsNull() || raw.Type() != cty.Number {
-		v.Int64 = types.Int64Null()
-		return v
-	}
-	n, _ := raw.AsBigFloat().Int64()
-	v.Int64 = types.Int64Value(n)
 	return v
 }
 

--- a/internal/common/sdkv2config/sdkv2config.go
+++ b/internal/common/sdkv2config/sdkv2config.go
@@ -1,0 +1,141 @@
+// Package sdkv2config reads Terraform HCL from SDKv2 GetRawConfig as TPF-like values.
+// Use it when Get/GetOk/GetOkExists cannot tell unset from a zero value, or when
+// Optional+Computed Get still carries prior state.
+package sdkv2config
+
+import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type resourceView interface {
+	GetRawConfig() cty.Value
+	HasChange(key string) bool
+}
+
+type hasChange bool
+
+// HasChange reports ResourceData/ResourceDiff.HasChange for this attribute.
+func (h hasChange) HasChange() bool { return bool(h) }
+
+// StringValue embeds TPF types.String so IsNull, IsUnknown, and ValueString promote.
+type StringValue struct {
+	types.String
+	hasChange
+}
+
+// BoolValue embeds TPF types.Bool so IsNull, IsUnknown, and ValueBool promote.
+type BoolValue struct {
+	types.Bool
+	hasChange
+}
+
+// Int64Value embeds TPF types.Int64 so IsNull, IsUnknown, and ValueInt64 promote.
+type Int64Value struct {
+	types.Int64
+	hasChange
+}
+
+// String reads name from raw config. Missing, JSON null, and wrong type are null.
+// Empty string is a set value. Unknown stays unknown.
+func String(d resourceView, name string) StringValue {
+	v := StringValue{hasChange: hasChange(d.HasChange(name))}
+	raw := attrAt(d.GetRawConfig(), name)
+	if !raw.IsKnown() {
+		v.String = types.StringUnknown()
+		return v
+	}
+	if raw.IsNull() || raw.Type() != cty.String {
+		v.String = types.StringNull()
+		return v
+	}
+	v.String = types.StringValue(raw.AsString())
+	return v
+}
+
+// Bool reads name from raw config. Missing, JSON null, and wrong type are null.
+// false is a set value. ValueBool on null is false, so null+changed PATCHes false.
+func Bool(d resourceView, name string) BoolValue {
+	v := BoolValue{hasChange: hasChange(d.HasChange(name))}
+	raw := attrAt(d.GetRawConfig(), name)
+	if !raw.IsKnown() {
+		v.Bool = types.BoolUnknown()
+		return v
+	}
+	if raw.IsNull() || raw.Type() != cty.Bool {
+		v.Bool = types.BoolNull()
+		return v
+	}
+	v.Bool = types.BoolValue(raw.True())
+	return v
+}
+
+// Int64 reads name from raw config. Schema TypeInt is a cty Number.
+// Missing, JSON null, and wrong type are null. 0 is a set value.
+func Int64(d resourceView, name string) Int64Value {
+	v := Int64Value{hasChange: hasChange(d.HasChange(name))}
+	raw := attrAt(d.GetRawConfig(), name)
+	if !raw.IsKnown() {
+		v.Int64 = types.Int64Unknown()
+		return v
+	}
+	if raw.IsNull() || raw.Type() != cty.Number {
+		v.Int64 = types.Int64Null()
+		return v
+	}
+	n, _ := raw.AsBigFloat().Int64()
+	v.Int64 = types.Int64Value(n)
+	return v
+}
+
+// CollectionEmpty is true when the named list or set is not a known non-empty collection:
+// attr null, attr unknown, or known length 0. If the resource raw-config object is null or
+// unknown, it returns false: the attribute cannot be read, so this is not an HCL omit.
+func CollectionEmpty(d resourceView, name string) bool {
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return false
+	}
+	return knownCollectionLen(attrAt(raw, name)) == 0
+}
+
+// NestedCollectionLen is the known length of list[index].attr in raw config.
+// Parent list must be a list or tuple. Nested sets are measured with LengthInt only.
+// Returns 0 when the list is omitted, unknown, out of range, or the nested attr is
+// omitted, unknown, or empty.
+func NestedCollectionLen(d resourceView, list string, index int, attr string) int {
+	listVal := attrAt(d.GetRawConfig(), list)
+	if listVal.IsNull() || !listVal.IsKnown() {
+		return 0
+	}
+	ty := listVal.Type()
+	if !ty.IsListType() && !ty.IsTupleType() {
+		return 0
+	}
+	if index < 0 || index >= listVal.LengthInt() {
+		return 0
+	}
+	return knownCollectionLen(attrAt(listVal.Index(cty.NumberIntVal(int64(index))), attr))
+}
+
+// attrAt walks one object attribute. It returns null on a missing name, null root, or
+// non-object, and unknown when the parent is unknown. It does not panic.
+func attrAt(raw cty.Value, name string) cty.Value {
+	if !raw.IsKnown() {
+		return cty.UnknownVal(cty.DynamicPseudoType)
+	}
+	if raw.IsNull() || !raw.Type().IsObjectType() {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+	if _, ok := raw.Type().AttributeTypes()[name]; !ok {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+	return raw.GetAttr(name)
+}
+
+func knownCollectionLen(v cty.Value) int {
+	if v.IsNull() || !v.IsKnown() || !v.CanIterateElements() {
+		return 0
+	}
+	return v.LengthInt()
+}

--- a/internal/common/sdkv2config/sdkv2config.go
+++ b/internal/common/sdkv2config/sdkv2config.go
@@ -5,6 +5,8 @@
 package sdkv2config
 
 import (
+	"math/big"
+
 	"github.com/hashicorp/go-cty/cty"
 )
 
@@ -105,6 +107,8 @@ func Bool(d resourceView, name string) BoolValue {
 
 // Int64 reads name from raw config. Schema TypeInt is a cty Number.
 // Missing, JSON null, and wrong type are null. 0 is a set value.
+// A number that is not an exact int64 (fractional or out of range) is unknown,
+// so no predicate can send a truncated or clamped value.
 func Int64(d resourceView, name string) Int64Value {
 	v := Int64Value{state: state{changed: d.HasChange(name)}}
 	raw := attrAt(d.GetRawConfig(), name)
@@ -114,7 +118,11 @@ func Int64(d resourceView, name string) Int64Value {
 	case raw.IsNull() || raw.Type() != cty.Number:
 		v.null = true
 	default:
-		v.value, _ = raw.AsBigFloat().Int64()
+		if n, acc := raw.AsBigFloat().Int64(); acc == big.Exact {
+			v.value = n
+		} else {
+			v.unknown = true
+		}
 	}
 	return v
 }

--- a/internal/common/sdkv2config/sdkv2config_test.go
+++ b/internal/common/sdkv2config/sdkv2config_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -35,69 +34,73 @@ func obj(attrs map[string]cty.Value) cty.Value {
 func TestString(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name    string
 		raw     cty.Value
-		want    types.String
+		name    string
+		want    string
 		changed []string
+		null    bool
+		unknown bool
 	}{
 		{
 			name: "missing attr",
 			raw:  obj(map[string]cty.Value{"other": cty.StringVal("x")}),
-			want: types.StringNull(),
+			null: true,
 		},
 		{
 			name: "json null",
 			raw:  obj(map[string]cty.Value{"operations_contact": cty.NullVal(cty.String)}),
-			want: types.StringNull(),
+			null: true,
 		},
 		{
-			name: "unknown",
-			raw:  obj(map[string]cty.Value{"operations_contact": cty.UnknownVal(cty.String)}),
-			want: types.StringUnknown(),
+			name:    "json null and HasChange is Removed",
+			raw:     obj(map[string]cty.Value{"operations_contact": cty.NullVal(cty.String)}),
+			null:    true,
+			changed: []string{"operations_contact"},
+		},
+		{
+			name:    "unknown",
+			raw:     obj(map[string]cty.Value{"operations_contact": cty.UnknownVal(cty.String)}),
+			unknown: true,
 		},
 		{
 			name: "empty string is a value",
 			raw:  obj(map[string]cty.Value{"operations_contact": cty.StringVal("")}),
-			want: types.StringValue(""),
 		},
 		{
 			name: "set string",
 			raw:  obj(map[string]cty.Value{"operations_contact": cty.StringVal("a@b.com")}),
-			want: types.StringValue("a@b.com"),
+			want: "a@b.com",
 		},
 		{
 			name: "wrong type",
 			raw:  obj(map[string]cty.Value{"operations_contact": cty.True}),
-			want: types.StringNull(),
+			null: true,
 		},
 		{
-			name:    "null and HasChange",
-			raw:     obj(map[string]cty.Value{"operations_contact": cty.NullVal(cty.String)}),
-			want:    types.StringNull(),
-			changed: []string{"operations_contact"},
-		},
-		{
-			name: "unknown parent yields unknown",
-			raw:  cty.UnknownVal(cty.EmptyObject),
-			want: types.StringUnknown(),
+			name:    "unknown parent yields unknown",
+			raw:     cty.UnknownVal(cty.EmptyObject),
+			unknown: true,
 		},
 		{
 			name: "null parent yields null",
 			raw:  cty.NullVal(cty.EmptyObject),
-			want: types.StringNull(),
+			null: true,
 		},
 		{
 			name: "non-object parent yields null",
 			raw:  cty.StringVal("nope"),
-			want: types.StringNull(),
+			null: true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := sdkv2config.String(view(tc.raw, tc.changed...), "operations_contact")
-			assertEqualString(t, tc.want, got)
+			assert.Equal(t, tc.null, got.IsNull())
+			assert.Equal(t, tc.unknown, got.IsUnknown())
 			assert.Equal(t, len(tc.changed) > 0, got.HasChange())
+			assert.Equal(t, tc.want, got.ValueString())
+			assert.Equal(t, tc.null && len(tc.changed) > 0, got.Removed())
 		})
 	}
 }
@@ -108,53 +111,63 @@ func TestBool(t *testing.T) {
 		raw     cty.Value
 		name    string
 		changed []string
-		want    types.Bool
+		null    bool
+		unknown bool
 		wantVal bool
 	}{
 		{
 			name: "missing attr",
 			raw:  obj(map[string]cty.Value{"other": cty.True}),
-			want: types.BoolNull(),
+			null: true,
 		},
 		{
-			name: "unknown",
-			raw:  obj(map[string]cty.Value{"auto_export_enabled": cty.UnknownVal(cty.Bool)}),
-			want: types.BoolUnknown(),
+			name: "json null",
+			raw:  obj(map[string]cty.Value{"auto_export_enabled": cty.NullVal(cty.Bool)}),
+			null: true,
 		},
 		{
-			name:    "false is a value",
-			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.False}),
-			want:    types.BoolValue(false),
-			wantVal: false,
+			name:    "json null and changed PATCHes false via ValueBool",
+			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.NullVal(cty.Bool)}),
+			null:    true,
+			changed: []string{"auto_export_enabled"},
+		},
+		{
+			name:    "unknown",
+			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.UnknownVal(cty.Bool)}),
+			unknown: true,
+		},
+		{
+			name: "false is a value",
+			raw:  obj(map[string]cty.Value{"auto_export_enabled": cty.False}),
 		},
 		{
 			name:    "true",
 			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.True}),
-			want:    types.BoolValue(true),
 			wantVal: true,
 		},
 		{
-			name:    "null and changed PATCHes false via ValueBool",
-			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.NullVal(cty.Bool)}),
-			want:    types.BoolNull(),
+			name:    "set and changed",
+			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.True}),
+			wantVal: true,
 			changed: []string{"auto_export_enabled"},
-			wantVal: false,
 		},
 		{
 			name: "wrong type",
 			raw:  obj(map[string]cty.Value{"auto_export_enabled": cty.StringVal("true")}),
-			want: types.BoolNull(),
+			null: true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := sdkv2config.Bool(view(tc.raw, tc.changed...), "auto_export_enabled")
-			assertEqualBool(t, tc.want, got)
+			assert.Equal(t, tc.null, got.IsNull())
+			assert.Equal(t, tc.unknown, got.IsUnknown())
 			assert.Equal(t, len(tc.changed) > 0, got.HasChange())
-			if !got.IsUnknown() {
-				assert.Equal(t, tc.wantVal, got.ValueBool())
-			}
+			assert.Equal(t, tc.wantVal, got.ValueBool())
+			assert.Equal(t, !tc.unknown && !tc.null, got.Set())
+			assert.Equal(t, tc.null && len(tc.changed) > 0, got.Removed())
+			assert.Equal(t, !tc.unknown && (!tc.null || len(tc.changed) > 0), got.SetOrRemoved())
 		})
 	}
 }
@@ -164,46 +177,44 @@ func TestInt64(t *testing.T) {
 	tests := []struct {
 		raw     cty.Value
 		name    string
-		want    types.Int64
 		wantVal int64
+		null    bool
+		unknown bool
 	}{
 		{
 			name: "missing attr",
 			raw:  obj(map[string]cty.Value{"other": cty.NumberIntVal(1)}),
-			want: types.Int64Null(),
+			null: true,
 		},
 		{
-			name: "unknown omitted Optional+Computed",
-			raw:  obj(map[string]cty.Value{"reference_hour_of_day": cty.UnknownVal(cty.Number)}),
-			want: types.Int64Unknown(),
+			name:    "unknown omitted Optional+Computed",
+			raw:     obj(map[string]cty.Value{"reference_hour_of_day": cty.UnknownVal(cty.Number)}),
+			unknown: true,
 		},
 		{
-			name:    "zero is a value",
-			raw:     obj(map[string]cty.Value{"reference_hour_of_day": cty.NumberIntVal(0)}),
-			want:    types.Int64Value(0),
-			wantVal: 0,
+			name: "zero is a value",
+			raw:  obj(map[string]cty.Value{"reference_hour_of_day": cty.NumberIntVal(0)}),
 		},
 		{
 			name:    "set int",
 			raw:     obj(map[string]cty.Value{"reference_hour_of_day": cty.NumberIntVal(7)}),
-			want:    types.Int64Value(7),
 			wantVal: 7,
 		},
 		{
 			name: "wrong type",
 			raw:  obj(map[string]cty.Value{"reference_hour_of_day": cty.StringVal("7")}),
-			want: types.Int64Null(),
+			null: true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := sdkv2config.Int64(view(tc.raw), "reference_hour_of_day")
-			assertEqualInt64(t, tc.want, got)
+			assert.Equal(t, tc.null, got.IsNull())
+			assert.Equal(t, tc.unknown, got.IsUnknown())
 			assert.False(t, got.HasChange())
-			if !got.IsNull() && !got.IsUnknown() {
-				assert.Equal(t, tc.wantVal, got.ValueInt64())
-			}
+			assert.Equal(t, tc.wantVal, got.ValueInt64())
+			assert.Equal(t, !tc.unknown && !tc.null, got.Set())
 		})
 	}
 }
@@ -366,31 +377,4 @@ func TestStringDoesNotPanicOnMissingAttr(t *testing.T) {
 	require.NotPanics(t, func() {
 		_ = sdkv2config.String(view(obj(map[string]cty.Value{"x": cty.StringVal("y")})), "missing")
 	})
-}
-
-func assertEqualString(t *testing.T, want types.String, got sdkv2config.StringValue) {
-	t.Helper()
-	assert.Equal(t, want.IsNull(), got.IsNull())
-	assert.Equal(t, want.IsUnknown(), got.IsUnknown())
-	if !want.IsNull() && !want.IsUnknown() {
-		assert.Equal(t, want.ValueString(), got.ValueString())
-	}
-}
-
-func assertEqualBool(t *testing.T, want types.Bool, got sdkv2config.BoolValue) {
-	t.Helper()
-	assert.Equal(t, want.IsNull(), got.IsNull())
-	assert.Equal(t, want.IsUnknown(), got.IsUnknown())
-	if !want.IsNull() && !want.IsUnknown() {
-		assert.Equal(t, want.ValueBool(), got.ValueBool())
-	}
-}
-
-func assertEqualInt64(t *testing.T, want types.Int64, got sdkv2config.Int64Value) {
-	t.Helper()
-	assert.Equal(t, want.IsNull(), got.IsNull())
-	assert.Equal(t, want.IsUnknown(), got.IsUnknown())
-	if !want.IsNull() && !want.IsUnknown() {
-		assert.Equal(t, want.ValueInt64(), got.ValueInt64())
-	}
 }

--- a/internal/common/sdkv2config/sdkv2config_test.go
+++ b/internal/common/sdkv2config/sdkv2config_test.go
@@ -205,6 +205,16 @@ func TestInt64(t *testing.T) {
 			raw:  obj(map[string]cty.Value{"reference_hour_of_day": cty.StringVal("7")}),
 			null: true,
 		},
+		{
+			name:    "fractional number is unknown, not truncated",
+			raw:     obj(map[string]cty.Value{"reference_hour_of_day": cty.NumberFloatVal(1.5)}),
+			unknown: true,
+		},
+		{
+			name:    "out-of-range number is unknown, not clamped",
+			raw:     obj(map[string]cty.Value{"reference_hour_of_day": cty.NumberFloatVal(1e30)}),
+			unknown: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/common/sdkv2config/sdkv2config_test.go
+++ b/internal/common/sdkv2config/sdkv2config_test.go
@@ -1,0 +1,396 @@
+package sdkv2config_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/sdkv2config"
+)
+
+type fakeView struct {
+	raw     cty.Value
+	changes map[string]bool
+}
+
+func (f fakeView) GetRawConfig() cty.Value { return f.raw }
+
+func (f fakeView) HasChange(key string) bool { return f.changes[key] }
+
+func view(raw cty.Value, changed ...string) fakeView {
+	changes := make(map[string]bool, len(changed))
+	for _, name := range changed {
+		changes[name] = true
+	}
+	return fakeView{raw: raw, changes: changes}
+}
+
+func obj(attrs map[string]cty.Value) cty.Value {
+	return cty.ObjectVal(attrs)
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		raw     cty.Value
+		want    types.String
+		changed []string
+	}{
+		{
+			name: "missing attr",
+			raw:  obj(map[string]cty.Value{"other": cty.StringVal("x")}),
+			want: types.StringNull(),
+		},
+		{
+			name: "json null",
+			raw:  obj(map[string]cty.Value{"operations_contact": cty.NullVal(cty.String)}),
+			want: types.StringNull(),
+		},
+		{
+			name: "unknown",
+			raw:  obj(map[string]cty.Value{"operations_contact": cty.UnknownVal(cty.String)}),
+			want: types.StringUnknown(),
+		},
+		{
+			name: "empty string is a value",
+			raw:  obj(map[string]cty.Value{"operations_contact": cty.StringVal("")}),
+			want: types.StringValue(""),
+		},
+		{
+			name: "set string",
+			raw:  obj(map[string]cty.Value{"operations_contact": cty.StringVal("a@b.com")}),
+			want: types.StringValue("a@b.com"),
+		},
+		{
+			name: "wrong type",
+			raw:  obj(map[string]cty.Value{"operations_contact": cty.True}),
+			want: types.StringNull(),
+		},
+		{
+			name:    "null and HasChange",
+			raw:     obj(map[string]cty.Value{"operations_contact": cty.NullVal(cty.String)}),
+			want:    types.StringNull(),
+			changed: []string{"operations_contact"},
+		},
+		{
+			name: "unknown parent yields unknown",
+			raw:  cty.UnknownVal(cty.EmptyObject),
+			want: types.StringUnknown(),
+		},
+		{
+			name: "null parent yields null",
+			raw:  cty.NullVal(cty.EmptyObject),
+			want: types.StringNull(),
+		},
+		{
+			name: "non-object parent yields null",
+			raw:  cty.StringVal("nope"),
+			want: types.StringNull(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sdkv2config.String(view(tc.raw, tc.changed...), "operations_contact")
+			assertEqualString(t, tc.want, got)
+			assert.Equal(t, len(tc.changed) > 0, got.HasChange())
+		})
+	}
+}
+
+func TestBool(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		raw     cty.Value
+		name    string
+		changed []string
+		want    types.Bool
+		wantVal bool
+	}{
+		{
+			name: "missing attr",
+			raw:  obj(map[string]cty.Value{"other": cty.True}),
+			want: types.BoolNull(),
+		},
+		{
+			name: "unknown",
+			raw:  obj(map[string]cty.Value{"auto_export_enabled": cty.UnknownVal(cty.Bool)}),
+			want: types.BoolUnknown(),
+		},
+		{
+			name:    "false is a value",
+			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.False}),
+			want:    types.BoolValue(false),
+			wantVal: false,
+		},
+		{
+			name:    "true",
+			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.True}),
+			want:    types.BoolValue(true),
+			wantVal: true,
+		},
+		{
+			name:    "null and changed PATCHes false via ValueBool",
+			raw:     obj(map[string]cty.Value{"auto_export_enabled": cty.NullVal(cty.Bool)}),
+			want:    types.BoolNull(),
+			changed: []string{"auto_export_enabled"},
+			wantVal: false,
+		},
+		{
+			name: "wrong type",
+			raw:  obj(map[string]cty.Value{"auto_export_enabled": cty.StringVal("true")}),
+			want: types.BoolNull(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sdkv2config.Bool(view(tc.raw, tc.changed...), "auto_export_enabled")
+			assertEqualBool(t, tc.want, got)
+			assert.Equal(t, len(tc.changed) > 0, got.HasChange())
+			if !got.IsUnknown() {
+				assert.Equal(t, tc.wantVal, got.ValueBool())
+			}
+		})
+	}
+}
+
+func TestInt64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		raw     cty.Value
+		name    string
+		want    types.Int64
+		wantVal int64
+	}{
+		{
+			name: "missing attr",
+			raw:  obj(map[string]cty.Value{"other": cty.NumberIntVal(1)}),
+			want: types.Int64Null(),
+		},
+		{
+			name: "unknown omitted Optional+Computed",
+			raw:  obj(map[string]cty.Value{"reference_hour_of_day": cty.UnknownVal(cty.Number)}),
+			want: types.Int64Unknown(),
+		},
+		{
+			name:    "zero is a value",
+			raw:     obj(map[string]cty.Value{"reference_hour_of_day": cty.NumberIntVal(0)}),
+			want:    types.Int64Value(0),
+			wantVal: 0,
+		},
+		{
+			name:    "set int",
+			raw:     obj(map[string]cty.Value{"reference_hour_of_day": cty.NumberIntVal(7)}),
+			want:    types.Int64Value(7),
+			wantVal: 7,
+		},
+		{
+			name: "wrong type",
+			raw:  obj(map[string]cty.Value{"reference_hour_of_day": cty.StringVal("7")}),
+			want: types.Int64Null(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sdkv2config.Int64(view(tc.raw), "reference_hour_of_day")
+			assertEqualInt64(t, tc.want, got)
+			assert.False(t, got.HasChange())
+			if !got.IsNull() && !got.IsUnknown() {
+				assert.Equal(t, tc.wantVal, got.ValueInt64())
+			}
+		})
+	}
+}
+
+func TestCollectionEmpty(t *testing.T) {
+	t.Parallel()
+	listTy := cty.List(cty.EmptyObject)
+	tests := []struct {
+		raw  cty.Value
+		name string
+		want bool
+	}{
+		{
+			name: "null root is not an HCL omit",
+			raw:  cty.NullVal(cty.EmptyObject),
+			want: false,
+		},
+		{
+			name: "unknown root is not an HCL omit",
+			raw:  cty.UnknownVal(cty.EmptyObject),
+			want: false,
+		},
+		{
+			name: "attr null",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.NullVal(listTy)}),
+			want: true,
+		},
+		{
+			name: "attr unknown",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.UnknownVal(listTy)}),
+			want: true,
+		},
+		{
+			name: "length 0",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.ListValEmpty(cty.EmptyObject)}),
+			want: true,
+		},
+		{
+			name: "missing attr",
+			raw:  obj(map[string]cty.Value{"other": cty.ListValEmpty(cty.EmptyObject)}),
+			want: true,
+		},
+		{
+			name: "known length greater than 0",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.ListVal([]cty.Value{cty.EmptyObjectVal})}),
+			want: false,
+		},
+		{
+			name: "empty set",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.SetValEmpty(cty.String)}),
+			want: true,
+		},
+		{
+			name: "non-empty set",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.SetVal([]cty.Value{cty.StringVal("DAILY")})}),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, sdkv2config.CollectionEmpty(view(tc.raw), "copy_settings"))
+		})
+	}
+}
+
+func TestNestedCollectionLen(t *testing.T) {
+	t.Parallel()
+	freqSet := cty.Set(cty.String)
+	entryTy := cty.Object(map[string]cty.Type{"frequencies": freqSet})
+	listTy := cty.List(entryTy)
+
+	entryWith := func(freqs cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{"frequencies": freqs})
+	}
+	listOf := func(entries ...cty.Value) cty.Value {
+		return obj(map[string]cty.Value{"copy_settings": cty.ListVal(entries)})
+	}
+
+	tests := []struct {
+		raw   cty.Value
+		name  string
+		index int
+		want  int
+	}{
+		{
+			name: "omitted list",
+			raw:  obj(map[string]cty.Value{"other": cty.ListValEmpty(entryTy)}),
+			want: 0,
+		},
+		{
+			name: "unknown list",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.UnknownVal(listTy)}),
+			want: 0,
+		},
+		{
+			name: "empty list",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.ListValEmpty(entryTy)}),
+			want: 0,
+		},
+		{
+			name:  "index out of range",
+			raw:   listOf(entryWith(cty.SetVal([]cty.Value{cty.StringVal("DAILY")}))),
+			index: 1,
+			want:  0,
+		},
+		{
+			name: "nested attr omitted",
+			raw:  listOf(cty.EmptyObjectVal),
+			want: 0,
+		},
+		{
+			name: "nested attr unknown",
+			raw:  listOf(entryWith(cty.UnknownVal(freqSet))),
+			want: 0,
+		},
+		{
+			name: "nested attr empty set",
+			raw:  listOf(entryWith(cty.SetValEmpty(cty.String))),
+			want: 0,
+		},
+		{
+			name: "two frequencies",
+			raw:  listOf(entryWith(cty.SetVal([]cty.Value{cty.StringVal("DAILY"), cty.StringVal("WEEKLY")}))),
+			want: 2,
+		},
+		{
+			name:  "second entry",
+			raw:   listOf(entryWith(cty.SetValEmpty(cty.String)), entryWith(cty.SetVal([]cty.Value{cty.StringVal("DAILY")}))),
+			index: 1,
+			want:  1,
+		},
+		{
+			name: "parent is a set so Index is not used",
+			raw:  obj(map[string]cty.Value{"copy_settings": cty.SetVal([]cty.Value{cty.EmptyObjectVal})}),
+			want: 0,
+		},
+		{
+			name: "null root",
+			raw:  cty.NullVal(cty.EmptyObject),
+			want: 0,
+		},
+		{
+			name: "unknown root",
+			raw:  cty.UnknownVal(cty.EmptyObject),
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sdkv2config.NestedCollectionLen(view(tc.raw), "copy_settings", tc.index, "frequencies")
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestStringDoesNotPanicOnMissingAttr(t *testing.T) {
+	t.Parallel()
+	require.NotPanics(t, func() {
+		_ = sdkv2config.String(view(obj(map[string]cty.Value{"x": cty.StringVal("y")})), "missing")
+	})
+}
+
+func assertEqualString(t *testing.T, want types.String, got sdkv2config.StringValue) {
+	t.Helper()
+	assert.Equal(t, want.IsNull(), got.IsNull())
+	assert.Equal(t, want.IsUnknown(), got.IsUnknown())
+	if !want.IsNull() && !want.IsUnknown() {
+		assert.Equal(t, want.ValueString(), got.ValueString())
+	}
+}
+
+func assertEqualBool(t *testing.T, want types.Bool, got sdkv2config.BoolValue) {
+	t.Helper()
+	assert.Equal(t, want.IsNull(), got.IsNull())
+	assert.Equal(t, want.IsUnknown(), got.IsUnknown())
+	if !want.IsNull() && !want.IsUnknown() {
+		assert.Equal(t, want.ValueBool(), got.ValueBool())
+	}
+}
+
+func assertEqualInt64(t *testing.T, want types.Int64, got sdkv2config.Int64Value) {
+	t.Helper()
+	assert.Equal(t, want.IsNull(), got.IsNull())
+	assert.Equal(t, want.IsUnknown(), got.IsUnknown())
+	if !want.IsNull() && !want.IsUnknown() {
+		assert.Equal(t, want.ValueInt64(), got.ValueInt64())
+	}
+}

--- a/internal/service/cloudbackupschedule/customize_diff.go
+++ b/internal/service/cloudbackupschedule/customize_diff.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"maps"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/sdkv2config"
 )
 
 const (
@@ -24,29 +25,14 @@ const (
 // after apply). SetNew only works on the top-level copy_settings list, so we rewrite the whole
 // block: force [] when raw config omits the list, and clear frequency sets when the flag is on.
 func resourceCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ any) error {
-	copySettingsRaw := copySettingsFromRawConfig(d.GetRawConfig())
-	if err := validateCopySettingsModes(d, copySettingsRaw); err != nil {
+	if err := validateCopySettingsModes(d); err != nil {
 		return err
 	}
 	// Optional+Computed would keep last state when HCL omits copy_settings. Force an empty list so delete-on-omit stays.
-	// Do not require Get() length > 0: omitted/unknown config makes Get() empty even though planned state would keep last copies.
-	if copySettingsRawConfigEmpty(copySettingsRaw) {
+	if sdkv2config.CollectionEmpty(d, "copy_settings") {
 		return d.SetNew("copy_settings", []any{})
 	}
 	return clearFrequenciesWhenCopyPolicyEnabled(d)
-}
-
-// copySettingsRawConfigEmpty reports whether HCL omitted copy_settings. Also used at apply time by copySettingsForUpdate.
-func copySettingsRawConfigEmpty(raw cty.Value) bool {
-	// Omitted Optional+Computed nested blocks arrive as unknown (computed from state), not as null.
-	return raw.IsNull() || !raw.IsKnown() || raw.LengthInt() == 0
-}
-
-func copySettingsFromRawConfig(rawConfig cty.Value) cty.Value {
-	if rawConfig.IsNull() || !rawConfig.IsKnown() {
-		return cty.NullVal(cty.DynamicPseudoType)
-	}
-	return rawConfig.GetAttr("copy_settings")
 }
 
 func clearFrequenciesWhenCopyPolicyEnabled(d *schema.ResourceDiff) error {
@@ -81,7 +67,7 @@ func copySettingsWithEmptyFrequencies(copySettings []any) ([]any, bool) {
 	return rewritten, changed
 }
 
-func validateCopySettingsModes(d *schema.ResourceDiff, copySettingsRaw cty.Value) error {
+func validateCopySettingsModes(d *schema.ResourceDiff) error {
 	enabled, _ := d.Get("copy_policy_items_enabled").(bool)
 	updateCopy, _ := d.Get("update_copy_snapshots").(bool)
 	deleteCopy, _ := d.Get("delete_copy_snapshots").(bool)
@@ -104,7 +90,8 @@ func validateCopySettingsModes(d *schema.ResourceDiff, copySettingsRaw cty.Value
 		hasLastN := lastN > 0
 
 		modeCount := 0
-		if copySettingsEntryHasExplicitFrequencies(copySettingsRaw, i) {
+		// Raw config only: d.Get frequencies can still be leftover Optional+Computed state.
+		if sdkv2config.NestedCollectionLen(d, "copy_settings", i, "frequencies") > 0 {
 			modeCount++
 		}
 		if hasItems {
@@ -125,31 +112,6 @@ func validateCopySettingsModes(d *schema.ResourceDiff, copySettingsRaw cty.Value
 		}
 	}
 	return nil
-}
-
-// copySettingsEntryHasExplicitFrequencies reports frequencies the user set in HCL.
-// d.Get("copy_settings") also carries Optional+Computed frequencies from prior state when switching
-// to copy_policy_items or last_number_of_snapshots in one apply; those leftovers are cleared later
-// and must not count as a second mode.
-func copySettingsEntryHasExplicitFrequencies(raw cty.Value, index int) bool {
-	if raw.IsNull() || !raw.IsKnown() || index < 0 || index >= raw.LengthInt() {
-		return false
-	}
-	entry := raw.Index(cty.NumberIntVal(int64(index)))
-	if !entry.Type().IsObjectType() {
-		return false
-	}
-	if _, ok := entry.Type().AttributeTypes()["frequencies"]; !ok {
-		return false
-	}
-	return knownCollectionLen(entry.GetAttr("frequencies")) > 0
-}
-
-func knownCollectionLen(v cty.Value) int {
-	if v.IsNull() || !v.IsKnown() {
-		return 0
-	}
-	return v.LengthInt()
 }
 
 func collectionLen(v any) int {

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -556,10 +556,13 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 		policiesItem = append(policiesItem, *ExpandPolicyItems(v.([]any), Yearly)...)
 	}
 
-	if v := sdkv2config.Bool(d, "auto_export_enabled"); !v.IsNull() && !v.IsUnknown() {
+	// Optional-only can still be assigned an unknown expression. Skip it like master's GetOkExists
+	// did (a NewComputed diff gave ok=false); ValueBool on unknown would silently send false.
+	if v := sdkv2config.Bool(d, "auto_export_enabled"); !v.IsUnknown() && (!v.IsNull() || v.HasChange()) {
 		req.AutoExportEnabled = new(v.ValueBool())
 	}
 
+	// Same unknown guard as auto_export_enabled: preserve master's GetOkExists skip.
 	if v := sdkv2config.Bool(d, "copy_policy_items_enabled"); !v.IsUnknown() && (!v.IsNull() || v.HasChange()) {
 		req.CopyPolicyItemsEnabled = new(v.ValueBool())
 	}

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -556,14 +556,11 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 		policiesItem = append(policiesItem, *ExpandPolicyItems(v.([]any), Yearly)...)
 	}
 
-	// Optional-only can still be assigned an unknown expression. Skip it like master's GetOkExists
-	// did (a NewComputed diff gave ok=false); ValueBool on unknown would silently send false.
-	if v := sdkv2config.Bool(d, "auto_export_enabled"); !v.IsUnknown() && (!v.IsNull() || v.HasChange()) {
+	if v := sdkv2config.Bool(d, "auto_export_enabled"); v.SetOrRemoved() {
 		req.AutoExportEnabled = new(v.ValueBool())
 	}
 
-	// Same unknown guard as auto_export_enabled: preserve master's GetOkExists skip.
-	if v := sdkv2config.Bool(d, "copy_policy_items_enabled"); !v.IsUnknown() && (!v.IsNull() || v.HasChange()) {
+	if v := sdkv2config.Bool(d, "copy_policy_items_enabled"); v.SetOrRemoved() {
 		req.CopyPolicyItemsEnabled = new(v.ValueBool())
 	}
 
@@ -575,13 +572,13 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 		req.UseOrgAndGroupNamesInExportPrefix = new(d.Get("use_org_and_group_names_in_export_prefix").(bool))
 	}
 
-	if v := sdkv2config.Int64(d, "reference_hour_of_day"); !v.IsNull() && !v.IsUnknown() {
+	if v := sdkv2config.Int64(d, "reference_hour_of_day"); v.Set() {
 		req.ReferenceHourOfDay = new(int(v.ValueInt64()))
 	}
-	if v := sdkv2config.Int64(d, "reference_minute_of_hour"); !v.IsNull() && !v.IsUnknown() {
+	if v := sdkv2config.Int64(d, "reference_minute_of_hour"); v.Set() {
 		req.ReferenceMinuteOfHour = new(int(v.ValueInt64()))
 	}
-	if v := sdkv2config.Int64(d, "restore_window_days"); !v.IsNull() && !v.IsUnknown() {
+	if v := sdkv2config.Int64(d, "restore_window_days"); v.Set() {
 		req.RestoreWindowDays = new(int(v.ValueInt64()))
 	}
 

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/sdkv2config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -555,12 +556,12 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 		policiesItem = append(policiesItem, *ExpandPolicyItems(v.([]any), Yearly)...)
 	}
 
-	if v, ok := d.GetOkExists("auto_export_enabled"); ok {
-		req.AutoExportEnabled = new(v.(bool))
+	if v := sdkv2config.Bool(d, "auto_export_enabled"); !v.IsNull() && !v.IsUnknown() {
+		req.AutoExportEnabled = new(v.ValueBool())
 	}
 
-	if _, ok := d.GetOkExists("copy_policy_items_enabled"); ok || d.HasChange("copy_policy_items_enabled") {
-		req.CopyPolicyItemsEnabled = new(d.Get("copy_policy_items_enabled").(bool))
+	if v := sdkv2config.Bool(d, "copy_policy_items_enabled"); !v.IsUnknown() && (!v.IsNull() || v.HasChange()) {
+		req.CopyPolicyItemsEnabled = new(v.ValueBool())
 	}
 
 	if v, ok := d.GetOk("export"); ok {
@@ -571,14 +572,14 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 		req.UseOrgAndGroupNamesInExportPrefix = new(d.Get("use_org_and_group_names_in_export_prefix").(bool))
 	}
 
-	if v, ok := d.GetOkExists("reference_hour_of_day"); ok {
-		req.ReferenceHourOfDay = new(v.(int))
+	if v := sdkv2config.Int64(d, "reference_hour_of_day"); !v.IsNull() && !v.IsUnknown() {
+		req.ReferenceHourOfDay = new(int(v.ValueInt64()))
 	}
-	if v, ok := d.GetOkExists("reference_minute_of_hour"); ok {
-		req.ReferenceMinuteOfHour = new(v.(int))
+	if v := sdkv2config.Int64(d, "reference_minute_of_hour"); !v.IsNull() && !v.IsUnknown() {
+		req.ReferenceMinuteOfHour = new(int(v.ValueInt64()))
 	}
-	if v, ok := d.GetOkExists("restore_window_days"); ok {
-		req.RestoreWindowDays = new(v.(int))
+	if v := sdkv2config.Int64(d, "restore_window_days"); !v.IsNull() && !v.IsUnknown() {
+		req.RestoreWindowDays = new(int(v.ValueInt64()))
 	}
 
 	value := new(d.Get("update_snapshots").(bool))
@@ -614,11 +615,8 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 // CustomizeDiff clears copy_settings in the plan when the block is omitted, but d.Get at apply time
 // still returns the pre-plan entry; raw config is the apply-time source of truth for delete-on-omit.
 func copySettingsForUpdate(d *schema.ResourceData) ([]any, bool) {
-	rawConfig := d.GetRawConfig()
-	if rawConfig.IsKnown() && !rawConfig.IsNull() {
-		if copySettingsRawConfigEmpty(copySettingsFromRawConfig(rawConfig)) {
-			return []any{}, true
-		}
+	if sdkv2config.CollectionEmpty(d, "copy_settings") {
+		return []any{}, true
 	}
 	if d.HasChange("copy_settings") || d.HasChange("copy_settings.#") {
 		_, newVal := d.GetChange("copy_settings")

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -387,11 +387,10 @@ func newOrganizationSettings(d *schema.ResourceData) *admin.OrganizationSettings
 	// The config value is always sent so the API validates it. operationsContact is
 	// cleared with an explicit null when removed from config, and omitted when it was never set.
 	contact := sdkv2config.String(d, "operations_contact")
-	if contact.IsNull() {
-		if contact.HasChange() {
-			settings.SetOperationsContactNil()
-		}
-	} else {
+	switch {
+	case contact.Removed():
+		settings.SetOperationsContactNil()
+	case !contact.IsNull():
 		settings.SetOperationsContact(contact.ValueString())
 	}
 	return settings

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/sdkv2config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -382,15 +383,16 @@ func newOrganizationSettings(d *schema.ResourceData) *admin.OrganizationSettings
 		GenAIFeaturesEnabled:    new(d.Get("gen_ai_features_enabled").(bool)),
 		SecurityContact:         new(d.Get("security_contact").(string)),
 	}
-	// SDKv2 Get() cannot distinguish an explicit empty string from an unset field, GetRawConfig() distinguishes
-	// between the two. The value in config is always sent so the API validates it, `operationsContact`
-	// is cleared with an explicit null when removed from config, and omitted when it was never set.
-	if d.GetRawConfig().GetAttr("operations_contact").IsNull() {
-		if d.HasChange("operations_contact") {
+	// SDKv2 Get() cannot distinguish an explicit empty string from an unset field.
+	// The config value is always sent so the API validates it. operationsContact is
+	// cleared with an explicit null when removed from config, and omitted when it was never set.
+	contact := sdkv2config.String(d, "operations_contact")
+	if contact.IsNull() {
+		if contact.HasChange() {
 			settings.SetOperationsContactNil()
 		}
 	} else {
-		settings.SetOperationsContact(d.Get("operations_contact").(string))
+		settings.SetOperationsContact(contact.ValueString())
 	}
 	return settings
 }

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -390,9 +390,11 @@ func newOrganizationSettings(d *schema.ResourceData) *admin.OrganizationSettings
 	switch {
 	case contact.Removed():
 		settings.SetOperationsContactNil()
-	case !contact.IsNull():
+	case contact.Set():
 		settings.SetOperationsContact(contact.ValueString())
 	}
+	// Unknown config (an expression resolved during apply) matches no case: OperationsContact is
+	// omitempty, so the PATCH omits the field and the server value is left untouched.
 	return settings
 }
 


### PR DESCRIPTION
## Description

Adds `internal/common/sdkv2config` so SDKv2 resources can read HCL from `GetRawConfig` as TPF-like values (null, unknown, or set). `Get` / `GetOk` / `GetOkExists` cannot tell an unset attribute from `""`, `false`, or `0`, and Optional+Computed `Get()` still returns leftover state after the user drops the attribute from HCL.

Call sites no longer call `GetRawConfig` themselves. Helpers return typed wrappers with `IsNull()`, `IsUnknown()`, and `HasChange()`. Callers compose those; there is no `IsNullUnchanged`.

Stacked on [#4693](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4693). Switches that PR's backup-schedule raw-config reads, plus `operations_contact` on `mongodbatlas_organization` from [#4700](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4700) after merging `master`.

Jira: [CLOUDP-388562](https://jira.mongodb.org/browse/CLOUDP-388562)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Internal helper. No changelog: no user-facing schema or behavior change beyond what #4693 and #4700 already ship. Contributing notes live in `development-best-practices.md`.

**Helpers:**

- `String` / `Bool` / `Int64`: typed null, unknown, or set value. Empty string, `false`, and `0` are set, not null.
- `CollectionEmpty`: true when the named list or set is null, unknown, or length 0.
- `NestedCollectionLen`: known length of `list[index].attr` in raw config.

**Call sites:**

- `mongodbatlas_cloud_backup_schedule`: `copy_settings` omit, nested `frequencies` mode checks, and several `GetOkExists` replacements (`auto_export_enabled`, `copy_policy_items_enabled`, reference hour/minute, `restore_window_days`).
- `mongodbatlas_organization` `operations_contact`: send the config value; `SetOperationsContactNil()` only when the attribute is null and `HasChange()`.

Out of scope until a caller needs them: `GetRawPlan` / `GetRawState`, `SetNew` wrappers, nested primitives such as `advanced_configuration.0.*`.

The GitHub diff vs #4693 also includes the merge of `master` (needed so #4700 is in the tree). The helper change itself is commit `96e3c62d8` (6 files).