### PR TITLE
chore: Clear maintenance schedule on wave-only transition

### DIFF
--- a/.changelog/4716.txt
+++ b/.changelog/4716.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/mongodbatlas_maintenance_window: Clears an existing maintenance schedule when transitioning to a wave-only configuration so the resource converges instead of drifting
-```

--- a/.changelog/4716.txt
+++ b/.changelog/4716.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_maintenance_window: Clears an existing maintenance schedule when transitioning to a wave-only configuration so the resource converges instead of drifting
+```

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -285,7 +285,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 	}
 
-	return nil
+	return resourceRead(ctx, d, meta)
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -233,14 +233,16 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	params := new(admin.GroupMaintenanceWindowPreviewUpdateRequest)
-	// TODO(CLOUDP-440317): omitting day_of_week/hour_of_day leaves them out of the PATCH rather than
-	// clearing them, so removing an existing schedule to go wave-only does not converge. Send them as
-	// explicit null (SetDayOfWeekNil/SetHourOfDayNil) once the API honors null unset (CLOUDP-439562).
+
 	if !d.GetRawConfig().GetAttr("day_of_week").IsNull() {
-		params.DayOfWeek = new(d.Get("day_of_week").(int))
+		params.SetDayOfWeek(d.Get("day_of_week").(int))
+	} else if d.HasChange("day_of_week") {
+		params.SetDayOfWeekNil()
 	}
 	if !d.GetRawConfig().GetAttr("hour_of_day").IsNull() {
-		params.HourOfDay = new(d.Get("hour_of_day").(int))
+		params.SetHourOfDay(d.Get("hour_of_day").(int))
+	} else if d.HasChange("hour_of_day") {
+		params.SetHourOfDayNil()
 	}
 
 	if d.HasChange("auto_defer_once_enabled") {

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -234,14 +234,15 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	params := new(admin.GroupMaintenanceWindowPreviewUpdateRequest)
 
+	// Both fields are RequiredWith, gate on either since hour_of_day=0 (midnight) has no diff on its own.
 	if !d.GetRawConfig().GetAttr("day_of_week").IsNull() {
 		params.SetDayOfWeek(d.Get("day_of_week").(int))
-	} else if d.HasChange("day_of_week") {
+	} else if d.HasChange("day_of_week") || d.HasChange("hour_of_day") {
 		params.SetDayOfWeekNil()
 	}
 	if !d.GetRawConfig().GetAttr("hour_of_day").IsNull() {
 		params.SetHourOfDay(d.Get("hour_of_day").(int))
-	} else if d.HasChange("hour_of_day") {
+	} else if d.HasChange("day_of_week") || d.HasChange("hour_of_day") {
 		params.SetHourOfDayNil()
 	}
 

--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -244,6 +244,20 @@ func TestAccConfigRSMaintenanceWindow_waveAssignment(t *testing.T) {
 				),
 			},
 			{
+				// Transition from scheduled to wave-only: removing the schedule must clear it
+				Config: configWaveOnly(orgID, projectName, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "wave_assignment", "2"),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", "0"),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", "0"),
+				),
+			},
+			{
+				Config:   configWaveOnly(orgID, projectName, 2),
+				PlanOnly: true,
+			},
+			{
 				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay, nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),

--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -350,6 +350,50 @@ func configPartialSchedule(orgID, projectName, attr string, value int) string {
 		}`, orgID, projectName, attr, value)
 }
 
+// TestAccConfigRSMaintenanceWindow_waveAssignmentMidnight covers a midnight schedule (hour_of_day = 0)
+// transitioning to wave-only
+func TestAccConfigRSMaintenanceWindow_waveAssignmentMidnight(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		dayOfWeek   = 7
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				// schedule at midnight: hour_of_day = 0 is a valid value AND the TypeInt zero value.
+				Config: configWithWave(orgID, projectName, dayOfWeek, 0, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", "0"),
+					resource.TestCheckResourceAttr(resourceName, "wave_assignment", "1"),
+				),
+			},
+			{
+				// transition to wave-only: must clear the schedule even though hour_of_day=0
+				// matches its TypeInt zero value and produces no standalone diff.
+				Config: configWaveOnly(orgID, projectName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", "0"),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", "0"),
+					resource.TestCheckResourceAttr(resourceName, "wave_assignment", "1"),
+				),
+			},
+			{
+				// the wave-only resource must converge (no phantom drift).
+				Config:   configWaveOnly(orgID, projectName, 1),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func checkBasic(dayOfWeek, hourOfDay int, protectedHours *admin.ProtectedHours) resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{
 		checkExists(resourceName),

--- a/internal/service/maintenancewindow/resource_test.go
+++ b/internal/service/maintenancewindow/resource_test.go
@@ -376,7 +376,6 @@ func TestAccConfigRSMaintenanceWindow_waveAssignmentMidnight(t *testing.T) {
 			},
 			{
 				// transition to wave-only: must clear the schedule even though hour_of_day=0
-				// matches its TypeInt zero value and produces no standalone diff.
 				Config: configWaveOnly(orgID, projectName, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
@@ -386,7 +385,6 @@ func TestAccConfigRSMaintenanceWindow_waveAssignmentMidnight(t *testing.T) {
 				),
 			},
 			{
-				// the wave-only resource must converge (no phantom drift).
 				Config:   configWaveOnly(orgID, projectName, 1),
 				PlanOnly: true,
 			},


### PR DESCRIPTION
## Description

Allows `mongodbatlas_maintenance_window` to clear an existing maintenance schedule when transitioning to a wave-only configuration (schedule omitted, `wave_assignment` retained). The update path now sends `day_of_week` and `hour_of_day` as explicit null via the SDK `NullFields` mechanism when they are removed from config, so Atlas clears the schedule instead of retaining the old values. Also adds a follow-up `Read` after `Update` to refresh computed attributes that may change server-side during the transition.

Link to any related issue(s): CLOUDP-440317, blocked by CLOUDP-439562 (now resolved)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

Internal work on an unreleased feature (maintenance waves). None of the above apply.

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fix and verified my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

The `Read` after `Update` fixes a pre-existing issue where computed attributes (such as `time_zone_id`) went stale after an update until the next plan/refresh. This was latent until the wave-only transition introduced a path where a computed attribute changes value mid-lifecycle. No changelog entry is needed as this is internal work on an unreleased feature; the user-facing changelog is covered by the overall maintenance waves enhancement.
